### PR TITLE
Fix Python 3.9 compatibility and JSON parsing in AI processors

### DIFF
--- a/content-pipeline/processors/ai_analyzer.py
+++ b/content-pipeline/processors/ai_analyzer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import anthropic
 
@@ -49,7 +50,11 @@ def analyze_article(full_content: str) -> dict | None:
                 messages=[{"role": "user", "content": prompt}],
             )
             response_text = message.content[0].text.strip()
-            result = json.loads(response_text)
+            # Extract JSON from markdown code blocks or raw text
+            json_match = re.search(r'\{.*\}', response_text, re.DOTALL)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = json.loads(json_match.group())
             logger.info("Analyzed article, category: %s, urgency: %s",
                          result.get("category"), result.get("urgency"))
             return result

--- a/content-pipeline/processors/ai_scorer.py
+++ b/content-pipeline/processors/ai_scorer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import anthropic
 
@@ -47,7 +48,11 @@ def score_article(title: str, summary: str) -> float | None:
                 messages=[{"role": "user", "content": prompt}],
             )
             response_text = message.content[0].text.strip()
-            result = json.loads(response_text)
+            # Extract JSON from markdown code blocks or raw text
+            json_match = re.search(r'\{[^{}]*\}', response_text)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = json.loads(json_match.group())
             # Calculate total if not provided
             if "total" in result:
                 total = float(result["total"])


### PR DESCRIPTION
## Summary
- Fix Python 3.9 compat: add `from __future__ import annotations` for union type syntax
- Fix AI scorer/analyzer: extract JSON from markdown-wrapped model responses

## Test plan
- [ ] Run `python3 main.py` on Python 3.9 — no TypeError
- [ ] Verify AI scorer parses scores successfully
