### PR TITLE
Fix Python 3.9 compatibility: use future annotations for union types

### DIFF
--- a/content-pipeline/collectors/twitter_collector.py
+++ b/content-pipeline/collectors/twitter_collector.py
@@ -1,5 +1,7 @@
 """Twitter/X collector using Twitter API v2."""
 
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta, timezone
 from urllib.request import Request, urlopen

--- a/content-pipeline/processors/ai_analyzer.py
+++ b/content-pipeline/processors/ai_analyzer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 

--- a/content-pipeline/processors/ai_scorer.py
+++ b/content-pipeline/processors/ai_scorer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 


### PR DESCRIPTION
The `X | None` syntax requires Python 3.10+. Adding `from __future__ import annotations` makes it work on Python 3.9.

https://claude.ai/code/session_014bRb6Er2CZ9tAxTirPvq3j