### PR TITLE
fix: hotfixes from pipeline end-to-end testing

### DIFF
--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 # API Keys
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -26,9 +26,10 @@ logger = logging.getLogger(__name__)
 
 PEXELS_API_BASE = "https://api.pexels.com"
 
-# NotoSans-Bold for Vietnamese subtitle rendering (Google Fonts CDN)
+# NotoSans variable font for Vietnamese subtitle rendering (Google Fonts)
+# NotoSans-Bold.ttf was replaced by a variable font in the google/fonts repo
 _NOTO_FONT_URL = (
-    "https://github.com/google/fonts/raw/main/ofl/notosans/NotoSans-Bold.ttf"
+    "https://raw.githubusercontent.com/google/fonts/main/ofl/notosans/NotoSans%5Bwdth%2Cwght%5D.ttf"
 )
 _FONT_PATH = os.path.join(os.path.dirname(__file__), "assets", "fonts", "NotoSans-Bold.ttf")
 

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -62,8 +62,11 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
         width, height = 1920, 1080
 
     if not os.path.exists(bg_video):
-        logger.error("Background video not found: %s", bg_video)
-        return None
+        logger.warning("Background video not found: %s — generating solid-color fallback", bg_video)
+        bg_video = _generate_solid_background(bg_video, width, height)
+        if bg_video is None:
+            logger.error("Failed to generate fallback background")
+            return None
     if not os.path.exists(audio_path):
         logger.error("Audio file not found: %s", audio_path)
         return None
@@ -96,6 +99,26 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+def _generate_solid_background(output_path: str, width: int, height: int,
+                                color: str = "0x0d1b2a", duration: int = 10) -> str | None:
+    """Generate a short solid-color loopable background video using ffmpeg."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y",
+        "-f", "lavfi",
+        "-i", f"color=c={color}:size={width}x{height}:rate=30:duration={duration}",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p",
+        output_path,
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, check=True)
+        logger.info("Generated solid background: %s", output_path)
+        return output_path
+    except subprocess.CalledProcessError as exc:
+        logger.error("Failed to generate solid background: %s", exc.stderr.decode()[:200])
+        return None
+
 
 def _compose_without_subtitles(bg_video: str, audio_path: str, output_path: str,
                                 width: int, height: int, audio_duration: float) -> str | None:


### PR DESCRIPTION
## Summary

Hotfixes discovered during full pipeline end-to-end test (`python3 main.py --force-video short`):

- **`config.py`** — `load_dotenv(override=True)` so `.env` values win over empty shell env vars (the Claude Code runtime sets `ANTHROPIC_API_KEY=''`, silently breaking AI scoring)
- **`video/pexels_downloader.py`** — fix NotoSans font URL: `NotoSans-Bold.ttf` was removed from `google/fonts`; updated to the replacement variable font `NotoSans[wdth,wght].ttf` on `raw.githubusercontent.com`
- **`video/video_composer.py`** — add `_generate_solid_background()` fallback: when no Pexels background video is available (e.g. expired API key), generate a 10s navy solid-color clip via `ffmpeg lavfi` so video composition never hard-fails

## Test plan

- [x] Full pipeline ran successfully end-to-end with `--force-video short`
- [x] Font downloaded (2001 KB) on fresh run
- [x] Solid-color fallback generated and used for video composition when Pexels API returned 403
- [x] Video composed and sent to Telegram for approval (video id=2, msg_id=107)

🤖 Generated with [Claude Code](https://claude.com/claude-code)