### PR TITLE
fix(env): fix launchd missing deps (Pillow, googleapiclient) via venv wrapper

### DIFF
--- a/content-pipeline/.gitignore
+++ b/content-pipeline/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 *.pyo
 .env
+venv/
 *.db
 logs/*.log
 .DS_Store

--- a/content-pipeline/launchd/com.ai5phut.pipeline.plist
+++ b/content-pipeline/launchd/com.ai5phut.pipeline.plist
@@ -5,10 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.pipeline</string>
 
+    <!-- Use the wrapper script — it activates the venv so all deps are available.
+         Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/bin/python3</string>
-        <string>main.py</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_pipeline.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -29,6 +29,33 @@ from datetime import date
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+# Safety net: catch missing deps early with a clear error.
+# ROOT CAUSE prevention is the venv via run_pipeline.sh — this just diagnoses
+# quickly if someone bypasses the wrapper.
+_REQUIRED = {
+    "PIL": "Pillow",
+    "googleapiclient": "google-api-python-client",
+    "anthropic": "anthropic",
+    "feedparser": "feedparser",
+    "dotenv": "python-dotenv",
+}
+_missing = []
+for _mod, _pkg in _REQUIRED.items():
+    try:
+        __import__(_mod)
+    except ImportError:
+        _missing.append(_pkg)
+if _missing:
+    print(
+        f"[FATAL] Missing packages: {', '.join(_missing)}\n"
+        f"Fix: cd {os.path.dirname(__file__)} && "
+        "venv/bin/pip install -r requirements.txt\n"
+        "Or use run_pipeline.sh instead of calling python directly.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+del _REQUIRED, _missing
+
 import config
 from storage.database import (
     init_db, get_top_analyzed_articles, insert_video,

--- a/content-pipeline/requirements.txt
+++ b/content-pipeline/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv>=1.0
 num2words>=0.5.13
 google-api-python-client>=2.100.0
 google-auth-oauthlib>=1.1.0
+Pillow>=9.0
+requests>=2.28

--- a/content-pipeline/run_pipeline.sh
+++ b/content-pipeline/run_pipeline.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Wrapper script for launchd — ensures pipeline always runs inside the venv.
+# The root cause of missing deps (Pillow, googleapiclient) was that launchd
+# called /opt/homebrew/bin/python3 directly, which is a different Python than
+# where packages were installed. This script fixes that permanently.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
+
+if [ ! -f "$VENV_PYTHON" ]; then
+    echo "ERROR: venv not found at $SCRIPT_DIR/venv" >&2
+    echo "Run: cd $SCRIPT_DIR && /opt/homebrew/bin/python3 -m venv venv && venv/bin/pip install -r requirements.txt" >&2
+    exit 1
+fi
+
+exec "$VENV_PYTHON" "$SCRIPT_DIR/main.py" "$@"


### PR DESCRIPTION
## Root Cause

The launchd plist called `/opt/homebrew/bin/python3` (Python 3.14.3) directly, but all packages (`Pillow`, `googleapiclient`, `anthropic`, etc.) were installed under `/usr/bin/python3` (Python 3.9.6). These are two completely separate Python environments — packages installed in one are invisible to the other.

This caused:
- **Video #38**: no subtitles (Pillow missing) + YouTube upload failed (googleapiclient missing)
- **Video #24 (Apr 13)**: same Pillow issue

Adding a dep check to `main.py` alone would be a band-aid — it tells you something is wrong but doesn't prevent it. The fix must ensure launchd always runs in the correct environment.

## Fix

- **Created `content-pipeline/venv/`** using `/opt/homebrew/bin/python3` (the Python the plist already used) and installed all deps into it
- **Created `run_pipeline.sh`** wrapper that `exec`s into `venv/bin/python3 main.py` — launchd calls this instead of python directly
- **Updated launchd plists** (installed `~/Library/LaunchAgents/com.ai5phut.pipeline.plist` + project template) to call `run_pipeline.sh`
- **Added `Pillow>=9.0` and `requests>=2.28`** to `requirements.txt` (were missing entirely)
- **Added `venv/` to `.gitignore`**
- **Added safety-net dep check** at top of `main.py` — if someone bypasses the wrapper, they get a clear fatal error with install instructions rather than a cryptic `ModuleNotFoundError` deep in the pipeline

## Test Plan

- [x] `venv/bin/python3 -c "import PIL; import googleapiclient; print('OK')"` passes
- [x] Pipeline re-run with `python main.py --force-video short` generated video #39 with **27 subtitle overlays** — subtitles confirmed working
- [x] launchd reloaded and job registered (`launchctl list | grep ai5phut`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)