### PR TITLE
Fix Python 3.9 compat: add from __future__ import annotations

### DIFF
--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Content Pipeline Orchestrator — "AI 5 Phút Mỗi Ngày"
 

--- a/content-pipeline/notifier/_narrative.py
+++ b/content-pipeline/notifier/_narrative.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Narrative Report Generator — Tạo bài tổng hợp 800 từ từ top articles.
 

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Telegram Bot — Persistent bot chạy long-polling.
 

--- a/content-pipeline/publisher/scheduler.py
+++ b/content-pipeline/publisher/scheduler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Scheduler — Xác định loại video cần tạo và platform đăng theo ngày trong tuần.
 

--- a/content-pipeline/publisher/tiktok_uploader.py
+++ b/content-pipeline/publisher/tiktok_uploader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 TikTok Uploader — Upload video lên TikTok qua Content Publishing API.
 

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 YouTube Uploader — Upload video lên YouTube / YouTube Shorts qua YouTube Data API v3.
 

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sqlite3
 import json
 import logging

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Pexels Video Downloader — Tự động tải background video miễn phí từ Pexels.
 

--- a/content-pipeline/video/script_generator.py
+++ b/content-pipeline/video/script_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Script Generator — Tạo script dài (YouTube) và ngắn (Shorts/TikTok) từ bài tổng hợp.
 

--- a/content-pipeline/video/subtitle_generator.py
+++ b/content-pipeline/video/subtitle_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Subtitle Generator — Tạo file SRT từ script text + audio duration.
 

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 TTS Client — Wrapper cho TTS-Enso API.
 

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Video Composer — Ghép audio + background video + subtitle thành video hoàn chỉnh.
 


### PR DESCRIPTION
The `dict | None` and `list[str]` type syntax requires Python 3.10+. Adding `from __future__ import annotations` to all 12 affected files makes these annotations strings (lazy evaluation), compatible with 3.7+.

https://claude.ai/code/session_014bRb6Er2CZ9tAxTirPvq3j