### PR TITLE
Improve pipeline to get more articles + resume-style Telegram report

### DIFF
--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -30,12 +30,13 @@ RSS_FEEDS = [
 TWITTER_ACCOUNTS = ["OpenAI", "AnthropicAI", "GoogleDeepMind", "sama", "levelsio"]
 
 # Scoring thresholds
-SCORE_THRESHOLD_ANALYSIS = 6.5
-SCORE_THRESHOLD_NOTIFY = 7.0
+SCORE_THRESHOLD_ANALYSIS = 5.5   # Hạ từ 6.5 → 5.5 để có nhiều bài hơn vào phân tích sâu
+SCORE_THRESHOLD_NOTIFY = 5.5     # Hạ từ 7.0 → 5.5 để đảm bảo ít nhất 5 bài vào báo cáo
 
 # Limits
 MAX_ARTICLES_PER_RUN = 50
-MAX_DEEP_ANALYSIS = 5
+MAX_DEEP_ANALYSIS = 10           # Tăng từ 5 → 10 để có đủ bài cho resume top 5
+TOP_RESUME_COUNT = 5             # Số bài tối đa trong bản resume gửi Telegram
 
 # Database
 DB_PATH = os.path.join(os.path.dirname(__file__), "storage", "content.db")

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -12,68 +12,125 @@ from storage.database import get_report_articles
 
 logger = logging.getLogger(__name__)
 
+# Telegram message max length (UTF-8)
+TELEGRAM_MAX_LENGTH = 4096
+
 
 def send_telegram_message(text: str) -> bool:
-    """Send a message via Telegram Bot API."""
+    """Send a message via Telegram Bot API. Splits long messages if needed."""
     if not config.TELEGRAM_BOT_TOKEN or not config.TELEGRAM_CHAT_ID:
         logger.warning("Telegram credentials not configured, skipping notification.")
         return False
 
-    url = (
-        f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}"
-        f"/sendMessage?chat_id={config.TELEGRAM_CHAT_ID}"
-        f"&parse_mode=HTML"
-        f"&text={quote(text)}"
-    )
+    # Split into chunks if too long
+    chunks = _split_message(text, TELEGRAM_MAX_LENGTH)
 
-    try:
-        req = Request(url)
-        with urlopen(req, timeout=10) as resp:
-            if resp.status == 200:
-                logger.info("Telegram message sent successfully.")
-                return True
-            logger.error("Telegram API returned status %d", resp.status)
-            return False
-    except Exception as e:
-        logger.error("Failed to send Telegram message: %s", e)
-        return False
+    success = True
+    for chunk in chunks:
+        url = (
+            f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}"
+            f"/sendMessage?chat_id={config.TELEGRAM_CHAT_ID}"
+            f"&parse_mode=HTML"
+            f"&text={quote(chunk)}"
+        )
+        try:
+            req = Request(url)
+            with urlopen(req, timeout=10) as resp:
+                if resp.status != 200:
+                    logger.error("Telegram API returned status %d", resp.status)
+                    success = False
+        except Exception as e:
+            logger.error("Failed to send Telegram message: %s", e)
+            success = False
+
+    if success:
+        logger.info("Telegram message sent successfully.")
+    return success
+
+
+def _split_message(text: str, max_len: int) -> list[str]:
+    """Split a long message into chunks at line boundaries."""
+    if len(text) <= max_len:
+        return [text]
+
+    chunks = []
+    while text:
+        if len(text) <= max_len:
+            chunks.append(text)
+            break
+        # Find last newline before max_len
+        split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            split_at = max_len
+        chunks.append(text[:split_at])
+        text = text[split_at:].lstrip("\n")
+    return chunks
 
 
 def build_report() -> str:
-    """Build the daily report message."""
+    """Build the daily resume-style report — top 5 articles, direct and clear."""
     today = date.today().strftime("%d/%m/%Y")
     articles = get_report_articles(config.SCORE_THRESHOLD_NOTIFY)
 
-    immediate = articles.get("immediate", [])
-    this_week = articles.get("this_week", [])
-    backlog = articles.get("backlog", [])
+    # Flatten all articles, sort by score descending, pick top N
+    all_articles = []
+    for group in articles.values():
+        all_articles.extend(group)
+    all_articles.sort(key=lambda a: a.get("ai_score", 0), reverse=True)
 
-    lines = [f"📊 BÁO CÁO CONTENT - {today}\n"]
+    top_n = getattr(config, "TOP_RESUME_COUNT", 5)
+    top_articles = all_articles[:top_n]
 
-    if immediate:
-        lines.append(f"🔥 ĐĂNG NGAY ({len(immediate)} bài):")
-        for i, a in enumerate(immediate, 1):
-            analysis = json.loads(a["ai_analysis"]) if a.get("ai_analysis") else {}
-            lines.append(
-                f"{i}. [{a.get('ai_score', 0):.1f}/10] {a['title']}\n"
-                f"   → Góc: {analysis.get('viet_angle', 'N/A')}\n"
-                f"   → Loại: {a.get('category', 'N/A')}\n"
-                f"   → Link: {a.get('url', '')}"
-            )
+    if not top_articles:
+        return f"📊 AI 5 PHÚT — {today}\n\nKhông có bài viết nào đạt ngưỡng hôm nay."
+
+    lines = [
+        f"📊 <b>AI 5 PHÚT MỖI NGÀY — {today}</b>",
+        f"Top {len(top_articles)} tin AI đáng đọc hôm nay:\n",
+    ]
+
+    for i, article in enumerate(top_articles, 1):
+        analysis = {}
+        if article.get("ai_analysis"):
+            try:
+                analysis = json.loads(article["ai_analysis"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        score = article.get("ai_score", 0)
+        title = article.get("title", "N/A")
+        url = article.get("url", "")
+        summary = analysis.get("one_line_summary", "")
+        viet_angle = analysis.get("viet_angle", "")
+        category = analysis.get("category", "")
+        urgency = analysis.get("urgency", "")
+
+        # Category emoji
+        cat_emoji = {"tips": "💡", "news": "📰", "comparison": "⚖️"}.get(category, "📌")
+        # Urgency tag
+        urg_tag = {"immediate": "🔴 Nóng", "this_week": "🟡 Tuần này", "backlog": "🟢 Tham khảo"}.get(urgency, "")
+
+        lines.append(f"{'─' * 30}")
+        lines.append(f"{cat_emoji} <b>{i}. {title}</b>")
+        lines.append(f"⭐ {score:.1f}/10 │ {urg_tag}")
+
+        if summary:
+            lines.append(f"\n{summary}")
+
+        if viet_angle:
+            lines.append(f"\n👉 <i>{viet_angle}</i>")
+
+        if url:
+            lines.append(f"\n🔗 {url}")
+
         lines.append("")
 
-    if this_week:
-        lines.append(f"📅 TRONG TUẦN ({len(this_week)} bài):")
-        for i, a in enumerate(this_week, 1):
-            lines.append(f"{i}. [{a.get('ai_score', 0):.1f}/10] {a['title']}")
-        lines.append("")
+    # Footer
+    remaining = len(all_articles) - len(top_articles)
+    if remaining > 0:
+        lines.append(f"📦 Còn {remaining} bài khác trong backlog.")
 
-    backlog_count = len(backlog)
-    if backlog_count:
-        lines.append(f"💾 BACKLOG: {backlog_count} bài")
-
-    if not immediate and not this_week and not backlog_count:
-        lines.append("Không có bài viết nào đạt ngưỡng hôm nay.")
+    lines.append(f"\n— AI 5 Phút Mỗi Ngày 🤖")
 
     return "\n".join(lines)
 

--- a/content-pipeline/processors/ai_scorer.py
+++ b/content-pipeline/processors/ai_scorer.py
@@ -16,13 +16,19 @@ logger = logging.getLogger(__name__)
 
 SCORE_PROMPT = """Bạn là content strategist cho kênh YouTube/TikTok về AI dành cho
 người Việt đi làm văn phòng (22-35 tuổi, không rành kỹ thuật).
-Định vị kênh: "Giúp người Việt đi làm hiểu và dùng AI trong 5 phút"
+Định vị kênh: "AI 5 Phút Mỗi Ngày" — giúp người Việt đi làm hiểu và dùng AI.
 
-Chấm điểm bài viết sau từ 1-10 theo 4 tiêu chí:
-1. Người đi làm bình thường có quan tâm không? (1-10)
-2. Có thể làm theo/áp dụng ngay hôm nay không? (1-10)
-3. Giải thích được trong 5 phút không? (1-10)
-4. Có gây cảm xúc (tò mò/hữu ích/lo lắng) không? (1-10)
+Kênh có 3 dạng content: tin tức AI nóng, mẹo dùng AI, và so sánh công cụ.
+Cả 3 dạng đều có giá trị — TIN NÓNG cũng cần điểm cao nếu đáng nói.
+
+Chấm điểm bài viết từ 1-10 theo 4 tiêu chí:
+1. Người đi làm bình thường có quan tâm/tò mò không? (1-10)
+2. Có giá trị thực tế (biết thêm điều mới HOẶC áp dụng được)? (1-10)
+3. Giải thích được dễ hiểu trong 5 phút không? (1-10)
+4. Có đủ hấp dẫn để làm video (gây tò mò/wow/lo lắng)? (1-10)
+
+LƯU Ý: Tin tức về sản phẩm AI mới, cập nhật lớn, hoặc thay đổi ảnh hưởng nhiều người
+nên được chấm điểm CAO vì khán giả muốn biết sớm. Đừng phạt bài chỉ vì không actionable.
 
 TIÊU ĐỀ: {title}
 TÓM TẮT: {summary}

--- a/content-pipeline/processors/rule_filter.py
+++ b/content-pipeline/processors/rule_filter.py
@@ -8,24 +8,36 @@ from storage.database import get_connection
 logger = logging.getLogger(__name__)
 
 RELEVANT_KEYWORDS = [
-    # English
-    "chatgpt", "claude", "gemini", "gpt-4", "gpt-5", "llm",
-    "ai tool", "ai feature", "productivity", "workflow", "automation",
-    "prompt", "copilot", "midjourney", "sora", "runway",
-    "openai", "anthropic", "google ai", "microsoft ai",
-    "artificial intelligence", "machine learning", "deep learning",
-    "generative ai", "gen ai", "ai agent", "ai model",
-    # Vietnamese
+    # English — AI products & brands
+    "chatgpt", "claude", "gemini", "gpt-4", "gpt-5", "gpt-4o", "llm",
+    "openai", "anthropic", "google ai", "microsoft ai", "meta ai",
+    "copilot", "midjourney", "sora", "runway", "dall-e", "stable diffusion",
+    "perplexity", "notion ai", "canva ai", "adobe ai", "grammarly",
+    # English — concepts (broader to catch more news)
+    "ai tool", "ai feature", "ai app", "ai update", "ai launch",
+    "ai assistant", "ai chatbot", "ai image", "ai video", "ai search",
+    "ai agent", "ai model", "ai startup", "ai company",
+    "generative ai", "gen ai", "artificial intelligence",
+    "productivity", "workflow", "automation", "prompt",
+    "machine learning", "deep learning", "neural network",
+    "text to image", "text to video", "text to speech",
+    "large language model", "multimodal", "transformer",
+    # Vietnamese — broader to catch VnExpress articles
     "trí tuệ nhân tạo", "công cụ ai", "ai tạo sinh",
     "mô hình ai", "ứng dụng ai", "chatbot", "robot",
     "học máy", "trợ lý ảo", "tự động hóa",
+    "trợ lý ai", "công nghệ ai", "phần mềm ai",
+    "tạo ảnh", "tạo video", "tạo nội dung",
+    "deepfake", "bán dẫn", "chip ai",
 ]
 
 SKIP_KEYWORDS = [
-    "arxiv", "paper", "dataset", "benchmark", "fine-tuning",
-    "huggingface", "github repo", "open source weights",
-    "fundraising", "valuation", "lawsuit", "regulation", "policy",
-    "acquisition", "merger", "ipo",
+    # Only skip truly technical/irrelevant content
+    "arxiv.org", "dataset release", "benchmark score",
+    "fine-tuning tutorial", "training loss",
+    "huggingface model", "github repo", "open source weights",
+    "fundraising round", "series a", "series b",
+    "ipo filing", "merger agreement",
 ]
 
 


### PR DESCRIPTION
- rule_filter: expand RELEVANT_KEYWORDS (AI brands, Vietnamese terms), narrow SKIP_KEYWORDS (only truly irrelevant technical content)
- config: lower thresholds (6.5→5.5 for analysis, 7.0→5.5 for notify), increase MAX_DEEP_ANALYSIS to 10, add TOP_RESUME_COUNT=5
- ai_scorer: rebalance scoring prompt — news articles no longer penalized for not being actionable, added note to score hot news high
- telegram_bot: rewrite report as top-5 resume format — logical, direct, easy to read. Includes summary, Vietnamese angle, urgency tag, and link. Added message splitting for long reports.

https://claude.ai/code/session_014bRb6Er2CZ9tAxTirPvq3j