### PR TITLE
Add systemd services for Linux — fix pipeline not running

### DIFF
--- a/content-pipeline/setup_services.sh
+++ b/content-pipeline/setup_services.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+# AI 5 Phút Mỗi Ngày — Service Setup Script
+# Auto-detects macOS (launchd) vs Linux (systemd)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHON_BIN="$(which python3)"
+
+echo "=== AI 5 Phút Mỗi Ngày — Service Setup ==="
+echo "Project dir: $SCRIPT_DIR"
+echo "Python:      $PYTHON_BIN"
+echo ""
+
+# Check .env exists
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+    echo "ERROR: .env file not found at $SCRIPT_DIR/.env"
+    echo "Copy .env.example and fill in your API keys first."
+    exit 1
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Detected: macOS — using launchd"
+    echo ""
+
+    PLIST_DIR="$SCRIPT_DIR/launchd"
+    DEST_DIR="$HOME/Library/LaunchAgents"
+    mkdir -p "$DEST_DIR"
+
+    # Update paths in plist files
+    for plist in "$PLIST_DIR"/com.ai5phut.*.plist; do
+        filename="$(basename "$plist")"
+        echo "Installing $filename..."
+
+        # Replace placeholder paths with actual paths
+        sed "s|/Users/YOU/ContentCreator/content-pipeline|$SCRIPT_DIR|g; s|/usr/bin/python3|$PYTHON_BIN|g" \
+            "$plist" > "$DEST_DIR/$filename"
+
+        # Unload if already loaded, then load
+        launchctl unload "$DEST_DIR/$filename" 2>/dev/null || true
+        launchctl load "$DEST_DIR/$filename"
+        echo "  → Loaded"
+    done
+
+    echo ""
+    echo "Done! Check status:"
+    echo "  launchctl list | grep ai5phut"
+
+elif command -v systemctl &>/dev/null; then
+    echo "Detected: Linux — using systemd"
+    echo ""
+
+    SYSTEMD_DIR="$SCRIPT_DIR/systemd"
+
+    # Update paths in service files
+    for unit in "$SYSTEMD_DIR"/ai5phut-*.{service,timer}; do
+        [ -f "$unit" ] || continue
+        filename="$(basename "$unit")"
+        echo "Installing $filename..."
+
+        # Replace paths with actual values
+        sudo sed "s|/home/user/ContentCreator/content-pipeline|$SCRIPT_DIR|g; s|/usr/local/bin/python3|$PYTHON_BIN|g" \
+            "$unit" > /tmp/"$filename"
+        sudo mv /tmp/"$filename" /etc/systemd/system/"$filename"
+        echo "  → Copied to /etc/systemd/system/"
+    done
+
+    sudo systemctl daemon-reload
+
+    # Enable and start
+    echo ""
+    echo "Enabling services..."
+
+    sudo systemctl enable --now ai5phut-pipeline.timer
+    echo "  → Pipeline timer enabled (7:00 daily)"
+
+    sudo systemctl enable --now ai5phut-bot.service
+    echo "  → Telegram bot started"
+
+    echo ""
+    echo "Done! Check status:"
+    echo "  systemctl list-timers | grep ai5phut"
+    echo "  systemctl status ai5phut-bot"
+
+else
+    echo "ERROR: Neither launchd (macOS) nor systemd (Linux) found."
+    echo "Please set up scheduling manually (crontab, etc.)"
+    exit 1
+fi

--- a/content-pipeline/systemd/README.md
+++ b/content-pipeline/systemd/README.md
@@ -1,0 +1,62 @@
+# Hướng dẫn cài đặt trên Linux (systemd)
+
+## Bước 1: Sửa đường dẫn (nếu cần)
+
+Mở các file `.service` và `.timer`, sửa đường dẫn cho đúng:
+- `WorkingDirectory=` → thư mục chứa `main.py`
+- `ExecStart=` → đường dẫn python3 (`which python3`)
+- `EnvironmentFile=` → đường dẫn file `.env`
+
+## Bước 2: Copy vào systemd
+
+```bash
+sudo cp ai5phut-pipeline.service /etc/systemd/system/
+sudo cp ai5phut-pipeline.timer /etc/systemd/system/
+sudo cp ai5phut-bot.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+## Bước 3: Enable và start
+
+```bash
+# Pipeline timer — chạy mỗi sáng 7:00
+sudo systemctl enable --now ai5phut-pipeline.timer
+
+# Telegram bot — chạy liên tục
+sudo systemctl enable --now ai5phut-bot.service
+```
+
+## Bước 4: Kiểm tra
+
+```bash
+# Xem timer có active không
+systemctl list-timers | grep ai5phut
+
+# Xem bot status
+systemctl status ai5phut-bot
+
+# Xem log pipeline
+journalctl -u ai5phut-pipeline --since today
+
+# Xem log bot
+journalctl -u ai5phut-bot -f
+```
+
+## Chạy pipeline thủ công
+
+```bash
+sudo systemctl start ai5phut-pipeline
+```
+
+## Quản lý
+
+```bash
+# Dừng bot
+sudo systemctl stop ai5phut-bot
+
+# Tắt timer
+sudo systemctl disable ai5phut-pipeline.timer
+
+# Restart bot
+sudo systemctl restart ai5phut-bot
+```

--- a/content-pipeline/systemd/ai5phut-bot.service
+++ b/content-pipeline/systemd/ai5phut-bot.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AI 5 Phut Moi Ngay — Telegram Bot (approve/publish)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/user/ContentCreator/content-pipeline
+ExecStart=/usr/local/bin/python3 main.py --bot
+EnvironmentFile=/home/user/ContentCreator/content-pipeline/.env
+Restart=on-failure
+RestartSec=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/content-pipeline/systemd/ai5phut-pipeline.service
+++ b/content-pipeline/systemd/ai5phut-pipeline.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=AI 5 Phut Moi Ngay — Daily Content Pipeline
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/user/ContentCreator/content-pipeline
+ExecStart=/usr/local/bin/python3 main.py
+EnvironmentFile=/home/user/ContentCreator/content-pipeline/.env
+
+# Logging — journalctl -u ai5phut-pipeline
+StandardOutput=journal
+StandardError=journal
+
+# Timeout: pipeline can take ~10 min (AI calls + video gen)
+TimeoutStartSec=900

--- a/content-pipeline/systemd/ai5phut-pipeline.timer
+++ b/content-pipeline/systemd/ai5phut-pipeline.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run AI 5 Phut pipeline every day at 7:00 AM
+
+[Timer]
+OnCalendar=*-*-* 07:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The launchd plists only work on macOS but the server runs Linux, so the pipeline was never scheduled and hasn't run since 03-16.

Added:
- systemd/ai5phut-pipeline.service + .timer (daily 7:00 AM)
- systemd/ai5phut-bot.service (persistent Telegram bot daemon)
- setup_services.sh (auto-detects macOS/Linux, installs services)

https://claude.ai/code/session_014bRb6Er2CZ9tAxTirPvq3j