### PR TITLE
Video pipeline review vs MoneyPrinterTurbo + unit tests

### DIFF
--- a/content-pipeline/tests/test_pexels_downloader.py
+++ b/content-pipeline/tests/test_pexels_downloader.py
@@ -1,0 +1,141 @@
+"""Tests for video.pexels_downloader pure logic (no network calls).
+
+Network/download functions are not exercised; these tests cover cache-key
+generation, best-file selection, and duration-matched background selection.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.pexels_downloader as pex
+from video.pexels_downloader import (
+    _cache_key,
+    _cached_path,
+    _find_best_file,
+    _select_best_background,
+    _any_cached,
+)
+
+
+class TestCacheKey(unittest.TestCase):
+    def test_deterministic(self):
+        self.assertEqual(
+            _cache_key("blue gradient", "landscape"),
+            _cache_key("blue gradient", "landscape"),
+        )
+
+    def test_orientation_changes_key(self):
+        self.assertNotEqual(
+            _cache_key("abstract", "landscape"),
+            _cache_key("abstract", "portrait"),
+        )
+
+    def test_sanitizes_unsafe_chars(self):
+        key = _cache_key("AI/Tech: 2024!", "landscape")
+        # Only alphanumerics + underscore survive in the readable prefix.
+        prefix = key.rsplit("_landscape_", 1)[0]
+        self.assertTrue(all(c.isalnum() or c == "_" for c in prefix))
+
+    def test_includes_orientation_and_hash(self):
+        key = _cache_key("particles", "portrait")
+        self.assertIn("_portrait_", key)
+
+    def test_cached_path_has_mp4_extension(self):
+        path = _cached_path("digital network", "landscape")
+        self.assertTrue(path.endswith(".mp4"))
+
+
+class TestFindBestFile(unittest.TestCase):
+    def test_empty_returns_none(self):
+        self.assertIsNone(_find_best_file([], "landscape"))
+
+    def test_picks_landscape_candidate(self):
+        files = [
+            {"width": 1920, "height": 1080, "quality": "hd", "link": "a"},
+            {"width": 640, "height": 360, "quality": "sd", "link": "b"},
+        ]
+        best = _find_best_file(files, "landscape")
+        self.assertEqual(best["link"], "a")
+
+    def test_prefers_hd_over_sd(self):
+        files = [
+            {"width": 1280, "height": 720, "quality": "sd", "link": "sd"},
+            {"width": 1280, "height": 720, "quality": "hd", "link": "hd"},
+        ]
+        best = _find_best_file(files, "landscape")
+        self.assertEqual(best["link"], "hd")
+
+    def test_prefers_higher_resolution(self):
+        files = [
+            {"width": 1280, "height": 720, "quality": "hd", "link": "small"},
+            {"width": 1920, "height": 1080, "quality": "hd", "link": "big"},
+        ]
+        best = _find_best_file(files, "landscape")
+        self.assertEqual(best["link"], "big")
+
+    def test_portrait_selection(self):
+        files = [
+            {"width": 1080, "height": 1920, "quality": "hd", "link": "p"},
+            {"width": 1920, "height": 1080, "quality": "hd", "link": "l"},
+        ]
+        best = _find_best_file(files, "portrait")
+        self.assertEqual(best["link"], "p")
+
+    def test_portrait_falls_back_to_wide_files(self):
+        # No true portrait files; fallback accepts wide files >= 1080 width.
+        files = [{"width": 1920, "height": 1080, "quality": "hd", "link": "l"}]
+        best = _find_best_file(files, "portrait")
+        self.assertEqual(best["link"], "l")
+
+    def test_rejects_too_small(self):
+        files = [{"width": 320, "height": 240, "quality": "sd", "link": "tiny"}]
+        self.assertIsNone(_find_best_file(files, "landscape"))
+
+
+class TestSelectBestBackground(unittest.TestCase):
+    def test_single_candidate_returned(self):
+        self.assertEqual(_select_best_background(["only.mp4"], 30.0), "only.mp4")
+
+    def test_unknown_duration_returns_a_candidate(self):
+        paths = ["a.mp4", "b.mp4"]
+        self.assertIn(_select_best_background(paths, 0), paths)
+
+    @patch("video.pexels_downloader.get_video_duration")
+    def test_picks_closest_duration_match(self, mock_dur):
+        durations = {"short.mp4": 5.0, "match.mp4": 29.0, "long.mp4": 120.0}
+        mock_dur.side_effect = lambda p: durations[p]
+        chosen = _select_best_background(list(durations), audio_duration=30.0)
+        self.assertEqual(chosen, "match.mp4")
+
+    @patch("video.pexels_downloader.get_video_duration")
+    def test_skips_unprobeable_files(self, mock_dur):
+        # 0.0 means ffprobe failed; such files must not win selection.
+        durations = {"bad.mp4": 0.0, "good.mp4": 28.0}
+        mock_dur.side_effect = lambda p: durations[p]
+        chosen = _select_best_background(list(durations), audio_duration=30.0)
+        self.assertEqual(chosen, "good.mp4")
+
+
+class TestAnyCached(unittest.TestCase):
+    def test_no_cache_dir_returns_none(self):
+        with patch.object(pex, "CACHE_DIR", "/nonexistent/path/xyz"):
+            self.assertIsNone(_any_cached("landscape"))
+
+    def test_matches_orientation_only(self):
+        tmp = tempfile.mkdtemp()
+        for name in ["a_landscape_111.mp4", "b_portrait_222.mp4",
+                     "notes.txt"]:
+            open(os.path.join(tmp, name), "w").close()
+        with patch.object(pex, "CACHE_DIR", tmp):
+            result = _any_cached("landscape", audio_duration=0)
+        self.assertTrue(result.endswith("a_landscape_111.mp4"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_scheduler.py
+++ b/content-pipeline/tests/test_scheduler.py
@@ -1,0 +1,86 @@
+"""Tests for publisher.scheduler — dual-format publishing schedule."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import date
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from publisher.scheduler import (
+    get_today_schedule,
+    get_next_scheduled_date,
+    get_platform_label,
+)
+
+# 2024-01-01 is a Monday, so 1..7 Jan map cleanly to Mon..Sun.
+MON = date(2024, 1, 1)
+TUE = date(2024, 1, 2)
+WED = date(2024, 1, 3)
+THU = date(2024, 1, 4)
+FRI = date(2024, 1, 5)
+SAT = date(2024, 1, 6)
+SUN = date(2024, 1, 7)
+
+
+class TestGetTodaySchedule(unittest.TestCase):
+    def test_monday_is_short(self):
+        s = get_today_schedule(MON)
+        self.assertEqual(s["video_type"], "short")
+        self.assertEqual(s["platforms"], ["youtube_shorts", "tiktok"])
+
+    def test_tuesday_is_long(self):
+        s = get_today_schedule(TUE)
+        self.assertEqual(s["video_type"], "long")
+        self.assertEqual(s["platforms"], ["youtube"])
+
+    def test_weekday_pattern(self):
+        expected = {
+            MON: "short", TUE: "long", WED: "short",
+            THU: "long", FRI: "short", SAT: "long",
+        }
+        for d, vtype in expected.items():
+            with self.subTest(day=d):
+                self.assertEqual(get_today_schedule(d)["video_type"], vtype)
+
+    def test_sunday_is_off(self):
+        self.assertIsNone(get_today_schedule(SUN))
+
+    def test_scheduled_date_echoed(self):
+        s = get_today_schedule(WED)
+        self.assertEqual(s["scheduled_date"], WED.isoformat())
+
+
+class TestGetNextScheduledDate(unittest.TestCase):
+    def test_saturday_skips_sunday_to_monday(self):
+        # From Sat Jan 6: Sun Jan 7 is off, so next is the following Mon (Jan 8).
+        next_date, schedule = get_next_scheduled_date(SAT)
+        self.assertEqual(next_date, date(2024, 1, 8))
+        self.assertEqual(next_date.weekday(), 0)  # Monday
+        self.assertEqual(schedule["video_type"], "short")
+
+    def test_returns_next_working_day(self):
+        next_date, schedule = get_next_scheduled_date(MON)
+        self.assertEqual(next_date, TUE)
+        self.assertEqual(schedule["video_type"], "long")
+
+    def test_never_returns_sunday(self):
+        for d in [MON, TUE, WED, THU, FRI, SAT, SUN]:
+            with self.subTest(day=d):
+                next_date, _ = get_next_scheduled_date(d)
+                self.assertNotEqual(next_date.weekday(), 6)
+
+
+class TestGetPlatformLabel(unittest.TestCase):
+    def test_known_labels(self):
+        self.assertEqual(get_platform_label("youtube"), "YouTube")
+        self.assertEqual(get_platform_label("youtube_shorts"), "YouTube Shorts")
+        self.assertEqual(get_platform_label("tiktok"), "TikTok")
+
+    def test_unknown_passthrough(self):
+        self.assertEqual(get_platform_label("instagram"), "instagram")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_subtitle_generator.py
+++ b/content-pipeline/tests/test_subtitle_generator.py
@@ -1,0 +1,167 @@
+"""Tests for video.subtitle_generator — SRT generation from script + duration."""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from video.subtitle_generator import (
+    generate_srt,
+    _split_into_segments,
+    _format_time,
+    WORDS_PER_SEGMENT,
+)
+
+
+class TestFormatTime(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(_format_time(0), "00:00:00,000")
+
+    def test_fractional_seconds(self):
+        self.assertEqual(_format_time(1.5), "00:00:01,500")
+
+    def test_minutes_and_seconds(self):
+        self.assertEqual(_format_time(75), "00:01:15,000")
+
+    def test_hours(self):
+        self.assertEqual(_format_time(3661.250), "01:01:01,250")
+
+    def test_millisecond_rounding_truncates(self):
+        # 2.999 -> 2 sec, 999 ms
+        self.assertEqual(_format_time(2.999), "00:00:02,999")
+
+
+class TestSplitIntoSegments(unittest.TestCase):
+    def test_short_sentence_kept_whole(self):
+        segs = _split_into_segments("Hôm nay trời đẹp.")
+        self.assertEqual(segs, ["Hôm nay trời đẹp."])
+
+    def test_each_sentence_becomes_segment(self):
+        text = "Câu một. Câu hai. Câu ba."
+        segs = _split_into_segments(text)
+        self.assertEqual(len(segs), 3)
+
+    def test_long_sentence_is_split(self):
+        # 24 words, > WORDS_PER_SEGMENT (10) -> must split into multiple segments
+        sentence = " ".join(f"từ{i}" for i in range(24)) + "."
+        segs = _split_into_segments(sentence)
+        self.assertGreater(len(segs), 1)
+        for seg in segs:
+            self.assertLessEqual(len(seg.split()), WORDS_PER_SEGMENT)
+
+    def test_split_prefers_comma_boundaries(self):
+        sentence = ("một hai ba bốn năm sáu, "
+                    "bảy tám chín mười mười_một mười_hai.")
+        segs = _split_into_segments(sentence)
+        self.assertGreaterEqual(len(segs), 2)
+
+    def test_consecutive_duplicates_removed(self):
+        # AI scripts sometimes repeat the closing line; dedup consecutive ones.
+        text = "Cảm ơn các bạn. Cảm ơn các bạn."
+        segs = _split_into_segments(text)
+        self.assertEqual(segs, ["Cảm ơn các bạn."])
+
+    def test_no_segments_for_whitespace(self):
+        self.assertEqual(_split_into_segments("   "), [])
+
+
+class TestGenerateSrt(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _out(self, name="sub.srt"):
+        return os.path.join(self.tmp, name)
+
+    def test_empty_text_returns_none(self):
+        self.assertIsNone(generate_srt("", 10.0, self._out()))
+
+    def test_zero_duration_returns_none(self):
+        self.assertIsNone(generate_srt("Xin chào.", 0, self._out()))
+
+    def test_negative_duration_returns_none(self):
+        self.assertIsNone(generate_srt("Xin chào.", -5, self._out()))
+
+    def test_creates_file_and_returns_path(self):
+        out = self._out()
+        result = generate_srt("Xin chào. Tạm biệt.", 10.0, out)
+        self.assertEqual(result, out)
+        self.assertTrue(os.path.exists(out))
+
+    def test_creates_missing_parent_dir(self):
+        out = os.path.join(self.tmp, "nested", "deep", "sub.srt")
+        result = generate_srt("Xin chào thế giới.", 5.0, out)
+        self.assertEqual(result, out)
+        self.assertTrue(os.path.exists(out))
+
+    def test_srt_structure_is_valid(self):
+        out = self._out()
+        generate_srt("Câu một. Câu hai. Câu ba.", 9.0, out)
+        with open(out, encoding="utf-8") as f:
+            content = f.read()
+        # Each block: index, timecode, text
+        blocks = re.split(r"\n\s*\n", content.strip())
+        self.assertEqual(len(blocks), 3)
+        first = blocks[0].splitlines()
+        self.assertEqual(first[0], "1")
+        self.assertRegex(
+            first[1],
+            r"\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}",
+        )
+
+    def test_timing_is_monotonic_and_covers_duration(self):
+        out = self._out()
+        duration = 30.0
+        generate_srt(
+            "Một hai ba. Bốn năm sáu. Bảy tám chín mười.", duration, out
+        )
+        with open(out, encoding="utf-8") as f:
+            content = f.read()
+        times = re.findall(
+            r"(\d{2}):(\d{2}):(\d{2}),(\d{3}) --> (\d{2}):(\d{2}):(\d{2}),(\d{3})",
+            content,
+        )
+        self.assertTrue(times)
+
+        def to_sec(h, m, s, ms):
+            return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+
+        prev_end = 0.0
+        last_end = 0.0
+        for t in times:
+            start = to_sec(*t[:4])
+            end = to_sec(*t[4:])
+            self.assertGreaterEqual(start, prev_end - 1e-6)  # no overlap
+            self.assertGreaterEqual(end, start)
+            prev_end = end
+            last_end = end
+        # Last subtitle should end at ~ the audio duration (proportional fill)
+        self.assertAlmostEqual(last_end, duration, delta=0.1)
+
+    def test_longer_segment_gets_more_time(self):
+        # Two sentences with very different word counts -> proportional timing.
+        out = self._out()
+        short = "Chào."
+        long = " ".join(["từ"] * 20) + "."
+        generate_srt(f"{short} {long}", 21.0, out)
+        with open(out, encoding="utf-8") as f:
+            content = f.read()
+        times = re.findall(
+            r"(\d{2}):(\d{2}):(\d{2}),(\d{3}) --> (\d{2}):(\d{2}):(\d{2}),(\d{3})",
+            content,
+        )
+
+        def dur(t):
+            def to_sec(h, m, s, ms):
+                return int(h) * 3600 + int(m) * 60 + int(s) + int(ms) / 1000
+            return to_sec(*t[4:]) - to_sec(*t[:4])
+
+        # First displayed segment ("Chào.") should be shorter than the last.
+        self.assertLess(dur(times[0]), dur(times[-1]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_text_preprocessor.py
+++ b/content-pipeline/tests/test_text_preprocessor.py
@@ -1,0 +1,124 @@
+"""Tests for video.text_preprocessor — number/symbol normalization for TTS."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.text_preprocessor as tp
+from video.text_preprocessor import (
+    preprocess_for_tts,
+    _int_to_vi_fallback,
+    _decimal_to_vi,
+)
+
+
+class TestIntToViFallback(unittest.TestCase):
+    """The internal fallback converter (used when num2words is absent)."""
+
+    def test_units(self):
+        self.assertEqual(_int_to_vi_fallback(0), "không")
+        self.assertEqual(_int_to_vi_fallback(7), "bảy")
+
+    def test_teens(self):
+        self.assertEqual(_int_to_vi_fallback(15), "mười lăm")
+
+    def test_tens_special_cases(self):
+        self.assertEqual(_int_to_vi_fallback(20), "hai mươi")
+        self.assertEqual(_int_to_vi_fallback(21), "hai mươi mốt")  # "mốt"
+        self.assertEqual(_int_to_vi_fallback(25), "hai mươi lăm")  # "lăm"
+
+    def test_hundreds(self):
+        self.assertEqual(_int_to_vi_fallback(100), "một trăm")
+        self.assertIn("lẻ", _int_to_vi_fallback(105))  # "một trăm lẻ năm"
+
+    def test_thousands(self):
+        self.assertIn("nghìn", _int_to_vi_fallback(1000))
+
+    def test_millions(self):
+        self.assertIn("triệu", _int_to_vi_fallback(1_000_000))
+
+    def test_negative(self):
+        self.assertTrue(_int_to_vi_fallback(-5).startswith("âm"))
+
+
+class TestDecimalToVi(unittest.TestCase):
+    def test_simple_decimal(self):
+        self.assertEqual(_decimal_to_vi("1.5"), "một phẩy năm")
+
+    def test_reads_each_decimal_digit(self):
+        # 3.14 -> "... phẩy một bốn" (digit-by-digit)
+        self.assertIn("phẩy một bốn", _decimal_to_vi("3.14"))
+
+    def test_integer_part_only(self):
+        self.assertNotIn("phẩy", _decimal_to_vi("42"))
+
+
+class TestPreprocessForTts(unittest.TestCase):
+    """End-to-end normalization cases (mirrors the module's manual cases)."""
+
+    CASES = [
+        ("100 người dùng", "một trăm người dùng"),
+        ("tăng 1.5 lần", "một phẩy năm"),
+        ("năm 2024", "hai nghìn"),
+        ("50% người dùng", "năm mươi phần trăm"),
+        ("$10 mỗi tháng", "mười đô la"),
+        ("tiết kiệm $1,000", "một nghìn đô la"),
+        ("thứ 3 trong tuần", "thứ ba"),
+        ("có 1,000,000 người", "một triệu"),
+        ("tốc độ 3.14 lần", "ba phẩy một bốn"),
+        ("5-7% tăng trưởng", "năm đến bảy phần trăm"),
+        ("10-15 phút", "mười đến mười lăm"),
+        ("3-5 triệu đồng", "ba đến năm triệu"),
+        ("1.5-2.5 lần", "một phẩy năm đến hai phẩy năm"),
+        ("GPT-4 là model", "GPT-bốn"),
+    ]
+
+    def test_all_cases(self):
+        for text_in, expected in self.CASES:
+            with self.subTest(text=text_in):
+                self.assertIn(expected, preprocess_for_tts(text_in))
+
+    def test_empty_string(self):
+        self.assertEqual(preprocess_for_tts(""), "")
+
+    def test_none_is_passed_through(self):
+        self.assertIsNone(preprocess_for_tts(None))
+
+    def test_text_without_numbers_unchanged(self):
+        text = "Hôm nay trời rất đẹp và mát mẻ."
+        self.assertEqual(preprocess_for_tts(text), text)
+
+    def test_no_digits_remain_for_plain_numbers(self):
+        # After preprocessing a plain sentence, raw ASCII digits should be gone.
+        result = preprocess_for_tts("Có 100 công cụ và 50 người dùng")
+        self.assertFalse(any(c.isdigit() for c in result))
+
+    def test_percent_range_takes_priority_over_plain_range(self):
+        # "5-7%" must become a percent range, not "năm đến bảy" + stray "%".
+        result = preprocess_for_tts("khoảng 5-7% mỗi năm")
+        self.assertIn("năm đến bảy phần trăm", result)
+        self.assertNotIn("%", result)
+
+
+class TestFallbackPath(unittest.TestCase):
+    """Force the no-num2words code path to ensure the fallback still works."""
+
+    def setUp(self):
+        self._orig = tp._HAS_NUM2WORDS
+        tp._HAS_NUM2WORDS = False
+
+    def tearDown(self):
+        tp._HAS_NUM2WORDS = self._orig
+
+    def test_fallback_converts_integers(self):
+        self.assertIn("một trăm", preprocess_for_tts("100 đồng"))
+
+    def test_fallback_converts_decimals(self):
+        self.assertIn("một phẩy năm", preprocess_for_tts("1.5 lần"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_video_composer.py
+++ b/content-pipeline/tests/test_video_composer.py
@@ -1,0 +1,124 @@
+"""Tests for video.video_composer pure helpers (SRT parsing, time, wrapping).
+
+The ffmpeg/Pillow-dependent paths are not exercised here (they require external
+binaries / system fonts); these tests cover the deterministic logic that drives
+subtitle placement and timing.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from video.video_composer import _parse_srt, _srt_time_to_sec
+
+try:
+    from PIL import ImageFont  # noqa: F401
+    _HAS_PIL = True
+except ImportError:
+    _HAS_PIL = False
+
+
+SAMPLE_SRT = """1
+00:00:00,000 --> 00:00:02,500
+Xin chào các bạn
+
+2
+00:00:02,500 --> 00:00:05,000
+Hôm nay có tin AI mới
+"""
+
+# Uses '.' as the millisecond separator (some tools emit this variant).
+DOT_SRT = """1
+00:00:01.000 --> 00:00:03.250
+Dòng phụ đề
+"""
+
+
+class TestSrtTimeToSec(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(_srt_time_to_sec("00:00:00,000"), 0.0)
+
+    def test_comma_millis(self):
+        self.assertAlmostEqual(_srt_time_to_sec("00:00:02,500"), 2.5)
+
+    def test_dot_millis(self):
+        self.assertAlmostEqual(_srt_time_to_sec("00:00:03.250"), 3.25)
+
+    def test_minutes_and_hours(self):
+        self.assertAlmostEqual(_srt_time_to_sec("01:02:03,000"), 3723.0)
+
+
+class TestParseSrt(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def _write(self, content, name="test.srt"):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(_parse_srt(os.path.join(self.tmp, "nope.srt")), [])
+
+    def test_parses_entries(self):
+        entries = _parse_srt(self._write(SAMPLE_SRT))
+        self.assertEqual(len(entries), 2)
+        start, end, text = entries[0]
+        self.assertEqual(start, 0.0)
+        self.assertAlmostEqual(end, 2.5)
+        self.assertEqual(text, "Xin chào các bạn")
+
+    def test_entries_are_time_ordered(self):
+        entries = _parse_srt(self._write(SAMPLE_SRT))
+        starts = [e[0] for e in entries]
+        self.assertEqual(starts, sorted(starts))
+
+    def test_dot_separator_supported(self):
+        entries = _parse_srt(self._write(DOT_SRT))
+        self.assertEqual(len(entries), 1)
+        self.assertAlmostEqual(entries[0][0], 1.0)
+        self.assertAlmostEqual(entries[0][1], 3.25)
+
+    def test_multiline_text_joined(self):
+        srt = "1\n00:00:00,000 --> 00:00:02,000\nDòng một\nDòng hai\n"
+        entries = _parse_srt(self._write(srt))
+        self.assertEqual(entries[0][2], "Dòng một Dòng hai")
+
+    def test_malformed_block_skipped(self):
+        srt = "1\nthis is not a timecode\nsome text\n"
+        self.assertEqual(_parse_srt(self._write(srt)), [])
+
+    def test_roundtrip_with_generated_srt(self):
+        # Cross-check against the real subtitle generator output.
+        from video.subtitle_generator import generate_srt
+        out = os.path.join(self.tmp, "gen.srt")
+        generate_srt("Câu một. Câu hai dài hơn một chút.", 12.0, out)
+        entries = _parse_srt(out)
+        self.assertTrue(entries)
+        self.assertAlmostEqual(entries[-1][1], 12.0, delta=0.1)
+
+
+@unittest.skipUnless(_HAS_PIL, "Pillow not installed")
+class TestWrapText(unittest.TestCase):
+    def test_wraps_long_text_into_multiple_lines(self):
+        from video.video_composer import _wrap_text
+        font = ImageFont.load_default()
+        text = " ".join(["word"] * 60)
+        lines = _wrap_text(text, font, max_width=120)
+        self.assertGreater(len(lines), 1)
+        # All original words preserved across the wrapped lines.
+        self.assertEqual(" ".join(lines).split(), text.split())
+
+    def test_empty_text(self):
+        from video.video_composer import _wrap_text
+        font = ImageFont.load_default()
+        self.assertEqual(_wrap_text("", font, max_width=100), [""])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/current/video-enhancement/README.md
+++ b/docs/current/video-enhancement/README.md
@@ -1,0 +1,109 @@
+# Video Enhancement — Hybrid Roadmap (P0 → P1 → P2)
+
+> Triển khai khuyến nghị **hybrid** từ
+> [`../video-pipeline-analysis.md`](../video-pipeline-analysis.md): giữ backbone
+> localized + research-driven + Telegram approval, hấp thụ chọn lọc kỹ thuật
+> dựng video của MoneyPrinterTurbo (MPT).
+>
+> Mỗi phase có 2 file: `phase-N-detailed.md` (kiến trúc + acceptance) và
+> `phase-N-issues.md` (Epic + sub-issues sẵn để push GitHub).
+>
+> **Lưu ý đặt tên:** phase ở đây (P0/P1/P2) là track *Video Enhancement*, độc
+> lập với `phase-1..6` của roadmap Content Creator 2.0 ở thư mục cha. Đặt trong
+> thư mục riêng để tránh trùng số.
+
+## Nguyên tắc xuyên suốt (áp cho mọi issue)
+
+Ở mỗi bước luôn tự hỏi *"có thể làm tốt hơn không?"* và bảo đảm 5 trục:
+
+| Trục | Cam kết cụ thể |
+|---|---|
+| **Consistency** | Mọi thay đổi đi qua **feature flag** trong `config.py`; module mới giữ chữ ký hàm cũ (facade) để không vỡ `main.py`; tuân convention `tests/` hiện có (`unittest`). |
+| **Performance** | Mỗi flag có path "cũ" làm fallback; composer phải hạ từ **O(N) input → O(1)**; Whisper chạy model nhỏ trên CPU; đo thời gian render trước/sau. |
+| **UI/UX** | Giữ Telegram là cổng duyệt chính (mobile-first). Thêm tuỳ chọn chứ không thay luồng duyệt. Thông báo lỗi rõ ràng bằng tiếng Việt. |
+| **Security** | Bỏ `CERT_NONE`; secrets chỉ qua `.env`; validate đường dẫn file đầu vào ffmpeg/whisper; không log token. |
+| **Unit test** | Mỗi issue code có mục **Test required**. Logic thuần phải có test; phần I/O (ffmpeg/network/whisper) mock. Không merge nếu CI test đỏ. |
+
+## Sơ đồ kiến trúc — Hybrid target
+
+```
+        CONTENT BACKBONE (giữ nguyên)                 VIDEO ENGINE (nâng cấp)
+ ┌───────────────────────────────────┐   ┌──────────────────────────────────────┐
+ │ collectors → rule_filter           │   │ script_generator (Sonnet)            │
+ │  → ai_scorer(Haiku)                │   │        │                              │
+ │  → ai_analyzer(Sonnet)            │   │        ▼                              │
+ │  → narrative                       │──►│ text_preprocessor (số→chữ VN) ★giữ   │
+ └───────────────────────────────────┘   │        │                              │
+                                          │        ▼                              │
+                                          │  TTS LAYER  (P2: đa-provider)         │
+                                          │   ┌──────────────┐                    │
+                                          │   │ tts/factory  │─► nuitruc (primary)│
+                                          │   │ (facade cũ)  │─► edge   (fallback)│
+                                          │   └──────────────┘                    │
+                                          │        │ audio.mp3                    │
+                                          │        ▼                              │
+                                          │  SUBTITLE LAYER (P1: Whisper)         │
+                                          │   flag SUBTITLE_TIMING_MODE:          │
+                                          │    • wordcount  (cũ, fallback)        │
+                                          │    • whisper    (mới, bám audio)      │
+                                          │        │ subtitle.srt                 │
+                                          │        ▼                              │
+                                          │  BACKGROUND LAYER (P1: multi-clip+BGM)│
+                                          │   pexels_downloader (★giữ cache)      │
+                                          │    • single (cũ)  • multi (mới)       │
+                                          │        │                              │
+                                          │        ▼                              │
+                                          │  COMPOSER (P0: O(1); P2: MoviePy)     │
+                                          │   render subtitle 1 track (ASS/PNG)   │
+                                          │        │ video.mp4                    │
+                                          └────────┼──────────────────────────────┘
+                                                   ▼
+        DISTRIBUTION (giữ nguyên)
+ ┌───────────────────────────────────────────────────────────────────────────┐
+ │ Telegram review gate  →  /approve_<id>  →  publisher (YouTube / TikTok)       │
+ │                          scheduler dual-format (T2/4/6 short, T3/5/7 long)    │
+ └───────────────────────────────────────────────────────────────────────────┘
+
+ ★ = moat tiếng Việt — không thay thế.
+```
+
+### Composer: vì sao P0 ưu tiên (O(N) → O(1))
+
+```
+ HIỆN TẠI (rủi ro):  ffmpeg -i bg -i audio -i sub0.png -i sub1.png ... -i subN.png
+                     filter: overlay→overlay→overlay (chuỗi N mắt xích)
+                     → video 5-10' có N≈100+ input → chậm, ngốn RAM, dễ vỡ
+
+ TARGET P0:          ffmpeg -i bg -i audio -i subtitles.(ass|mov)   ← 1 lớp phụ đề
+                     → số input không phụ thuộc số dòng phụ đề
+```
+
+## Tổng quan phase
+
+| # | Phase | Mục tiêu | Rủi ro | Estimate | Status |
+|---|-------|----------|--------|----------|--------|
+| 0 | [Stabilize & Secure](phase-0-detailed.md) — [issues](phase-0-issues.md) | Sửa SSL TTS, hạ composer O(N)→O(1), feature-flag scaffold, hoàn thiện test nền | Thấp | ~4–5 ngày | 📋 |
+| 1 | [Quality Uplift](phase-1-detailed.md) — [issues](phase-1-issues.md) | Whisper subtitle timing + multi-clip background + nhạc nền | Trung bình | ~6–8 ngày | 📋 |
+| 2 | [Extensibility](phase-2-detailed.md) — [issues](phase-2-issues.md) | TTS đa-provider (Núi Trúc + Edge), engine MoviePy tuỳ chọn, web preview tuỳ chọn | Trung bình–cao | ~8–10 ngày | 📋 |
+
+**Tổng:** ~18–23 ngày làm việc (solo).
+
+## Phụ thuộc giữa phase
+
+```
+P0 (nền: flags + composer ổn định + security)
+ └─► P1 (Whisper/BG/BGM cắm vào composer đã ổn định)
+      └─► P2 (đa-provider + MoviePy — chỉ làm khi P0/P1 đã chứng minh giá trị)
+```
+
+- **P0 là blocker.** Không làm Whisper/multi-clip trên composer còn O(N).
+- P1 có thể chia đôi: subtitle (P1.A) và background/BGM (P1.B) chạy song song.
+- P2 là *optional* — chỉ kích hoạt nếu nhu cầu thực tế vượt khả năng FFmpeg flag-based.
+
+## Convention (kế thừa từ `../README.md`)
+
+- Label tối thiểu: `video-enh`, `phase-0|1|2`, loại con (`feat`/`fix`/`chore`/`docs`/`test`/`refactor`/`security`), domain (`video`/`audio`/`subtitle`/`bg`/`infra`).
+- Estimate: **S** ≤ 0.5 ngày · **M** = 0.5–1.5 ngày · **L** = 2–3 ngày.
+- Push: tạo Epic trước → sub-issue link `Part of #<epic>`.
+- Mỗi sub-issue code phải có checkbox `[ ] Unit test ... pass` trong Acceptance.
+</content>

--- a/docs/current/video-enhancement/phase-0-detailed.md
+++ b/docs/current/video-enhancement/phase-0-detailed.md
@@ -1,0 +1,107 @@
+# Phase 0 — Stabilize & Secure (Detailed)
+
+> **Mục tiêu:** Trước khi thêm tính năng mới, làm cho nền video pipeline **an
+> toàn, ổn định và có thể bật/tắt từng phần**. Đây là blocker cho P1/P2.
+>
+> **Tại sao P0 trước:** thêm Whisper/multi-clip lên một composer còn O(N)-input
+> và một TTS client còn `CERT_NONE` = xây nhà trên nền nứt. P0 vá nền.
+
+---
+
+## 1. Phạm vi
+
+| # | Hạng mục | Vấn đề hiện tại | Kết quả mong muốn |
+|---|----------|-----------------|-------------------|
+| 1 | **Security TTS** | `video/tts_client.py` đặt `check_hostname=False` + `ssl.CERT_NONE` cho mọi request → MITM risk | Verify cert bằng CA bundle hệ thống; chỉ cho phép permissive khi opt-in rõ ràng qua env |
+| 2 | **Composer O(N)** | `_compose_with_overlay` tạo 1 input ffmpeg / dòng phụ đề → 100+ input cho video dài | Phụ đề gộp thành **1 lớp** (ASS nếu có libass, else 1 video phụ đề transparent) → input không phụ thuộc N |
+| 3 | **Feature-flag scaffold** | Hành vi hard-code, khó rollback khi thêm tính năng | `config.py` có nhóm flag video; default = hành vi cũ |
+| 4 | **Test nền** | PR #55 đã phủ logic thuần; còn thiếu test cho code mới của P0 | Test cho SSL helper + composer builder + flags |
+
+> **"Có thể làm tốt hơn không?"** — P0 cố tình *không* đổi chất lượng đầu ra
+> (giữ nguyên timing word-count, nền single-clip). Chỉ đổi *cách dựng* để vừa
+> nhanh hơn vừa an toàn hơn. Tách bạch "refactor an toàn" khỏi "tính năng mới"
+> giúp review dễ và rollback gọn.
+
+---
+
+## 2. Thiết kế
+
+### 2.1 Security — TLS cho TTS (`video/tts_client.py`)
+
+Hiện tại:
+```python
+ssl_ctx.check_hostname = False
+ssl_ctx.verify_mode = ssl.CERT_NONE   # ⚠️ tắt xác thực cho MỌI request
+```
+
+Thiết kế mới — *secure by default, permissive by opt-in*:
+```python
+def _build_opener(*, insecure: bool) -> OpenerDirector:
+    ctx = ssl.create_default_context()          # verify ON theo CA hệ thống
+    if insecure:                                 # chỉ khi TTS_ALLOW_INSECURE_SSL=1
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        logger.warning("TTS SSL verification DISABLED via TTS_ALLOW_INSECURE_SSL")
+    return build_opener(HTTPSHandler(context=ctx))
+```
+- Thêm `TTS_ALLOW_INSECURE_SSL` (mặc định `0`) vào `config.py` + `.env.example`.
+- Nếu endpoint `tts.nuitruc.ai` chỉ phục vụ `http://` (không TLS) thì không có
+  vấn đề SSL — nhưng nếu là `https://` với cert tự ký, phải opt-in *có ý thức*
+  thay vì tắt mặc định.
+- **Không log** body/token. `Authorization` header không xuất hiện trong log.
+
+### 2.2 Composer — hạ O(N) → O(1) (`video/video_composer.py`)
+
+Chiến lược 2 nhánh, chọn lúc runtime theo khả năng ffmpeg:
+
+```
+detect_libass() ?
+ ├─ CÓ  → render 1 file .ass (styling + timing) → ffmpeg -vf "ass=subtitle.ass"
+ │         (1 filter, 0 input ảnh)                       ← path ưu tiên
+ └─ KHÔNG → render chuỗi PNG → ghép thành 1 video phụ đề RGBA transparent
+             (concat theo timing) → ffmpeg overlay 1 lần  ← fallback, vẫn O(1) input
+```
+
+- Tách phần *xây lệnh ffmpeg* ra hàm thuần `build_compose_command(...)` trả về
+  `list[str]` để **unit-test không cần chạy ffmpeg**.
+- `_srt_to_ass(entries, style)` là hàm thuần → test trực tiếp.
+- Giữ API `compose_video(...)` y nguyên (facade) → `main.py` không đổi.
+- Số input ffmpeg = hằng số (bg + audio + ≤1 lớp phụ đề), không phụ thuộc N.
+
+### 2.3 Feature-flag scaffold (`config.py`)
+
+```python
+# --- Video engine flags (P0 scaffold; default = hành vi cũ) ---
+SUBTITLE_TIMING_MODE = os.getenv("SUBTITLE_TIMING_MODE", "wordcount")  # |whisper (P1)
+BACKGROUND_MODE      = os.getenv("BACKGROUND_MODE", "single")          # |multi (P1)
+TTS_PROVIDER         = os.getenv("TTS_PROVIDER", "nuitruc")            # |edge (P2)
+COMPOSER_ENGINE      = os.getenv("COMPOSER_ENGINE", "ffmpeg")          # |moviepy (P2)
+TTS_ALLOW_INSECURE_SSL = os.getenv("TTS_ALLOW_INSECURE_SSL", "0") == "1"
+ENABLE_BGM           = os.getenv("ENABLE_BGM", "0") == "1"             # (P1)
+```
+- Một hàm `config.validate_flags()` log cảnh báo nếu giá trị lạ → tránh lỗi âm thầm.
+
+---
+
+## 3. Acceptance Criteria (Definition of Done — Phase 0)
+
+- [ ] TTS verify cert mặc định; `TTS_ALLOW_INSECURE_SSL=1` mới tắt (có log cảnh báo).
+- [ ] Composer dùng số input ffmpeg **cố định** với video có 5 hay 200 dòng phụ đề.
+- [ ] Render video dài (≥ 8') hoàn tất không lỗi; đo thời gian render giảm hoặc tương đương, RAM không tăng theo N.
+- [ ] Tất cả flag mới mặc định = hành vi cũ; pipeline cũ chạy y hệt khi không set env.
+- [ ] `python -m unittest discover -s tests` xanh (bao gồm test mới của P0).
+- [ ] Không secret nào bị log; `.env.example` cập nhật.
+
+## 4. Rủi ro & giảm thiểu
+
+| Rủi ro | Giảm thiểu |
+|--------|-----------|
+| FFmpeg bản máy không có libass | Có nhánh fallback PNG→1 video phụ đề; detect tự động |
+| Đổi composer làm vỡ output | Giữ facade + so sánh thủ công 1 video long + 1 short trước khi merge |
+| Endpoint TTS thực chất là self-signed | Flag opt-in giữ vận hành chạy được, vẫn an toàn mặc định |
+
+## 5. Không làm trong P0 (để tránh scope creep)
+
+- Không thêm Whisper (P1), không multi-clip/BGM (P1), không Edge TTS (P2),
+  không MoviePy (P2), không Web UI (P2).
+</content>

--- a/docs/current/video-enhancement/phase-0-issues.md
+++ b/docs/current/video-enhancement/phase-0-issues.md
@@ -1,0 +1,146 @@
+# Phase 0 — Issues Master List
+
+> Bản nháp Epic + sub-issues cho **Phase 0 (Stabilize & Secure)**. Push lên
+> GitHub theo convention: Epic trước, sub-issue link `Part of #<epic>`.
+> Mỗi sub-issue code có mục **Test required** — không merge nếu test đỏ.
+
+---
+
+## EPIC #V0.1 — Security: TLS-an-toàn cho TTS client
+
+**Loại:** `epic` `video-enh` `phase-0` `security` `audio`
+**Mô tả:** Bỏ `ssl.CERT_NONE` mặc định trong `video/tts_client.py`, chuyển sang
+verify-by-default + opt-in permissive qua env. Đây là nợ bảo mật ưu tiên cao nhất.
+
+**Definition of Done:**
+- Verify cert bật mặc định; chỉ tắt khi `TTS_ALLOW_INSECURE_SSL=1`.
+- Có log cảnh báo khi chạy chế độ insecure.
+- Không token/secret nào bị log.
+
+### Sub-issues
+
+#### `[security]` Refactor opener TTS sang secure-by-default
+- **Labels:** `video-enh` `phase-0` `security` `audio`
+- **Estimate:** S
+- **Mô tả:** Thay `_build_opener_with_ssl()` bằng `_build_opener(insecure: bool)`; mặc định dùng `ssl.create_default_context()` (verify ON). Đọc cờ từ `config.TTS_ALLOW_INSECURE_SSL`.
+- **Acceptance:**
+  - [ ] Mặc định: context có `check_hostname=True`, `verify_mode=CERT_REQUIRED`
+  - [ ] `insecure=True`: log `WARNING` đúng một lần
+  - [ ] **Test required:** `tests/test_tts_client.py` — assert thuộc tính context ở 2 chế độ (mock, không gọi mạng)
+
+#### `[infra]` Thêm `TTS_ALLOW_INSECURE_SSL` vào config + `.env.example`
+- **Labels:** `video-enh` `phase-0` `infra`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] `config.TTS_ALLOW_INSECURE_SSL` (bool, default False)
+  - [ ] `.env.example` có biến + comment giải thích rủi ro
+
+#### `[test]` Đảm bảo không log secret
+- **Labels:** `video-enh` `phase-0` `security` `test`
+- **Estimate:** S
+- **Mô tả:** Test rằng `Authorization`/token không xuất hiện trong log record khi gọi `_tts_single` (mock opener + capture logging).
+- **Acceptance:**
+  - [ ] **Test required:** assertNoLogContains("Bearer")
+
+---
+
+## EPIC #V0.2 — Composer: hạ O(N) input → O(1)
+
+**Loại:** `epic` `video-enh` `phase-0` `video` `performance`
+**Mô tả:** Gộp phụ đề thành **1 lớp** (ASS nếu libass khả dụng, else 1 video phụ
+đề transparent) để số input ffmpeg không phụ thuộc số dòng phụ đề. Tách phần xây
+lệnh thành hàm thuần để test được.
+
+**Definition of Done:**
+- Video 5–200 dòng phụ đề đều dùng số input ffmpeg cố định.
+- API `compose_video()` không đổi chữ ký.
+- Render long video ≥8' không lỗi; RAM không tăng theo N.
+
+### Sub-issues
+
+#### `[feat]` Hàm thuần `_srt_to_ass(entries, style)`
+- **Labels:** `video-enh` `phase-0` `video` `subtitle` `feat`
+- **Estimate:** M
+- **Mô tả:** Chuyển list `(start, end, text)` → chuỗi file `.ass` hợp lệ (header `[Script Info]`/`[V4+ Styles]`/`[Events]`, style font/size/outline lấy từ `config`). Hỗ trợ tiếng Việt (UTF-8, font NotoSans).
+- **Acceptance:**
+  - [ ] Mỗi entry → đúng 1 dòng `Dialogue:` với timecode `H:MM:SS.cs`
+  - [ ] Escape ký tự đặc biệt (`{`, `}`, newline)
+  - [ ] **Test required:** `tests/test_ass_builder.py` — parse lại số Dialogue = số entry; timecode đúng; tiếng Việt giữ nguyên
+
+#### `[feat]` Detect libass + chọn nhánh render
+- **Labels:** `video-enh` `phase-0` `video` `feat`
+- **Estimate:** S
+- **Mô tả:** `_ffmpeg_has_libass()` chạy `ffmpeg -filters`/`-version` parse khả năng. Cache kết quả.
+- **Acceptance:**
+  - [ ] Trả bool; không crash khi thiếu ffmpeg
+  - [ ] **Test required:** mock `subprocess.run` cho 2 trường hợp có/không libass
+
+#### `[feat]` Fallback: render 1 video phụ đề transparent (no-libass)
+- **Labels:** `video-enh` `phase-0` `video` `feat`
+- **Estimate:** L
+- **Mô tả:** Khi không có libass, render PNG mỗi entry (tái dùng `_render_one_subtitle` hiện có) rồi **ghép thành 1 video RGBA** theo timing (concat/`overlay` 1 lần) thay vì N input.
+- **Acceptance:**
+  - [ ] Số input ffmpeg = hằng (bg + audio + 1 phụ đề)
+  - [ ] **Test required:** `build_compose_command(...)` trả lệnh có đúng 3 `-i` bất kể N
+
+#### `[refactor]` Tách `build_compose_command()` thuần khỏi `_run_ffmpeg`
+- **Labels:** `video-enh` `phase-0` `video` `refactor` `test`
+- **Estimate:** M
+- **Mô tả:** Phần lắp `cmd: list[str]` không I/O → hàm riêng để test; `compose_video` gọi nó rồi `_run_ffmpeg`.
+- **Acceptance:**
+  - [ ] `compose_video()` giữ nguyên signature + hành vi
+  - [ ] **Test required:** assert cấu trúc lệnh (scale/pad, map, codec) cho long & short
+
+#### `[test]` Bench: render time & input-count không tăng theo N
+- **Labels:** `video-enh` `phase-0` `video` `test` `performance`
+- **Estimate:** S
+- **Mô tả:** Test tham số hoá: N ∈ {5, 50, 200} → số `-i` không đổi. (Bench thời gian thực ghi tay vào PR description.)
+- **Acceptance:**
+  - [ ] **Test required:** input-count bất biến theo N
+
+---
+
+## EPIC #V0.3 — Feature-flag scaffold + consistency
+
+**Loại:** `epic` `video-enh` `phase-0` `infra`
+**Mô tả:** Thêm nhóm flag video vào `config.py` (default = hành vi cũ) để P1/P2
+bật/tắt an toàn, rollback gọn.
+
+**Definition of Done:**
+- Flag tồn tại, default giữ pipeline cũ y hệt.
+- `validate_flags()` cảnh báo giá trị lạ.
+
+### Sub-issues
+
+#### `[feat]` Thêm nhóm flag video vào `config.py`
+- **Labels:** `video-enh` `phase-0` `infra` `feat`
+- **Estimate:** S
+- **Mô tả:** `SUBTITLE_TIMING_MODE`, `BACKGROUND_MODE`, `TTS_PROVIDER`, `COMPOSER_ENGINE`, `ENABLE_BGM`, `TTS_ALLOW_INSECURE_SSL` (xem `phase-0-detailed.md` §2.3).
+- **Acceptance:**
+  - [ ] Default = hành vi cũ
+  - [ ] **Test required:** `tests/test_config_flags.py` — default values + `validate_flags()` cảnh báo khi sai
+
+#### `[docs]` Cập nhật `.env.example` + `CLAUDE.md` mục Video
+- **Labels:** `video-enh` `phase-0` `docs`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] Mỗi flag có comment ý nghĩa + giá trị hợp lệ
+
+#### `[chore]` Test runner trong CI/launchd
+- **Labels:** `video-enh` `phase-0` `infra` `chore`
+- **Estimate:** S
+- **Mô tả:** Đảm bảo `python -m unittest discover -s tests` chạy trong workflow/script trước khi deploy (tận dụng `code-review.yml` hoặc thêm bước test).
+- **Acceptance:**
+  - [ ] Bước chạy test tồn tại; đỏ thì chặn
+
+---
+
+## Tóm tắt Phase 0
+
+| Epic | Issues | Estimate |
+|------|--------|----------|
+| #V0.1 Security TTS | 3 | ~1 ngày |
+| #V0.2 Composer O(1) | 5 | ~2.5 ngày |
+| #V0.3 Flags + consistency | 3 | ~1 ngày |
+| **Tổng** | **11** | **~4.5 ngày** |
+</content>

--- a/docs/current/video-enhancement/phase-1-detailed.md
+++ b/docs/current/video-enhancement/phase-1-detailed.md
@@ -1,0 +1,98 @@
+# Phase 1 — Quality Uplift (Detailed)
+
+> **Mục tiêu:** Nâng chất lượng cảm nhận của video lên ngang MPT ở đúng những
+> khâu MPT thắng: **phụ đề bám tiếng (Whisper)** và **nền nhiều cảnh + nhạc nền**.
+> Tất cả cắm vào composer đã ổn định ở P0, qua feature flag.
+>
+> **Tiền đề:** P0 đã xong (composer O(1), flags, security).
+
+---
+
+## 1. Phạm vi
+
+| # | Hạng mục | Trước (P0) | Sau (P1) |
+|---|----------|------------|----------|
+| A | **Subtitle timing** | word-count tỉ lệ → trôi so với tiếng | Whisper align → bám audio chính xác |
+| B | **Background** | 1 clip loop cả video | Nhiều clip, đổi cảnh mỗi N giây |
+| C | **Audio** | chỉ giọng đọc | + nhạc nền volume thấp (ducking) |
+
+---
+
+## 2. Thiết kế
+
+### 2.1 (P1.A) Whisper subtitle alignment — `video/subtitle_aligner.py`
+
+```
+audio.mp3 ──► faster-whisper (model "base"/"small", CPU) ──► segments[(start,end,text)]
+                                  │
+                       SUBTITLE_TIMING_MODE == "whisper"?
+                        ├─ yes → dùng segments của Whisper
+                        └─ no/lỗi/không cài → fallback generate_srt() (P0)
+```
+
+- Module mới `subtitle_aligner.align(audio_path, script_text) -> list[entries]`.
+  - Whisper cho timing chính xác theo audio; *script_text* dùng để **hiệu đính
+    chính tả tiếng Việt** (Whisper có thể nghe sai từ) — ưu tiên text gốc, chỉ
+    lấy timing từ Whisper (kỹ thuật forced-alignment đơn giản: map segment text
+    về câu script gần nhất).
+- **Selector** trong `main._create_video`: chọn aligner theo flag; lỗi → fallback,
+  pipeline không bao giờ chết vì Whisper.
+- **Performance:** model `base` chạy CPU; cache model giữa các lần; chỉ chạy 1
+  lần/video. Đo thời gian, đặt timeout; quá ngưỡng → fallback.
+- **"Tốt hơn không?"** — Không dùng Whisper để *tạo lại text* (rủi ro sai tiếng
+  Việt + mất số đã chuẩn hoá ở `text_preprocessor`). Chỉ mượn **timing**. Giữ
+  text gốc = giữ moat.
+
+### 2.2 (P1.B) Multi-clip background — mở rộng `video/pexels_downloader.py` + composer
+
+```
+BACKGROUND_MODE == "multi"?
+ ├─ yes → lấy K clip (theo keywords + generic), tổng duration ≥ audio
+ │        → composer ghép tuần tự, cắt mỗi BG_CLIP_SECONDS (vd 5s), crossfade nhẹ
+ └─ no  → giữ single-clip loop (P0)
+```
+
+- `get_backgrounds(keywords, orientation, audio_duration, count) -> list[str]`
+  (số nhiều) — tái dùng cache + duration logic đã có.
+- Composer: dựng danh sách segment nền theo timeline; vẫn giữ nguyên tắc P0
+  (input cố định cho phụ đề; nền dùng concat filter, không 1 input/dòng).
+- Giữ fallback: thiếu clip → lặp lại clip sẵn có (không chết).
+
+### 2.3 (P1.C) Background music — `video/audio_mixer.py`
+
+```
+voice.mp3 + music.mp3 ──► ffmpeg amix/sidechaincompress (ducking) ──► final_audio.mp3
+                          music volume ~ -18dB, tự giảm khi có giọng
+```
+
+- Nhạc từ thư mục `video/assets/music/` (royalty-free, commit kèm hoặc tải về),
+  chọn ngẫu nhiên/cố định; `ENABLE_BGM` flag.
+- Hàm thuần `build_mix_command(voice, music, out, music_db)` để test lệnh.
+- **UI/UX:** caption Telegram cho biết video có nhạc nền hay không, để người
+  duyệt biết kiểm tra bản quyền/âm lượng.
+
+---
+
+## 3. Acceptance Criteria (DoD — Phase 1)
+
+- [ ] `SUBTITLE_TIMING_MODE=whisper` → phụ đề bám tiếng (sai lệch < ~0.3s trên mẫu); flag tắt hoặc Whisper lỗi → fallback word-count tự động.
+- [ ] `BACKGROUND_MODE=multi` → video đổi cảnh; single vẫn chạy như cũ.
+- [ ] `ENABLE_BGM=1` → có nhạc nền, giọng vẫn nghe rõ (ducking); tắt → chỉ giọng.
+- [ ] Mọi flag default vẫn = hành vi P0 (không hồi quy).
+- [ ] Whisper không cài/không sẵn → pipeline vẫn tạo được video.
+- [ ] `unittest discover` xanh; có test cho aligner-selector, multi-bg builder, mix builder.
+- [ ] Ghi nhận bench thời gian render trước/sau (Whisper thêm bao lâu) trong PR.
+
+## 4. Rủi ro & giảm thiểu
+
+| Rủi ro | Giảm thiểu |
+|--------|-----------|
+| faster-whisper nặng/chậm trên Mac Mini | Model `base`, CPU, timeout + fallback; cache model |
+| Whisper nghe sai tiếng Việt | Chỉ lấy timing, giữ text script gốc |
+| Bản quyền nhạc nền | Chỉ dùng nguồn royalty-free; ghi nguồn trong `assets/music/CREDITS.md` |
+| Ghép nhiều clip làm vỡ aspect/looping | Tái dùng scale/pad + duration-match đã test ở P0 |
+
+## 5. Không làm trong P1
+
+- Không Edge TTS / đa-provider (P2), không MoviePy engine (P2), không Web UI (P2).
+</content>

--- a/docs/current/video-enhancement/phase-1-issues.md
+++ b/docs/current/video-enhancement/phase-1-issues.md
@@ -1,0 +1,125 @@
+# Phase 1 — Issues Master List
+
+> Bản nháp Epic + sub-issues cho **Phase 1 (Quality Uplift)**. Tiền đề: Phase 0
+> đã merge (composer O(1), flags, security). Mỗi sub-issue code có **Test required**.
+
+---
+
+## EPIC #V1.1 — Whisper subtitle alignment (timing bám audio)
+
+**Loại:** `epic` `video-enh` `phase-1` `subtitle` `audio`
+**Mô tả:** Thêm `video/subtitle_aligner.py` dùng faster-whisper lấy **timing**
+chính xác, giữ **text script gốc** (bảo toàn localization). Chọn qua
+`SUBTITLE_TIMING_MODE`; lỗi → fallback word-count.
+
+**Definition of Done:**
+- `whisper` mode bám tiếng; fallback tự động khi lỗi/không cài.
+- Không bao giờ làm pipeline chết.
+
+### Sub-issues
+
+#### `[chore]` Thêm `faster-whisper` (optional dependency)
+- **Labels:** `video-enh` `phase-1` `infra` `chore`
+- **Estimate:** S
+- **Mô tả:** Thêm vào `requirements.txt` dạng optional/extra; import lazy + try/except.
+- **Acceptance:**
+  - [ ] Thiếu thư viện → log cảnh báo, không crash
+  - [ ] **Test required:** import-guard test (mock ImportError → fallback)
+
+#### `[feat]` `subtitle_aligner.align(audio, script_text)`
+- **Labels:** `video-enh` `phase-1` `subtitle` `feat`
+- **Estimate:** L
+- **Mô tả:** Gọi Whisper lấy segment timing; map về câu script gần nhất để giữ text gốc (forced-alignment đơn giản). Trả list `(start,end,text)`.
+- **Acceptance:**
+  - [ ] Output dùng được trực tiếp bởi `_srt_to_ass` (P0)
+  - [ ] Text trả về là câu script gốc (không phải transcript Whisper)
+  - [ ] **Test required:** `tests/test_subtitle_aligner.py` — mock Whisper segments, assert mapping timing↔text đúng; assert giữ số đã chuẩn hoá
+
+#### `[feat]` Selector trong `main._create_video` theo flag + timeout/fallback
+- **Labels:** `video-enh` `phase-1` `subtitle` `feat`
+- **Estimate:** M
+- **Mô tả:** Nếu `SUBTITLE_TIMING_MODE=whisper` → thử align; timeout/exception → `generate_srt()`.
+- **Acceptance:**
+  - [ ] **Test required:** mock aligner raise → assert dùng fallback và vẫn ra SRT
+
+#### `[test]` Đo độ lệch timing trên mẫu
+- **Labels:** `video-enh` `phase-1` `subtitle` `test`
+- **Estimate:** S
+- **Mô tả:** Mẫu audio ngắn + ground-truth → assert sai lệch trung bình < ngưỡng. (Có thể đánh dấu `slow`/skip nếu không có model trong CI.)
+
+---
+
+## EPIC #V1.2 — Multi-clip background
+
+**Loại:** `epic` `video-enh` `phase-1` `bg` `video`
+**Mô tả:** Cho phép nền nhiều cảnh đổi mỗi N giây, qua `BACKGROUND_MODE=multi`.
+Tái dùng cache + duration logic của `pexels_downloader`.
+
+**Definition of Done:**
+- `multi` đổi cảnh; `single` giữ nguyên P0; thiếu clip → lặp, không chết.
+
+### Sub-issues
+
+#### `[feat]` `get_backgrounds(..., count) -> list[str]`
+- **Labels:** `video-enh` `phase-1` `bg` `feat`
+- **Estimate:** M
+- **Mô tả:** Bản số nhiều của `get_background`; gom đủ clip để tổng duration ≥ audio.
+- **Acceptance:**
+  - [ ] Dùng lại `_cache_*`, `_select_best_background`
+  - [ ] **Test required:** mock cache/download → assert số clip & fallback khi thiếu
+
+#### `[feat]` Composer dựng timeline nền nhiều clip
+- **Labels:** `video-enh` `phase-1` `bg` `video` `feat`
+- **Estimate:** L
+- **Mô tả:** Ghép clip tuần tự, cắt mỗi `BG_CLIP_SECONDS`, crossfade nhẹ; vẫn giữ phụ đề 1 lớp (P0). Hàm thuần `build_multi_bg_filter(clips, durations)`.
+- **Acceptance:**
+  - [ ] Số input phụ đề vẫn O(1)
+  - [ ] **Test required:** assert filter concat/xfade đúng số đoạn theo audio_duration
+
+#### `[infra]` Flag `BG_CLIP_SECONDS` + default
+- **Labels:** `video-enh` `phase-1` `infra`
+- **Estimate:** S
+
+---
+
+## EPIC #V1.3 — Background music (BGM) + ducking
+
+**Loại:** `epic` `video-enh` `phase-1` `audio`
+**Mô tả:** Trộn nhạc nền royalty-free dưới giọng đọc với ducking, qua `ENABLE_BGM`.
+
+**Definition of Done:**
+- BGM bật → có nhạc, giọng vẫn rõ; tắt → chỉ giọng.
+
+### Sub-issues
+
+#### `[feat]` `audio_mixer.build_mix_command(voice, music, out, music_db)`
+- **Labels:** `video-enh` `phase-1` `audio` `feat`
+- **Estimate:** M
+- **Mô tả:** Hàm thuần dựng lệnh ffmpeg `amix`/`sidechaincompress` (ducking). `mix_audio()` gọi nó + `_run_ffmpeg`.
+- **Acceptance:**
+  - [ ] **Test required:** `tests/test_audio_mixer.py` — assert lệnh có ducking + volume đúng; music thiếu → trả voice gốc
+
+#### `[task]` Bổ sung nhạc royalty-free + CREDITS
+- **Labels:** `video-enh` `phase-1` `audio` `task`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] `video/assets/music/` có ≥3 track + `CREDITS.md` ghi nguồn/giấy phép
+
+#### `[feat]` Telegram caption báo có BGM
+- **Labels:** `video-enh` `phase-1` `bot` `feat`
+- **Estimate:** S
+- **Mô tả:** Thêm dòng "🎵 Nhạc nền: <tên>" vào caption duyệt để người duyệt kiểm tra.
+- **Acceptance:**
+  - [ ] **Test required:** assert caption chứa nhãn nhạc khi `ENABLE_BGM=1`
+
+---
+
+## Tóm tắt Phase 1
+
+| Epic | Issues | Estimate |
+|------|--------|----------|
+| #V1.1 Whisper timing | 4 | ~3 ngày |
+| #V1.2 Multi-clip BG | 3 | ~2.5 ngày |
+| #V1.3 BGM + ducking | 3 | ~1.5 ngày |
+| **Tổng** | **10** | **~7 ngày** |
+</content>

--- a/docs/current/video-enhancement/phase-2-detailed.md
+++ b/docs/current/video-enhancement/phase-2-detailed.md
@@ -1,0 +1,94 @@
+# Phase 2 — Extensibility (Detailed)
+
+> **Mục tiêu:** Mở khả năng mở rộng *khi đã chứng minh giá trị ở P0/P1*: TTS
+> đa-provider (giảm phụ thuộc 1 endpoint), engine MoviePy tuỳ chọn (timeline
+> phức tạp), và công cụ preview/biên tập web tuỳ chọn.
+>
+> **P2 là OPTIONAL.** Chỉ kích hoạt từng Epic khi có nhu cầu thật — tránh kéo
+> phụ thuộc nặng làm hỏng mục tiêu ~$4/tháng & vận hành nhẹ.
+
+---
+
+## 1. Phạm vi (mỗi Epic độc lập, bật theo nhu cầu)
+
+| # | Hạng mục | Động lực | Khi nào nên làm |
+|---|----------|----------|-----------------|
+| A | **TTS đa-provider** | Núi Trúc là single point of failure | Khi endpoint từng down hoặc cần A/B giọng |
+| B | **MoviePy engine** | FFmpeg flag-based chạm trần với timeline phức tạp | Khi cần transition/overlay nâng cao vượt P0/P1 |
+| C | **Web preview UI** | Cần xem trước/chọn biến thể trước khi duyệt | Khi sản lượng tăng, cần biên tập nhiều |
+
+---
+
+## 2. Thiết kế
+
+### 2.1 (P2.A) TTS đa-provider — `video/tts/`
+
+```
+video/tts/
+  ├─ base.py      # TTSProvider: synthesize(text, out, voice, speed) -> path|None
+  ├─ nuitruc.py   # provider hiện tại (chuyển từ tts_client)
+  ├─ edge.py      # Edge TTS (vi-VN-HoaiMyNeural / NamMinhNeural) — miễn phí
+  └─ factory.py   # get_provider(config.TTS_PROVIDER), fallback chain
+```
+
+- `tts_client.text_to_speech()` giữ nguyên làm **facade** → factory (consistency,
+  `main.py` không đổi).
+- **Fallback chain:** primary lỗi → thử provider kế (vd nuitruc → edge). Log rõ.
+- **Quan trọng:** `text_preprocessor` chạy *trước* mọi provider → Edge cũng đọc
+  số đúng. (Đây là lý do Edge ở MPT đọc số sai, còn ở đây thì không.)
+- **Security:** mỗi provider tự quản endpoint/secret qua `.env`; không hard-code.
+- **"Tốt hơn không?"** — interface 1 method, dễ thêm provider (Azure...) sau.
+  Không over-engineer: chỉ 2 provider lúc đầu.
+
+### 2.2 (P2.B) MoviePy engine tuỳ chọn — `video/composer_moviepy.py`
+
+```
+COMPOSER_ENGINE == "moviepy"?
+ ├─ yes → composer_moviepy.compose(...)   # timeline layer-based
+ └─ no  → video_composer.compose_video()  # FFmpeg (P0/P1) — mặc định
+```
+
+- Cùng chữ ký `compose(audio, subtitle, output, video_type, bg)` → hoán đổi được.
+- MoviePy mạnh cho transition/animation phụ đề; nhưng nặng hơn → để sau FFmpeg.
+- **Performance:** so bench với FFmpeg; chỉ khuyến nghị khi giá trị > chi phí thời
+  gian render.
+- Giữ FFmpeg là default; MoviePy chỉ là lựa chọn cắm thêm.
+
+### 2.3 (P2.C) Web preview UI tuỳ chọn — `webui/` (Streamlit, local-only)
+
+```
+streamlit app (chạy local) → liệt kê video pending_approval
+   → xem trước video + script → nút Approve/Reject (gọi cùng publish_callback)
+```
+
+- **Bổ sung, KHÔNG thay Telegram.** Telegram vẫn là cổng duyệt mobile chính.
+- Web UI dùng khi cần *biên tập/chọn biến thể* tại bàn làm việc.
+- **Security:** bind `127.0.0.1`, không expose ra ngoài; không nhúng secret vào
+  client; thao tác ghi đi qua cùng lớp DB/publish đã có (1 nguồn sự thật).
+- **UI/UX:** danh sách gọn, preview nhúng, trạng thái màu (pending/approved/
+  published), tiếng Việt.
+
+---
+
+## 3. Acceptance Criteria (DoD — Phase 2, theo từng Epic bật)
+
+- [ ] (A) `TTS_PROVIDER=edge` đọc tiếng Việt + số đúng (qua preprocessor); primary lỗi → fallback provider; facade cũ không đổi.
+- [ ] (B) `COMPOSER_ENGINE=moviepy` ra video tương đương; default vẫn FFmpeg.
+- [ ] (C) Web UI local liệt kê & duyệt được, dùng chung DB/publish; không expose ra ngoài.
+- [ ] Mọi Epic default = tắt → pipeline P0/P1 không đổi.
+- [ ] `unittest discover` xanh; test cho factory/fallback, engine-selector, webui logic (tách khỏi Streamlit runtime).
+
+## 4. Rủi ro & giảm thiểu
+
+| Rủi ro | Giảm thiểu |
+|--------|-----------|
+| Phụ thuộc nặng (MoviePy/Streamlit) phình | Mỗi Epic optional + default tắt; import lazy |
+| Edge TTS đổi giọng/giới hạn | Fallback chain; vẫn giữ Núi Trúc primary |
+| Web UI thành bề mặt tấn công | Local-only `127.0.0.1`, không secret client-side |
+| Hai cổng duyệt lệch trạng thái | Dùng chung DB + `publish_callback` (single source of truth) |
+
+## 5. Quyết định cần Phuong chốt (label `decision`)
+
+- Có thực sự cần Web UI không, hay Telegram là đủ? (mặc định: khoan làm C)
+- Provider TTS thứ 2 ưu tiên Edge hay Azure? (mặc định: Edge, miễn phí)
+</content>

--- a/docs/current/video-enhancement/phase-2-issues.md
+++ b/docs/current/video-enhancement/phase-2-issues.md
@@ -1,0 +1,127 @@
+# Phase 2 — Issues Master List
+
+> Bản nháp Epic + sub-issues cho **Phase 2 (Extensibility)**. **Optional** — bật
+> từng Epic theo nhu cầu. Tiền đề: P0 + P1 đã merge. Mỗi sub-issue code có
+> **Test required**.
+
+---
+
+## EPIC #V2.1 — TTS đa-provider (Núi Trúc + Edge)
+
+**Loại:** `epic` `video-enh` `phase-2` `audio`
+**Mô tả:** Tách TTS thành interface `video/tts/` với factory + fallback chain.
+`tts_client.text_to_speech` thành facade. Edge TTS làm provider thứ 2 (miễn phí,
+giọng vi-VN), vẫn chạy qua `text_preprocessor` để đọc số đúng.
+
+**Definition of Done:**
+- Đổi provider qua `TTS_PROVIDER`; primary lỗi → fallback; facade cũ không đổi.
+
+### Sub-issues
+
+#### `[refactor]` Định nghĩa `tts/base.py` + chuyển Núi Trúc sang `tts/nuitruc.py`
+- **Labels:** `video-enh` `phase-2` `audio` `refactor`
+- **Estimate:** M
+- **Mô tả:** Interface `TTSProvider.synthesize(text, out, voice, speed)`. Di chuyển logic hiện có (kèm SSL secure của P0) vào provider.
+- **Acceptance:**
+  - [ ] `tts_client.text_to_speech` vẫn hoạt động y hệt (facade)
+  - [ ] **Test required:** `tests/test_tts_factory.py` — facade gọi đúng provider
+
+#### `[feat]` `tts/edge.py` (Edge TTS vi-VN)
+- **Labels:** `video-enh` `phase-2` `audio` `feat`
+- **Estimate:** M
+- **Mô tả:** Provider dùng edge-tts (`vi-VN-HoaiMyNeural`/`NamMinhNeural`). Import lazy.
+- **Acceptance:**
+  - [ ] Thiếu thư viện → báo lỗi rõ, không crash factory
+  - [ ] **Test required:** mock edge-tts → assert gọi đúng voice + ghi file
+
+#### `[feat]` `tts/factory.py` + fallback chain
+- **Labels:** `video-enh` `phase-2` `audio` `feat`
+- **Estimate:** M
+- **Mô tả:** `get_provider(name)`; nếu primary `synthesize` trả None → thử provider kế theo thứ tự cấu hình.
+- **Acceptance:**
+  - [ ] **Test required:** primary trả None → fallback được gọi; cả hai lỗi → trả None + log
+
+#### `[test]` Bảo đảm preprocessor chạy trước mọi provider
+- **Labels:** `video-enh` `phase-2` `audio` `test`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] **Test required:** input có "$1,000" → text gửi provider đã là "một nghìn đô la"
+
+---
+
+## EPIC #V2.2 — MoviePy composer engine (tuỳ chọn)
+
+**Loại:** `epic` `video-enh` `phase-2` `video`
+**Mô tả:** Thêm engine MoviePy hoán đổi qua `COMPOSER_ENGINE`, cùng chữ ký với
+composer FFmpeg. Default vẫn FFmpeg.
+
+**Definition of Done:**
+- `moviepy` ra video tương đương; default FFmpeg không đổi.
+
+### Sub-issues
+
+#### `[chore]` Thêm MoviePy (optional dependency, import lazy)
+- **Labels:** `video-enh` `phase-2` `video` `chore`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] Thiếu MoviePy + `COMPOSER_ENGINE=moviepy` → báo lỗi rõ, gợi ý cài
+
+#### `[feat]` `composer_moviepy.compose(...)` cùng signature
+- **Labels:** `video-enh` `phase-2` `video` `feat`
+- **Estimate:** L
+- **Mô tả:** Dựng bg + audio + phụ đề bằng MoviePy timeline; hỗ trợ multi-clip/BGM của P1.
+- **Acceptance:**
+  - [ ] Chữ ký == `compose_video`
+  - [ ] **Test required:** mock MoviePy clip → assert layer/timeline lắp đúng (không render thật trong unit test)
+
+#### `[feat]` Engine selector trong `main`
+- **Labels:** `video-enh` `phase-2` `video` `feat`
+- **Estimate:** S
+- **Acceptance:**
+  - [ ] **Test required:** flag → chọn đúng engine; default FFmpeg
+
+---
+
+## EPIC #V2.3 — Web preview UI (tuỳ chọn, local-only)
+
+**Loại:** `epic` `video-enh` `phase-2` `bot` `decision`
+**Mô tả:** Streamlit app local liệt kê video `pending_approval`, xem trước, duyệt
+qua cùng `publish_callback`. Bổ sung, không thay Telegram. **Cần Phuong chốt
+trước khi code.**
+
+**Definition of Done:**
+- Liệt kê + preview + approve/reject hoạt động; dùng chung DB; bind 127.0.0.1.
+
+### Sub-issues
+
+#### `[feat]` Tách logic duyệt khỏi Telegram → `review_service.py`
+- **Labels:** `video-enh` `phase-2` `backend` `refactor`
+- **Estimate:** M
+- **Mô tả:** Trích `approve(video_id)`/`reject(video_id)` dùng chung cho Telegram & Web (single source of truth).
+- **Acceptance:**
+  - [ ] Telegram bot dùng service mới, hành vi không đổi
+  - [ ] **Test required:** `tests/test_review_service.py` — chuyển trạng thái đúng, chặn duyệt sai trạng thái
+
+#### `[feat]` Streamlit app `webui/app.py` (local)
+- **Labels:** `video-enh` `phase-2` `frontend` `feat`
+- **Estimate:** L
+- **Mô tả:** Danh sách pending + video preview + nút Approve/Reject gọi `review_service`. Bind `127.0.0.1`.
+- **Acceptance:**
+  - [ ] Không expose ra ngoài; không secret client-side
+  - [ ] **Test required:** logic tải danh sách/format tách khỏi runtime Streamlit và có test
+
+#### `[docs]` Hướng dẫn chạy Web UI + cảnh báo security
+- **Labels:** `video-enh` `phase-2` `docs`
+- **Estimate:** S
+
+---
+
+## Tóm tắt Phase 2
+
+| Epic | Issues | Estimate | Ghi chú |
+|------|--------|----------|---------|
+| #V2.1 TTS đa-provider | 4 | ~2.5 ngày | Khuyến nghị làm |
+| #V2.2 MoviePy engine | 3 | ~3 ngày | Chỉ khi cần timeline phức tạp |
+| #V2.3 Web UI | 3 | ~3 ngày | `decision` — mặc định hoãn |
+| **Tổng (nếu làm hết)** | **10** | **~8.5 ngày** | |
+</content>

--- a/docs/current/video-pipeline-analysis.md
+++ b/docs/current/video-pipeline-analysis.md
@@ -1,0 +1,195 @@
+# Phân tích luồng tạo video: Hiện tại vs MoneyPrinterTurbo
+
+> Tài liệu đánh giá hệ thống (System review) — đứng ở góc nhìn **systems engineer + product manager + UI/UX**.
+> Mục tiêu: trả lời câu hỏi *"giữ cách tạo video hiện tại hay chuyển sang MoneyPrinterTurbo?"*,
+> và ở mỗi bước luôn tự hỏi **"có thể làm tốt hơn không?"**.
+>
+> Kết luận ngắn (TL;DR): **Không thay thế toàn bộ. Giữ backbone hiện tại, hấp thụ
+> kỹ thuật dựng video của MoneyPrinterTurbo (MPT) một cách chọn lọc** — đây là
+> phương án tối ưu về chất lượng, chi phí và rủi ro.
+
+---
+
+## 1. Toàn cảnh luồng hoạt động hiện tại
+
+```
+Thu thập (RSS/Twitter/Reddit/ProductHunt)
+  → rule_filter (miễn phí)
+  → ai_scorer (Haiku, rẻ)
+  → ai_analyzer (Sonnet, top bài)
+  → narrative (bản tổng hợp)
+  ─────────────────────────────────────────────  ← ranh giới "content"
+  → script_generator (Sonnet: long/short + metadata)
+  → text_preprocessor (số → chữ tiếng Việt)        ★ tài sản riêng
+  → tts_client (Núi Trúc Vietnamese TTS)           ★ tài sản riêng
+  → subtitle_generator (SRT theo word-count)
+  → pexels_downloader (background + duration-match + cache)
+  → video_composer (FFmpeg + Pillow overlay PNG)
+  → Telegram: gửi script + video để DUYỆT          ★ human-in-the-loop
+  → /approve_<id> → publisher (YouTube / TikTok)
+```
+
+Điểm mạnh cốt lõi (moat) nằm ở 3 chỗ có dấu ★:
+1. **Localization tiếng Việt sâu** — `text_preprocessor` chuyển `"$1,000"`,
+   `"5-7%"`, `"GPT-4"`, `"năm 2024"` thành chữ đọc đúng; TTS giọng Việt; font
+   NotoSans render dấu tiếng Việt.
+2. **Tích hợp chặt với pipeline research** — video sinh ra *từ bản tin AI hằng
+   ngày đã được chấm điểm và phân tích*, không phải từ một "topic" rời rạc.
+3. **Human-in-the-loop qua Telegram** — duyệt trên điện thoại, `/approve` →
+   đăng ngay. UX kiểm soát rất phù hợp cho kênh 1 người vận hành.
+
+---
+
+## 2. MoneyPrinterTurbo là gì (đối chiếu thực tế)
+
+| Khía cạnh | MoneyPrinterTurbo |
+|---|---|
+| Dựng video | **MoviePy 2.x** trên nền FFmpeg — ghép nhiều clip, chuyển cảnh, nhạc nền |
+| TTS | **Edge TTS** (miễn phí) mặc định; Azure TTS V2 (trả phí) |
+| Tiếng Việt | Không quảng cáo, **nhưng** Edge TTS có 2 giọng `vi-VN-HoaiMyNeural` (nữ) & `vi-VN-NamMinhNeural` (nam) |
+| Subtitle | **Whisper / faster-whisper** → timing chính xác theo audio (cần GPU để nhanh); hoặc dùng timestamp của Edge TTS |
+| Background | Pexels / Pixabay / Coverr + material local; **đổi clip mỗi N giây** |
+| Giao diện | **Streamlit Web UI** + **FastAPI REST API** |
+| LLM | 15+ provider (OpenAI, Gemini, Ollama, DeepSeek, …) |
+| Khác | Batch generation, nhạc nền, một-click publish |
+
+Nguồn: README chính thức của dự án (MoviePy 2.x, Edge TTS, Pexels/Pixabay/Coverr,
+Streamlit+FastAPI) và xác nhận Edge TTS có giọng vi-VN (xem mục Nguồn cuối tài liệu).
+
+---
+
+## 3. So sánh từng bước — *"có thể làm tốt hơn không?"*
+
+### 3.1 Sinh script
+- **Hiện tại:** Sonnet, prompt riêng cho long/short, tách script/metadata bằng
+  delimiter `===SCRIPT===` (tránh vỡ JSON). Gắn liền narrative đã phân tích.
+- **MPT:** sinh script từ keyword/topic — *generic*, không có ngữ cảnh bản tin.
+- **Tốt hơn?** Pipeline hiện tại **thắng rõ**. Giữ nguyên. (Cải tiến nhỏ:
+  thêm kiểm tra trùng câu tự động trước khi TTS.)
+
+### 3.2 Chuẩn hoá text cho TTS
+- **Hiện tại:** `text_preprocessor` — xử lý số/%, range, tiền tệ, dấu phẩy nghìn.
+  Đây là thứ **MPT không có** và là lý do giọng đọc tiếng Việt nghe "đúng".
+- **Tốt hơn?** Đây là tài sản phải giữ. MPT thua. ✅ Giữ.
+
+### 3.3 TTS
+- **Hiện tại:** Núi Trúc TTS (giọng Việt chuyên dụng). Rủi ro: phụ thuộc 1
+  endpoint bên thứ ba, và **đang tắt xác thực SSL** (`CERT_NONE`) — nợ bảo mật.
+- **MPT/Edge TTS:** miễn phí, ổn định (hạ tầng Microsoft), có vi-VN nhưng chỉ
+  2 giọng và **không** chuẩn hoá số tiếng Việt.
+- **Tốt hơn?** Có. → **Thêm Edge TTS làm provider thứ 2 (fallback/A-B test)**
+  qua một interface `tts_client` chung. Giữ Núi Trúc làm primary vì chất lượng +
+  `text_preprocessor`. Sửa lỗ hổng SSL (xem §6).
+
+### 3.4 Subtitle / timing
+- **Hiện tại:** chia theo *word-count tỉ lệ* với tổng duration. Nhanh, không cần
+  GPU, **nhưng timing trôi** so với lời đọc thực tế → phụ đề lệch tiếng.
+- **MPT:** Whisper → timing bám audio chính xác.
+- **Tốt hơn?** **Có, đây là nâng cấp chất lượng đáng giá nhất.** → Bổ sung tuỳ
+  chọn dùng `faster-whisper` để căn lại timing SRT (chạy CPU vẫn được với model
+  `tiny/base`). Giữ thuật toán word-count làm fallback khi không có Whisper.
+
+### 3.5 Background video
+- **Hiện tại:** 1 clip Pexels loop cho cả video, có duration-match + cache.
+  → **đơn điệu** với video dài 5-10 phút.
+- **MPT:** ghép nhiều clip, đổi cảnh mỗi N giây, có nhạc nền.
+- **Tốt hơn?** **Có.** → Nâng `video_composer` để (a) ghép nhiều clip nền theo
+  segment, (b) thêm nhạc nền âm lượng thấp. Giữ pexels_downloader (đã có cache +
+  fallback tốt), chỉ mở rộng để lấy *nhiều* clip.
+
+### 3.6 Dựng video (composition) — *điểm yếu kỹ thuật lớn nhất hiện tại*
+- **Hiện tại:** `_compose_with_overlay` tạo **một input FFmpeg cho mỗi dòng phụ
+  đề** rồi `overlay` nối chuỗi. Video dài có 100+ segment → 100+ input + một
+  `filter_complex` khổng lồ. Hệ quả: **chậm, ngốn RAM, dễ vỡ** (giới hạn độ dài
+  dòng lệnh / số arg của FFmpeg). Đây là rủi ro performance & độ ổn định thật.
+- **MPT:** MoviePy quản lý layer/timeline gọn gàng, scale tốt theo số phụ đề.
+- **Tốt hơn?** **Có, cần sửa.** 2 lựa chọn:
+  - (A) Chuyển `video_composer` sang **MoviePy** (mượn cách làm của MPT).
+  - (B) Giữ FFmpeg nhưng render phụ đề thành **1 chuỗi PNG/ASS theo thời gian**
+    thay vì N input (giảm từ O(N) input xuống O(1)).
+  → Khuyến nghị (A) trung hạn, (B) là quick-win ngắn hạn.
+
+### 3.7 Duyệt & UI/UX
+- **Hiện tại:** Telegram — duyệt mobile, `/approve_<id>`, `/script_<id>`,
+  `/status`. Nhẹ, đúng nhu cầu 1 người vận hành. Có PID-lock chống 409.
+- **MPT:** Streamlit Web UI — mạnh khi *chỉnh sửa & xem trước nhiều biến thể*,
+  nhưng cần mở port/đăng nhập, không tiện duyệt trên điện thoại lúc 7:30 sáng.
+- **Tốt hơn?** Tuỳ ngữ cảnh. Cho luồng *duyệt hằng ngày* → Telegram thắng. Có
+  thể bổ sung Web UI sau như công cụ *biên tập* khi cần nhiều biến thể. Không
+  thay thế Telegram.
+
+### 3.8 Publish
+- **Hiện tại:** YouTube (OAuth) + TikTok, gắn với scheduler dual-format (T2/4/6
+  short, T3/5/7 long, CN nghỉ).
+- **MPT:** one-click publish nhưng không có logic lịch theo cadence kênh.
+- **Tốt hơn?** Giữ nguyên. Pipeline hiện tại phù hợp chiến lược kênh hơn.
+
+---
+
+## 4. Bảng tổng hợp quyết định
+
+| Bước | Giữ hiện tại | Mượn từ MPT | Hành động |
+|---|:--:|:--:|---|
+| Research → narrative | ✅ | | Giữ |
+| Script (long/short) | ✅ | | Giữ |
+| Chuẩn hoá số tiếng Việt | ✅ | | Giữ (moat) |
+| TTS | ✅ primary | ➕ Edge TTS fallback | Interface đa-provider + sửa SSL |
+| Subtitle timing | fallback | ✅ Whisper | Thêm faster-whisper |
+| Background | ✅ cache | ✅ multi-clip + BGM | Mở rộng composer |
+| Composition engine | ⚠️ | ✅ MoviePy/timeline | Refactor (điểm yếu lớn nhất) |
+| Duyệt (UX) | ✅ Telegram | (Web UI optional) | Giữ Telegram |
+| Publish + scheduler | ✅ | | Giữ |
+
+**Vì sao KHÔNG thay thế toàn bộ bằng MPT:**
+1. MPT là *topic → video*, không hiểu pipeline *bản tin AI đã chấm điểm*.
+2. Mất toàn bộ localization tiếng Việt (`text_preprocessor`, Núi Trúc TTS).
+3. Mất luồng duyệt Telegram + scheduler dual-format.
+4. Kéo theo phụ thuộc nặng (MoviePy, Streamlit, FastAPI, torch/whisper-GPU) —
+   nghịch với mục tiêu **~$4/tháng**, chạy nhẹ qua launchd trên máy cá nhân.
+
+**Vì sao KHÔNG đứng yên:** composition O(N)-input dễ vỡ, subtitle trôi, nền đơn
+điệu — đều là những điểm MPT làm tốt hơn rõ rệt.
+
+→ **Hybrid là phương án tốt nhất.**
+
+---
+
+## 5. Lộ trình đề xuất (giảm rủi ro, làm tốt dần)
+
+- **P0 — Quick wins (ít rủi ro):**
+  - Sửa lỗ hổng SSL trong `tts_client` (§6).
+  - Giảm O(N) input trong composer (dùng chuỗi PNG/ASS theo timeline).
+  - **Bổ sung unit test cho toàn bộ module video** *(đã làm trong PR này)*.
+- **P1 — Chất lượng:**
+  - Thêm `faster-whisper` để căn timing SRT (tuỳ chọn, fallback word-count).
+  - Multi-clip background + nhạc nền.
+- **P2 — Tuỳ chọn:**
+  - Interface TTS đa-provider (Núi Trúc + Edge TTS).
+  - Refactor composer sang MoviePy nếu cần timeline phức tạp hơn.
+  - Web UI biên tập (chỉ khi cần nhiều biến thể/clip).
+
+---
+
+## 6. Ghi chú Security / Performance / Consistency
+
+- **Security:** `video/tts_client.py` đang đặt `check_hostname=False` +
+  `CERT_NONE`. Đây là MITM risk. Nên dùng CA bundle hợp lệ; chỉ fallback
+  permissive khi có biến môi trường opt-in rõ ràng. (Ngoài phạm vi PR test này
+  nhưng cần xử lý ở P0.)
+- **Performance:** nút thắt là composition (§3.6) và việc gọi TTS 1 request dài
+  (timeout 400s). Whisper nên dùng model nhỏ trên CPU để giữ chi phí.
+- **Consistency:** mọi module đã theo cùng convention (chạy độc lập, `logging`,
+  fallback graceful, `sys.path.insert`). Bộ test mới giữ đúng convention
+  `unittest` như `tests/test_telegram_split.py`.
+
+---
+
+## 7. Nguồn
+
+- MoneyPrinterTurbo — kiến trúc, MoviePy 2.x, Edge TTS, Pexels/Pixabay/Coverr,
+  Streamlit + FastAPI, Whisper subtitle: <https://github.com/harry0703/MoneyPrinterTurbo>
+- Edge TTS có giọng tiếng Việt (`vi-VN-HoaiMyNeural`, `vi-VN-NamMinhNeural`):
+  [edge-tts voices list](https://gist.github.com/BettyJJ/17cbaa1de96235a7f5773b8690a20462),
+  [Azure Vietnamese voices](https://json2video.com/ai-voices/azure/languages/vietnamese/)
+</content>
+</invoke>

--- a/docs/current/video-pipeline-analysis.md
+++ b/docs/current/video-pipeline-analysis.md
@@ -156,6 +156,11 @@ Streamlit+FastAPI) và xác nhận Edge TTS có giọng vi-VN (xem mục Nguồn
 
 ## 5. Lộ trình đề xuất (giảm rủi ro, làm tốt dần)
 
+> Chi tiết kiến trúc + chia issue theo phase: xem
+> [`video-enhancement/`](video-enhancement/README.md)
+> (P0 detailed/issues · P1 detailed/issues · P2 detailed/issues).
+
+
 - **P0 — Quick wins (ít rủi ro):**
   - Sửa lỗ hổng SSL trong `tts_client` (§6).
   - Giảm O(N) input trong composer (dùng chuỗi PNG/ASS theo timeline).


### PR DESCRIPTION
## Mục tiêu

Kiểm tra lại toàn bộ luồng tạo video của Content Creator, so sánh cách dựng video **hiện tại** (FFmpeg + Pillow overlay) với **MoneyPrinterTurbo (MPT)**, và đưa ra phương án tốt nhất — đứng ở góc nhìn systems engineer + product manager + UI/UX. Kèm bổ sung unit test cho toàn bộ module video.

## 1. Tài liệu phân tích — `docs/current/video-pipeline-analysis.md`

Đánh giá từng bước với câu hỏi *"có thể làm tốt hơn không?"*:

| Bước | Kết luận |
|---|---|
| Research → narrative → script | Giữ (MPT là *topic→video*, không hiểu pipeline bản tin AI đã chấm điểm) |
| Chuẩn hoá số tiếng Việt (`text_preprocessor`) | Giữ — **moat**, MPT không có |
| TTS | Giữ Núi Trúc primary + thêm Edge TTS fallback; sửa lỗ hổng SSL (`CERT_NONE`) |
| Subtitle timing | **Thêm Whisper** (MPT làm tốt hơn rõ rệt — timing bám audio) |
| Background | **Multi-clip + nhạc nền** (hiện tại 1 clip loop, đơn điệu) |
| Composition engine | **Điểm yếu lớn nhất**: composer tạo *1 input FFmpeg / dòng phụ đề* → O(N) input, chậm/ngốn RAM/dễ vỡ với video dài. Cần refactor (MoviePy hoặc PNG/ASS theo timeline) |
| Duyệt (UX) | Giữ Telegram (mobile, `/approve`) — hợp 1 người vận hành hơn Web UI Streamlit |
| Publish + scheduler | Giữ |

**Kết luận: KHÔNG thay thế toàn bộ. Hybrid** — giữ backbone localized + research-driven + Telegram approval, hấp thụ chọn lọc kỹ thuật dựng video của MPT. Thay thế toàn bộ sẽ mất localization tiếng Việt, mất Telegram/scheduler, và kéo theo phụ thuộc nặng (MoviePy/Streamlit/FastAPI/whisper-GPU) nghịch với mục tiêu ~$4/tháng.

Có lộ trình P0/P1/P2 và ghi chú Security/Performance/Consistency.

## 2. Unit test (lấp khoảng trống lớn nhất — trước đây chỉ có test cho telegram)

- `test_subtitle_generator.py` — timing SRT, tách segment, dedup
- `test_text_preprocessor.py` — chuẩn hoá số/% tiếng Việt + nhánh fallback (không có num2words)
- `test_video_composer.py` — parse SRT, đổi timecode, wrap text (gated theo Pillow)
- `test_pexels_downloader.py` — cache key, chọn file tốt nhất, chọn nền theo duration
- `test_scheduler.py` — lịch dual-format theo ngày trong tuần

**91 tests pass** (`python3 -m unittest discover -s tests`), theo đúng convention của `tests/test_telegram_split.py`.

## Lưu ý
PR này cố ý **chỉ phân tích + test**, chưa đổi code production của luồng video — để bạn duyệt hướng đi (hybrid) trước khi triển khai P0/P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0154AKd2xWdqEuHpAwQTHL2H)_