### PR TITLE
Send narrative summary to Telegram before video generation

### DIFF
--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -50,7 +50,7 @@ from video.pexels_downloader import download_backgrounds
 from publisher.scheduler import get_today_schedule, get_platform_label
 from notifier.telegram_bot import (
     send_video_for_approval, send_publish_notification,
-    send_pipeline_summary, run_bot,
+    send_pipeline_summary, send_narrative_report, run_bot,
 )
 
 # Ensure logs and output directories exist
@@ -144,6 +144,11 @@ def run_pipeline():
         logger.error("Failed to generate narrative report")
         send_pipeline_summary(0, 0, errors + ["Narrative generation failed"])
         return
+
+    # Send narrative summary to Telegram immediately — before video generation
+    # so user always gets the daily summary even if video creation fails
+    send_narrative_report(narrative, len(articles))
+    logger.info("Narrative report sent to Telegram")
 
     # --- Phase 3: Video Generation ---
     logger.info("--- Phase 3: Video Generation ---")

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -79,6 +79,59 @@ def send_publish_notification(video_id: int, platform: str, url: str):
     _send_text(f"🚀 Video {video_id} đã đăng lên {platform}!\n🔗 {url}")
 
 
+def send_narrative_report(narrative: str, article_count: int) -> bool:
+    """Send the narrative summary as a text message before video generation.
+
+    This ensures the user always receives the daily summary even if
+    video generation fails downstream.
+    """
+    if not config.TELEGRAM_BOT_TOKEN or not config.TELEGRAM_CHAT_ID:
+        logger.warning("Telegram credentials not configured, skipping narrative.")
+        return False
+
+    today = date.today().strftime("%d/%m/%Y")
+    header = f"📝 TÓM TẮT AI HÔM NAY — {today}\n({article_count} bài đã phân tích)\n\n"
+    full_text = header + narrative
+
+    # Telegram max is 4096 chars — split if needed
+    if len(full_text) <= TELEGRAM_MAX_LENGTH:
+        return _send_text(full_text)
+
+    # Split into chunks at paragraph boundaries
+    parts = _split_message(full_text)
+    success = True
+    for part in parts:
+        if not _send_text(part):
+            success = False
+    return success
+
+
+def _split_message(text: str, max_len: int = TELEGRAM_MAX_LENGTH) -> list[str]:
+    """Split long text into chunks at paragraph boundaries."""
+    if len(text) <= max_len:
+        return [text]
+
+    chunks = []
+    while text:
+        if len(text) <= max_len:
+            chunks.append(text)
+            break
+
+        # Find last double-newline within limit
+        split_at = text.rfind("\n\n", 0, max_len)
+        if split_at == -1:
+            # Fall back to single newline
+            split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            # Last resort: hard cut
+            split_at = max_len
+
+        chunks.append(text[:split_at])
+        text = text[split_at:].lstrip("\n")
+
+    return chunks
+
+
 def send_pipeline_summary(long_count: int, short_count: int, errors: list[str]):
     """Send a summary of the pipeline run."""
     today = date.today().strftime("%d/%m/%Y")


### PR DESCRIPTION
Previously the user only received content via Telegram when video generation succeeded. Now the text summary is sent immediately after narrative generation (Phase 2), before video creation (Phase 3). This ensures the daily AI digest is always delivered even if script/TTS/video composition fails downstream.

Added send_narrative_report() with auto-splitting for long messages.

https://claude.ai/code/session_014bRb6Er2CZ9tAxTirPvq3j