### PR TITLE
Video enhancement P0 + P1: secure/O(1) composer, Whisper timing, multi-clip BG, BGM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,28 @@ MAX_DEEP_ANALYSIS = 5            # Tối đa bài phân tích sâu mỗi ngày (
 
 ---
 
+## Video engine flags (Video Enhancement roadmap)
+
+Các flag bật/tắt nâng cấp video, mặc định = hành vi cũ (xem
+`docs/current/video-enhancement/`):
+
+| Flag (env) | Default | Ý nghĩa |
+|------------|---------|---------|
+| `SUBTITLE_TIMING_MODE` | `wordcount` | `wordcount` (cũ) \| `whisper` (P1, bám audio) |
+| `BACKGROUND_MODE` | `single` | `single` (cũ) \| `multi` (P1, nhiều clip) |
+| `TTS_PROVIDER` | `nuitruc` | `nuitruc` (cũ) \| `edge` (P2) |
+| `COMPOSER_ENGINE` | `ffmpeg` | `ffmpeg` (default) \| `moviepy` (P2) |
+| `ENABLE_BGM` | `0` | `1` để trộn nhạc nền (P1) |
+| `TTS_ALLOW_INSECURE_SSL` | `0` | **Security:** chỉ bật cho endpoint TLS tự ký tin cậy; mặc định verify cert |
+
+`config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
+fallback về hành vi cũ.
+
+**Composer:** phụ đề được gộp thành **một track trong suốt** (concat-demuxer →
+overlay 1 lần) nên số input ffmpeg là hằng số, không phụ thuộc số dòng phụ đề.
+
+---
+
 ## Nguyên tắc khi viết code
 
 - Dùng Python 3.10+

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -18,3 +18,18 @@ YOUTUBE_CLIENT_SECRETS=/path/to/client_secret.json
 
 # --- TikTok ---
 TIKTOK_ACCESS_TOKEN=...
+
+# --- Video engine flags (default = legacy behaviour; see docs/current/video-enhancement/) ---
+# Subtitle timing: wordcount (legacy, proportional) | whisper (P1, audio-aligned)
+SUBTITLE_TIMING_MODE=wordcount
+# Background: single (legacy, one looped clip) | multi (P1, multi-clip)
+BACKGROUND_MODE=single
+# TTS provider: nuitruc (legacy) | edge (P2, Edge TTS vi-VN)
+TTS_PROVIDER=nuitruc
+# Composer engine: ffmpeg (default) | moviepy (P2)
+COMPOSER_ENGINE=ffmpeg
+# Background music under narration: 1 to enable (P1)
+ENABLE_BGM=0
+# SECURITY: set to 1 ONLY for a trusted self-signed TTS endpoint. Default 0
+# keeps TLS certificate verification ON. Enabling it exposes the call to MITM.
+TTS_ALLOW_INSECURE_SSL=0

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -66,5 +66,57 @@ YOUTUBE_CLIENT_SECRETS = os.getenv("YOUTUBE_CLIENT_SECRETS", "")   # Path to OAu
 YOUTUBE_TOKEN_FILE = os.path.join(os.path.dirname(__file__), "publisher", ".youtube_token.json")
 TIKTOK_ACCESS_TOKEN = os.getenv("TIKTOK_ACCESS_TOKEN", "")
 
+# --- Video engine flags (Video Enhancement roadmap; default = legacy behaviour) ---
+# Each flag has a "legacy" default so the pipeline behaves exactly as before
+# unless explicitly opted in. See docs/current/video-enhancement/.
+#
+# SUBTITLE_TIMING_MODE: "wordcount" (legacy, proportional) | "whisper" (P1, audio-aligned)
+SUBTITLE_TIMING_MODE = os.getenv("SUBTITLE_TIMING_MODE", "wordcount")
+# BACKGROUND_MODE: "single" (legacy, one looped clip) | "multi" (P1, multi-clip)
+BACKGROUND_MODE = os.getenv("BACKGROUND_MODE", "single")
+# TTS_PROVIDER: "nuitruc" (legacy) | "edge" (P2, Edge TTS vi-VN)
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "nuitruc")
+# COMPOSER_ENGINE: "ffmpeg" (legacy/default) | "moviepy" (P2)
+COMPOSER_ENGINE = os.getenv("COMPOSER_ENGINE", "ffmpeg")
+# ENABLE_BGM: mix royalty-free background music under narration (P1)
+ENABLE_BGM = os.getenv("ENABLE_BGM", "0") == "1"
+# TTS_ALLOW_INSECURE_SSL: disable TLS verification for the TTS endpoint.
+# SECURITY: only enable for a known self-signed endpoint you trust. Default OFF.
+TTS_ALLOW_INSECURE_SSL = os.getenv("TTS_ALLOW_INSECURE_SSL", "0") == "1"
+
+# Allowed values for the string-valued flags above (used by validate_flags()).
+_FLAG_CHOICES = {
+    "SUBTITLE_TIMING_MODE": {"wordcount", "whisper"},
+    "BACKGROUND_MODE": {"single", "multi"},
+    "TTS_PROVIDER": {"nuitruc", "edge"},
+    "COMPOSER_ENGINE": {"ffmpeg", "moviepy"},
+}
+
+
+def validate_flags(logger=None):
+    """Warn about out-of-range video flag values, returning the list of issues.
+
+    Does not raise — an unknown value simply logs a warning and the consuming
+    code falls back to its legacy path. Returns a list of human-readable
+    warning strings (empty when all flags are valid).
+    """
+    issues = []
+    current = {
+        "SUBTITLE_TIMING_MODE": SUBTITLE_TIMING_MODE,
+        "BACKGROUND_MODE": BACKGROUND_MODE,
+        "TTS_PROVIDER": TTS_PROVIDER,
+        "COMPOSER_ENGINE": COMPOSER_ENGINE,
+    }
+    for name, value in current.items():
+        allowed = _FLAG_CHOICES[name]
+        if value not in allowed:
+            msg = (f"{name}={value!r} is not one of {sorted(allowed)}; "
+                   f"falling back to legacy behaviour")
+            issues.append(msg)
+            if logger is not None:
+                logger.warning("Invalid video flag: %s", msg)
+    return issues
+
+
 # Logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -83,6 +83,14 @@ ENABLE_BGM = os.getenv("ENABLE_BGM", "0") == "1"
 # TTS_ALLOW_INSECURE_SSL: disable TLS verification for the TTS endpoint.
 # SECURITY: only enable for a known self-signed endpoint you trust. Default OFF.
 TTS_ALLOW_INSECURE_SSL = os.getenv("TTS_ALLOW_INSECURE_SSL", "0") == "1"
+# Whisper model size for subtitle alignment when SUBTITLE_TIMING_MODE=whisper.
+WHISPER_MODEL_SIZE = os.getenv("WHISPER_MODEL_SIZE", "base")
+# Multi-clip background: switch clip roughly every N seconds (BACKGROUND_MODE=multi).
+BG_CLIP_SECONDS = int(os.getenv("BG_CLIP_SECONDS", "6"))
+BG_CLIP_COUNT = int(os.getenv("BG_CLIP_COUNT", "6"))  # max distinct clips to gather
+# Background music (ENABLE_BGM=1): directory + level under the narration.
+MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music")
+BGM_VOLUME_DB = float(os.getenv("BGM_VOLUME_DB", "-18"))  # music gain relative to voice
 
 # Allowed values for the string-valued flags above (used by validate_flags()).
 _FLAG_CHOICES = {

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -282,9 +282,10 @@ def _create_video(narrative: str, video_type: str, date_str: str,
         return None
 
     # Step 3b: Background music (P1, optional) — mix under the narration.
+    # Use an .m4a container: the mixer encodes AAC, which the mp3 muxer rejects.
     if config.ENABLE_BGM:
         from video.audio_mixer import mix_background_music
-        mixed_path = os.path.join(base_dir, f"audio_bgm_{video_id}.mp3")
+        mixed_path = os.path.join(base_dir, f"audio_bgm_{video_id}.m4a")
         audio_path = mix_background_music(audio_path, mixed_path)
 
     # Step 4: Subtitle — Whisper-aligned timing (P1) with word-count fallback.

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -112,6 +112,7 @@ def run_pipeline(force_video: str | None = None):
     """
     logger.info("=== Pipeline started ===")
     init_db()
+    config.validate_flags(logger)
     errors = []
 
     # --- Phase 0: Ensure assets exist ---

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -72,9 +72,11 @@ from processors.ai_analyzer import analyze_top_articles
 from video.script_generator import generate_long_script, generate_short_script
 from video.tts_client import text_to_speech, get_audio_duration
 from video.text_preprocessor import preprocess_for_tts
-from video.subtitle_generator import generate_srt
+from video.subtitle_generator import generate_srt, write_entries_srt
 from video.video_composer import compose_video
-from video.pexels_downloader import download_backgrounds, download_font, get_background
+from video.pexels_downloader import (
+    download_backgrounds, download_font, get_background, get_backgrounds,
+)
 from publisher.scheduler import get_today_schedule, get_platform_label
 from notifier.telegram_bot import (
     send_video_for_approval, send_publish_notification,
@@ -279,31 +281,58 @@ def _create_video(narrative: str, video_type: str, date_str: str,
         update_video_status(video_id, "draft")
         return None
 
-    # Step 4: Subtitle
+    # Step 3b: Background music (P1, optional) — mix under the narration.
+    if config.ENABLE_BGM:
+        from video.audio_mixer import mix_background_music
+        mixed_path = os.path.join(base_dir, f"audio_bgm_{video_id}.mp3")
+        audio_path = mix_background_music(audio_path, mixed_path)
+
+    # Step 4: Subtitle — Whisper-aligned timing (P1) with word-count fallback.
     duration = get_audio_duration(audio_path)
     if duration <= 0:
         logger.error("Cannot determine audio duration for video %d", video_id)
         return None
 
     srt_path = os.path.join(base_dir, f"subtitle_{video_id}.srt")
-    result = generate_srt(script_text, duration, srt_path)
+    entries = None
+    if config.SUBTITLE_TIMING_MODE == "whisper":
+        try:
+            from video.subtitle_aligner import align
+            entries = align(audio_path, script_text)
+        except Exception as e:  # never let alignment kill the pipeline
+            logger.warning("Whisper alignment error: %s — using word-count", e)
+            entries = None
+    if entries:
+        logger.info("Using Whisper-aligned subtitle timing (%d entries)", len(entries))
+        result = write_entries_srt(entries, srt_path)
+    else:
+        result = generate_srt(script_text, duration, srt_path)
     if not result:
         logger.error("Subtitle generation failed for video %d", video_id)
         return None
 
-    # Step 5: Select background + compose video
+    # Step 5: Select background(s) + compose video
     orientation = "portrait" if video_type == "short" else "landscape"
     keywords = _extract_keywords(youtube_title, script_text)
-    bg_video = get_background(keywords=keywords, orientation=orientation,
-                              audio_duration=duration)
-    if bg_video:
-        logger.info("Using background: %s", bg_video)
+    bg_video = None
+    bg_videos = None
+    if config.BACKGROUND_MODE == "multi":
+        bg_videos = get_backgrounds(keywords=keywords, orientation=orientation,
+                                    audio_duration=duration,
+                                    count=config.BG_CLIP_COUNT)
+        logger.info("Multi-clip background: %d clips", len(bg_videos or []))
     else:
-        logger.warning("No background found — compose_video will use default")
+        bg_video = get_background(keywords=keywords, orientation=orientation,
+                                  audio_duration=duration)
+        if bg_video:
+            logger.info("Using background: %s", bg_video)
+        else:
+            logger.warning("No background found — compose_video will use default")
 
     video_path = os.path.join(base_dir, f"video_{video_id}.mp4")
     result = compose_video(audio_path, srt_path, video_path,
-                           video_type=video_type, bg_video=bg_video)
+                           video_type=video_type, bg_video=bg_video,
+                           bg_videos=bg_videos)
     if not result:
         logger.error("Video composition failed for video %d", video_id)
         return None

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -60,6 +60,9 @@ def send_video_for_approval(video_id: int) -> bool:
     vtype = "DÀI (YouTube)" if video["video_type"] == "long" else "NGẮN (Shorts/TikTok)"
     platform = video.get("scheduled_platform", "")
     title = video.get("youtube_title", "") or video.get("tiktok_caption", "")
+    # Let the reviewer know to check music levels/licensing when BGM is on.
+    bgm_note = "\n🎵 Có nhạc nền — kiểm tra âm lượng & bản quyền." if getattr(
+        config, "ENABLE_BGM", False) else ""
 
     # --- Step 1: Send the script text as the review artifact ---
     script_text = video.get("script_text", "")
@@ -91,7 +94,7 @@ def send_video_for_approval(video_id: int) -> bool:
         f"🎬 VIDEO CHỜ DUYỆT — {today}\n\n"
         f"📌 Loại: {vtype}\n"
         f"📅 Lịch đăng: {video.get('scheduled_date', 'N/A')} → {platform}\n"
-        f"📝 Tiêu đề: {title}\n\n"
+        f"📝 Tiêu đề: {title}{bgm_note}\n\n"
         f"⚠️ Đối chiếu video này với script ở trên.\n"
         f"Script phải khớp 100% với nội dung video.\n\n"
         f"💬 Trả lời:\n"

--- a/content-pipeline/requirements.txt
+++ b/content-pipeline/requirements.txt
@@ -6,3 +6,9 @@ google-api-python-client>=2.100.0
 google-auth-oauthlib>=1.1.0
 Pillow>=9.0
 requests>=2.28
+
+# Optional (P1): Whisper subtitle alignment. Only needed when
+# SUBTITLE_TIMING_MODE=whisper; the pipeline falls back to word-count timing
+# if this is not installed. Heavy dependency — install explicitly:
+#   pip install faster-whisper
+# faster-whisper>=1.0

--- a/content-pipeline/tests/test_audio_mixer.py
+++ b/content-pipeline/tests/test_audio_mixer.py
@@ -1,0 +1,90 @@
+"""Tests for video.audio_mixer (Phase 1 / V1.3 background music)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.audio_mixer as mixer
+from video.audio_mixer import build_mix_command, pick_music, mix_background_music
+
+
+class TestBuildMixCommand(unittest.TestCase):
+    def test_has_ducking_and_amix(self):
+        cmd = build_mix_command("voice.mp3", "music.mp3", "out.mp3", -18.0)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("sidechaincompress", fc)  # ducking
+        self.assertIn("amix", fc)
+
+    def test_music_volume_applied(self):
+        cmd = build_mix_command("voice.mp3", "music.mp3", "out.mp3", -12.0)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("volume=-12.0dB", fc)
+
+    def test_voice_is_first_input(self):
+        cmd = build_mix_command("voice.mp3", "music.mp3", "out.mp3")
+        first_i = cmd.index("-i")
+        self.assertEqual(cmd[first_i + 1], "voice.mp3")
+
+    def test_output_length_follows_voice(self):
+        cmd = build_mix_command("voice.mp3", "music.mp3", "out.mp3")
+        self.assertIn("-shortest", cmd)
+        self.assertEqual(cmd[-1], "out.mp3")
+
+    def test_music_is_looped(self):
+        cmd = build_mix_command("voice.mp3", "music.mp3", "out.mp3")
+        self.assertIn("-stream_loop", cmd)
+
+
+class TestPickMusic(unittest.TestCase):
+    def test_no_dir_returns_none(self):
+        with patch.object(mixer.config, "MUSIC_DIR", "/no/such/dir"):
+            self.assertIsNone(pick_music())
+
+    def test_empty_dir_returns_none(self):
+        tmp = tempfile.mkdtemp()
+        self.assertIsNone(pick_music(tmp))
+
+    def test_ignores_non_audio(self):
+        tmp = tempfile.mkdtemp()
+        open(os.path.join(tmp, "CREDITS.md"), "w").close()
+        open(os.path.join(tmp, ".gitkeep"), "w").close()
+        self.assertIsNone(pick_music(tmp))
+
+    def test_picks_audio_file(self):
+        tmp = tempfile.mkdtemp()
+        track = os.path.join(tmp, "calm.mp3")
+        open(track, "w").close()
+        self.assertEqual(pick_music(tmp), track)
+
+
+class TestMixBackgroundMusic(unittest.TestCase):
+    def test_no_music_returns_voice(self):
+        with patch.object(mixer, "pick_music", return_value=None):
+            self.assertEqual(
+                mix_background_music("voice.mp3", "out.mp3"), "voice.mp3"
+            )
+
+    def test_ffmpeg_failure_returns_voice(self):
+        tmp = tempfile.mkdtemp()
+        track = os.path.join(tmp, "m.mp3")
+        open(track, "w").close()
+        with patch.object(mixer, "_run_ffmpeg", return_value=None):
+            out = mix_background_music("voice.mp3", "out.mp3", music_path=track)
+        self.assertEqual(out, "voice.mp3")
+
+    def test_success_returns_output(self):
+        tmp = tempfile.mkdtemp()
+        track = os.path.join(tmp, "m.mp3")
+        open(track, "w").close()
+        with patch.object(mixer, "_run_ffmpeg", return_value="out.mp3"):
+            out = mix_background_music("voice.mp3", "out.mp3", music_path=track)
+        self.assertEqual(out, "out.mp3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_config_flags.py
+++ b/content-pipeline/tests/test_config_flags.py
@@ -1,0 +1,83 @@
+"""Tests for the video engine feature flags in config (Phase 0 / V0.3)."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import config
+
+
+class TestFlagDefaults(unittest.TestCase):
+    """With no env overrides, flags must equal the legacy behaviour."""
+
+    def setUp(self):
+        # Reload config with a clean env so defaults are deterministic.
+        self._saved = {}
+        for key in ("SUBTITLE_TIMING_MODE", "BACKGROUND_MODE", "TTS_PROVIDER",
+                    "COMPOSER_ENGINE", "ENABLE_BGM", "TTS_ALLOW_INSECURE_SSL"):
+            self._saved[key] = os.environ.pop(key, None)
+        importlib.reload(config)
+
+    def tearDown(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        importlib.reload(config)
+
+    def test_subtitle_timing_default_is_wordcount(self):
+        self.assertEqual(config.SUBTITLE_TIMING_MODE, "wordcount")
+
+    def test_background_default_is_single(self):
+        self.assertEqual(config.BACKGROUND_MODE, "single")
+
+    def test_tts_provider_default_is_nuitruc(self):
+        self.assertEqual(config.TTS_PROVIDER, "nuitruc")
+
+    def test_composer_engine_default_is_ffmpeg(self):
+        self.assertEqual(config.COMPOSER_ENGINE, "ffmpeg")
+
+    def test_bgm_default_off(self):
+        self.assertFalse(config.ENABLE_BGM)
+
+    def test_insecure_ssl_default_off(self):
+        self.assertFalse(config.TTS_ALLOW_INSECURE_SSL)
+
+
+class TestValidateFlags(unittest.TestCase):
+    def test_valid_flags_no_issues(self):
+        # Defaults are valid -> empty issue list.
+        importlib.reload(config)
+        self.assertEqual(config.validate_flags(), [])
+
+    def test_invalid_flag_reported(self):
+        importlib.reload(config)
+        original = config.SUBTITLE_TIMING_MODE
+        try:
+            config.SUBTITLE_TIMING_MODE = "bogus"
+            issues = config.validate_flags()
+            self.assertTrue(any("SUBTITLE_TIMING_MODE" in i for i in issues))
+        finally:
+            config.SUBTITLE_TIMING_MODE = original
+
+    def test_logger_warning_called(self):
+        importlib.reload(config)
+        import logging
+        from unittest.mock import MagicMock
+        original = config.COMPOSER_ENGINE
+        try:
+            config.COMPOSER_ENGINE = "nope"
+            mock_logger = MagicMock(spec=logging.Logger)
+            config.validate_flags(mock_logger)
+            mock_logger.warning.assert_called()
+        finally:
+            config.COMPOSER_ENGINE = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_pexels_downloader.py
+++ b/content-pipeline/tests/test_pexels_downloader.py
@@ -20,6 +20,7 @@ from video.pexels_downloader import (
     _find_best_file,
     _select_best_background,
     _any_cached,
+    get_backgrounds,
 )
 
 
@@ -135,6 +136,40 @@ class TestAnyCached(unittest.TestCase):
         with patch.object(pex, "CACHE_DIR", tmp):
             result = _any_cached("landscape", audio_duration=0)
         self.assertTrue(result.endswith("a_landscape_111.mp4"))
+
+
+class TestGetBackgrounds(unittest.TestCase):
+    """Multi-clip gathering (P1 / V1.2)."""
+
+    def test_count_one_delegates_to_single(self):
+        with patch.object(pex, "get_background", return_value="single.mp4") as m:
+            result = get_backgrounds(orientation="landscape", count=1)
+        self.assertEqual(result, ["single.mp4"])
+        m.assert_called_once()
+
+    def test_count_one_empty_when_no_single(self):
+        with patch.object(pex, "get_background", return_value=None):
+            self.assertEqual(get_backgrounds(count=1), [])
+
+    def test_collects_cached_clips_up_to_count(self):
+        tmp = tempfile.mkdtemp()
+        # Pre-create cache files for two generic queries.
+        from video.pexels_downloader import SEARCH_QUERIES
+        paths = [pex._cached_path(q, "landscape") for q in SEARCH_QUERIES[:3]]
+        with patch.object(pex, "CACHE_DIR", tmp):
+            # _cached_path uses CACHE_DIR at call time
+            paths = [pex._cached_path(q, "landscape") for q in SEARCH_QUERIES[:3]]
+            for p in paths:
+                open(p, "w").close()
+            result = get_backgrounds(orientation="landscape", count=2)
+        self.assertEqual(len(result), 2)
+
+    def test_no_cache_no_apikey_returns_empty_or_fallback(self):
+        tmp = tempfile.mkdtemp()
+        with patch.object(pex, "CACHE_DIR", tmp), \
+             patch.object(pex.config, "PEXELS_API_KEY", ""):
+            result = get_backgrounds(orientation="landscape", count=3)
+        self.assertEqual(result, [])
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_subtitle_aligner.py
+++ b/content-pipeline/tests/test_subtitle_aligner.py
@@ -1,0 +1,88 @@
+"""Tests for video.subtitle_aligner (Phase 1 / V1.1 Whisper alignment).
+
+The Whisper model itself is never loaded here; we test the pure mapping logic
+and the graceful-fallback contract (missing lib / no words -> None).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.subtitle_aligner as aligner
+from video.subtitle_aligner import _map_segments_to_words, align
+
+
+class TestMapSegmentsToWords(unittest.TestCase):
+    def test_uses_word_timing_for_segments(self):
+        segments = ["xin chào", "các bạn nhé"]
+        words = [
+            ("xin", 0.0, 0.4), ("chào", 0.4, 1.0),
+            ("các", 1.2, 1.5), ("bạn", 1.5, 1.9), ("nhé", 1.9, 2.4),
+        ]
+        out = _map_segments_to_words(segments, words)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0], (0.0, 1.0, "xin chào"))
+        self.assertEqual(out[1][0], 1.2)
+        self.assertAlmostEqual(out[1][1], 2.4)
+        self.assertEqual(out[1][2], "các bạn nhé")
+
+    def test_keeps_script_text_not_transcript(self):
+        # Whisper word text differs from script; output must use script text.
+        segments = ["Doanh thu 100 tỷ"]
+        words = [("doanh", 0.0, 0.3), ("thu", 0.3, 0.6),
+                 ("một", 0.6, 0.8), ("trăm", 0.8, 1.1)]
+        out = _map_segments_to_words(segments, words)
+        self.assertEqual(out[0][2], "Doanh thu 100 tỷ")  # original, with "100"
+
+    def test_non_overlapping_monotonic(self):
+        segments = ["a b", "c d"]
+        words = [("a", 0.0, 1.0), ("b", 0.5, 2.0), ("c", 1.0, 1.2), ("d", 1.2, 3.0)]
+        out = _map_segments_to_words(segments, words)
+        for i in range(1, len(out)):
+            self.assertGreaterEqual(out[i][0], out[i - 1][1])
+        for start, end, _ in out:
+            self.assertLessEqual(start, end)
+
+    def test_stops_when_words_exhausted(self):
+        segments = ["a", "b", "c"]
+        words = [("a", 0.0, 0.5)]
+        out = _map_segments_to_words(segments, words)
+        self.assertEqual(len(out), 1)
+
+
+class TestAlignFallback(unittest.TestCase):
+    def test_missing_audio_returns_none(self):
+        self.assertIsNone(align("/no/such/audio.mp3", "xin chào"))
+
+    def test_no_words_returns_none(self):
+        with patch("os.path.exists", return_value=True), \
+             patch.object(aligner, "_transcribe", return_value=None):
+            self.assertIsNone(align("a.mp3", "xin chào các bạn"))
+
+    def test_empty_script_returns_none(self):
+        with patch("os.path.exists", return_value=True):
+            self.assertIsNone(align("a.mp3", "   "))
+
+    def test_success_path_builds_entries(self):
+        words = [("xin", 0.0, 0.5), ("chào", 0.5, 1.0)]
+        with patch("os.path.exists", return_value=True), \
+             patch.object(aligner, "_transcribe", return_value=words):
+            out = align("a.mp3", "xin chào")
+        self.assertEqual(out, [(0.0, 1.0, "xin chào")])
+
+
+class TestTranscribeImportGuard(unittest.TestCase):
+    def test_missing_faster_whisper_returns_none(self):
+        # Simulate the library being absent -> _get_model returns None.
+        with patch.dict(sys.modules, {"faster_whisper": None}):
+            aligner._MODEL = None
+            aligner._MODEL_SIZE = None
+            self.assertIsNone(aligner._get_model("base"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_subtitle_aligner.py
+++ b/content-pipeline/tests/test_subtitle_aligner.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import video.subtitle_aligner as aligner
-from video.subtitle_aligner import _map_segments_to_words, align
+from video.subtitle_aligner import (
+    _map_segments_to_words, _spoken_word_count, align,
+)
 
 
 class TestMapSegmentsToWords(unittest.TestCase):
@@ -53,6 +55,24 @@ class TestMapSegmentsToWords(unittest.TestCase):
         out = _map_segments_to_words(segments, words)
         self.assertEqual(len(out), 1)
 
+    def test_respects_explicit_counts(self):
+        # First segment should consume 3 spoken words, second consumes 1.
+        segments = ["50%", "rồi"]
+        words = [("năm", 0.0, 0.3), ("mươi", 0.3, 0.6),
+                 ("phần_trăm", 0.6, 1.0), ("rồi", 1.0, 1.4)]
+        out = _map_segments_to_words(segments, words, counts=[3, 1])
+        self.assertEqual(out[0], (0.0, 1.0, "50%"))
+        self.assertEqual(out[1], (1.0, 1.4, "rồi"))
+
+
+class TestSpokenWordCount(unittest.TestCase):
+    def test_expands_numbers(self):
+        # "50%" is one display token but several spoken Vietnamese words.
+        self.assertGreater(_spoken_word_count("50%"), 1)
+
+    def test_plain_words_unchanged(self):
+        self.assertEqual(_spoken_word_count("xin chào các bạn"), 4)
+
 
 class TestAlignFallback(unittest.TestCase):
     def test_missing_audio_returns_none(self):
@@ -73,6 +93,16 @@ class TestAlignFallback(unittest.TestCase):
              patch.object(aligner, "_transcribe", return_value=words):
             out = align("a.mp3", "xin chào")
         self.assertEqual(out, [(0.0, 1.0, "xin chào")])
+
+    def test_partial_mapping_falls_back_to_none(self):
+        # Two sentences need timing but Whisper only emits one word -> the
+        # mapping covers a prefix; align() must return None so the caller uses
+        # full-coverage word-count timing instead of subtitles that stop early.
+        words = [("xin", 0.0, 0.5)]
+        with patch("os.path.exists", return_value=True), \
+             patch.object(aligner, "_transcribe", return_value=words):
+            out = align("a.mp3", "Xin chào. Tạm biệt nhé.")
+        self.assertIsNone(out)
 
 
 class TestTranscribeImportGuard(unittest.TestCase):

--- a/content-pipeline/tests/test_subtitle_generator.py
+++ b/content-pipeline/tests/test_subtitle_generator.py
@@ -14,6 +14,8 @@ from video.subtitle_generator import (
     _split_into_segments,
     _format_time,
     WORDS_PER_SEGMENT,
+    build_wordcount_entries,
+    write_entries_srt,
 )
 
 
@@ -161,6 +163,46 @@ class TestGenerateSrt(unittest.TestCase):
 
         # First displayed segment ("Chào.") should be shorter than the last.
         self.assertLess(dur(times[0]), dur(times[-1]))
+
+
+class TestBuildWordcountEntries(unittest.TestCase):
+    def test_returns_tuples_covering_duration(self):
+        entries = build_wordcount_entries("Câu một. Câu hai dài hơn.", 12.0)
+        self.assertTrue(entries)
+        self.assertAlmostEqual(entries[-1][1], 12.0, delta=0.05)
+        self.assertEqual(entries[0][0], 0.0)
+
+    def test_empty_text_returns_empty_list(self):
+        self.assertEqual(build_wordcount_entries("   ", 10.0), [])
+
+
+class TestWriteEntriesSrt(unittest.TestCase):
+    """Shared SRT writer used by both word-count and Whisper paths (P1)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_writes_provided_entries(self):
+        out = os.path.join(self.tmp, "w.srt")
+        entries = [(0.0, 1.5, "Xin chào"), (1.5, 3.0, "Tạm biệt")]
+        self.assertEqual(write_entries_srt(entries, out), out)
+        with open(out, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("Xin chào", content)
+        self.assertIn("00:00:01,500 --> 00:00:03,000", content)
+
+    def test_empty_entries_returns_none(self):
+        out = os.path.join(self.tmp, "empty.srt")
+        self.assertIsNone(write_entries_srt([], out))
+
+    def test_roundtrip_with_parser(self):
+        from video.video_composer import _parse_srt
+        out = os.path.join(self.tmp, "rt.srt")
+        entries = [(0.0, 2.0, "một"), (2.0, 4.0, "hai")]
+        write_entries_srt(entries, out)
+        parsed = _parse_srt(out)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[1][2], "hai")
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_tts_client.py
+++ b/content-pipeline/tests/test_tts_client.py
@@ -1,0 +1,80 @@
+"""Tests for video.tts_client SSL hardening (Phase 0 / V0.1).
+
+These tests inspect the SSL context the opener is built with; they do not make
+any network calls.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.tts_client as tts
+
+
+def _extract_ssl_context(opener):
+    """Pull the SSLContext out of an opener's HTTPSHandler."""
+    for handler in opener.handlers:
+        ctx = getattr(handler, "_context", None)
+        if isinstance(ctx, ssl.SSLContext):
+            return ctx
+    raise AssertionError("no HTTPSHandler with an SSL context found")
+
+
+class TestSecureByDefault(unittest.TestCase):
+    def test_default_verifies_certificate(self):
+        ctx = _extract_ssl_context(tts._build_opener(insecure=False))
+        self.assertTrue(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    def test_reads_config_flag_when_not_overridden(self):
+        # Default config flag is False -> verifying context.
+        with patch.object(tts.config, "TTS_ALLOW_INSECURE_SSL", False):
+            ctx = _extract_ssl_context(tts._build_opener())
+        self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+
+class TestInsecureOptIn(unittest.TestCase):
+    def test_insecure_disables_verification(self):
+        ctx = _extract_ssl_context(tts._build_opener(insecure=True))
+        self.assertFalse(ctx.check_hostname)
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+
+    def test_insecure_logs_warning(self):
+        with self.assertLogs(tts.logger, level="WARNING") as cm:
+            tts._build_opener(insecure=True)
+        self.assertTrue(any("DISABLED" in m for m in cm.output))
+
+    def test_config_flag_enables_insecure(self):
+        with patch.object(tts.config, "TTS_ALLOW_INSECURE_SSL", True):
+            ctx = _extract_ssl_context(tts._build_opener())
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+
+
+class TestNoSecretLogging(unittest.TestCase):
+    def test_token_not_logged_on_failure(self):
+        """A failed TTS call must not leak the Authorization token into logs."""
+        with patch.object(tts.config, "TTS_API_URL", "https://tts.example/api"), \
+             patch.object(tts.config, "TTS_API_KEY", "super-secret-token"), \
+             patch.object(tts.config, "TTS_VOICE_ID", "voice1"), \
+             patch.object(tts.config, "TTS_VOICE_SPEED", 1.0), \
+             patch.object(tts.config, "TTS_ALLOW_INSECURE_SSL", False), \
+             patch.object(tts, "TTS_MAX_RETRIES", 1):
+            # Force the opener to fail fast.
+            with patch.object(tts, "_build_opener") as mock_opener:
+                mock_opener.return_value.open.side_effect = OSError("boom")
+                with self.assertLogs(tts.logger, level="INFO") as cm:
+                    result = tts._tts_single("xin chào", "/tmp/_tts_test_out.mp3")
+        self.assertIsNone(result)
+        joined = "\n".join(cm.output)
+        self.assertNotIn("super-secret-token", joined)
+        self.assertNotIn("Bearer super-secret-token", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_video_composer.py
+++ b/content-pipeline/tests/test_video_composer.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -248,6 +249,33 @@ class TestBuildMultiBgCommand(unittest.TestCase):
                                      1920, 1080, 30.0, 6)
         self.assertIn("-t", cmd)
         self.assertEqual(cmd[cmd.index("-t") + 1], "30.0")
+
+
+class TestCombineBackgrounds(unittest.TestCase):
+    """The combined multi-bg track must live inside the provided tempdir so it
+    is cleaned up with the compose run (no /tmp accumulation)."""
+
+    def test_writes_into_given_tmpdir(self):
+        from video import video_composer as vc
+        tmp = tempfile.mkdtemp()
+        captured = {}
+
+        def fake_run(cmd, out):
+            captured["out"] = out
+            return out
+
+        with patch.object(vc, "_run_ffmpeg", side_effect=fake_run):
+            result = vc._combine_backgrounds(["a.mp4", "b.mp4"], 1920, 1080,
+                                             30.0, 6, tmp)
+        self.assertEqual(os.path.dirname(captured["out"]), tmp)
+        self.assertEqual(result, captured["out"])
+
+    def test_zero_duration_returns_none(self):
+        from video import video_composer as vc
+        tmp = tempfile.mkdtemp()
+        self.assertIsNone(
+            vc._combine_backgrounds(["a.mp4", "b.mp4"], 1920, 1080, 0, 6, tmp)
+        )
 
 
 @unittest.skipUnless(_HAS_PIL, "Pillow not installed")

--- a/content-pipeline/tests/test_video_composer.py
+++ b/content-pipeline/tests/test_video_composer.py
@@ -13,7 +13,13 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from video.video_composer import _parse_srt, _srt_time_to_sec
+from video.video_composer import (
+    _parse_srt,
+    _srt_time_to_sec,
+    build_compose_command,
+    build_subtitle_concat,
+    _build_subtitle_track_cmd,
+)
 
 try:
     from PIL import ImageFont  # noqa: F401
@@ -101,6 +107,108 @@ class TestParseSrt(unittest.TestCase):
         entries = _parse_srt(out)
         self.assertTrue(entries)
         self.assertAlmostEqual(entries[-1][1], 12.0, delta=0.1)
+
+
+class TestBuildComposeCommand(unittest.TestCase):
+    """The O(1) compose command: input count must not depend on subtitle count."""
+
+    def _count_inputs(self, cmd):
+        return sum(1 for i, a in enumerate(cmd) if a == "-i")
+
+    def test_no_subtitle_has_two_inputs(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1920, 1080, 30.0)
+        self.assertEqual(self._count_inputs(cmd), 2)
+        self.assertIn("-vf", cmd)
+
+    def test_with_subtitle_has_three_inputs(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1920, 1080, 30.0, subtitle_track="subs.mov")
+        self.assertEqual(self._count_inputs(cmd), 3)
+        self.assertIn("-filter_complex", cmd)
+        self.assertIn("subs.mov", cmd)
+
+    def test_input_count_independent_of_subtitle_count(self):
+        # The whole point of the O(N)->O(1) refactor: a single subtitle track,
+        # so the command shape is identical for 5 or 500 subtitle lines.
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1080, 1920, 90.0, subtitle_track="subs.mov")
+        self.assertEqual(self._count_inputs(cmd), 3)
+
+    def test_has_expected_codecs_and_output_last(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1920, 1080, 12.0)
+        self.assertIn("libx264", cmd)
+        self.assertIn("aac", cmd)
+        self.assertEqual(cmd[-1], "out.mp4")
+
+    def test_scale_pad_uses_target_dimensions(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1080, 1920, 12.0)
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertIn("scale=1080:1920", vf)
+        self.assertIn("pad=1080:1920", vf)
+
+
+class TestBuildSubtitleConcat(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.blank = os.path.join(self.tmp, "blank.png")
+        self.concat = os.path.join(self.tmp, "subs.concat")
+
+    def _durations(self, content):
+        return [float(l.split()[1]) for l in content.splitlines()
+                if l.startswith("duration")]
+
+    def test_header_and_file_written(self):
+        entries = [(0.0, 2.0, "a"), (2.0, 4.0, "b")]
+        pngs = ["s0.png", "s1.png"]
+        build_subtitle_concat(entries, pngs, self.blank, 4.0, self.concat)
+        with open(self.concat) as f:
+            content = f.read()
+        self.assertTrue(content.startswith("ffconcat version 1.0"))
+        self.assertIn("s0.png", content)
+        self.assertIn("s1.png", content)
+
+    def test_durations_cover_audio_length(self):
+        entries = [(0.0, 2.0, "a"), (2.0, 4.0, "b")]
+        pngs = ["s0.png", "s1.png"]
+        build_subtitle_concat(entries, pngs, self.blank, 4.0, self.concat)
+        with open(self.concat) as f:
+            total = sum(self._durations(f.read()))
+        self.assertAlmostEqual(total, 4.0, delta=0.05)
+
+    def test_leading_gap_filled_with_blank(self):
+        # First subtitle starts at 2.0s -> a 2.0s blank should precede it.
+        entries = [(2.0, 4.0, "a")]
+        pngs = ["s0.png"]
+        build_subtitle_concat(entries, pngs, self.blank, 4.0, self.concat)
+        with open(self.concat) as f:
+            content = f.read()
+        # blank appears before the subtitle png
+        self.assertLess(content.index("blank.png"), content.index("s0.png"))
+
+    def test_trailing_blank_when_audio_longer(self):
+        entries = [(0.0, 2.0, "a")]
+        pngs = ["s0.png"]
+        build_subtitle_concat(entries, pngs, self.blank, 5.0, self.concat)
+        with open(self.concat) as f:
+            total = sum(self._durations(f.read()))
+        self.assertAlmostEqual(total, 5.0, delta=0.05)
+
+
+class TestBuildSubtitleTrackCmd(unittest.TestCase):
+    def test_uses_concat_demuxer_and_alpha_codec(self):
+        cmd = _build_subtitle_track_cmd("subs.concat", "track.mov", fps=30)
+        self.assertIn("concat", cmd)
+        self.assertIn("qtrle", cmd)       # alpha-capable lossless codec
+        self.assertIn("subs.concat", cmd)
+        self.assertEqual(cmd[-1], "track.mov")
+
+    def test_fps_is_parameterised(self):
+        cmd = _build_subtitle_track_cmd("subs.concat", "track.mov", fps=24)
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertIn("fps=24", vf)
 
 
 @unittest.skipUnless(_HAS_PIL, "Pillow not installed")

--- a/content-pipeline/tests/test_video_composer.py
+++ b/content-pipeline/tests/test_video_composer.py
@@ -19,6 +19,7 @@ from video.video_composer import (
     build_compose_command,
     build_subtitle_concat,
     _build_subtitle_track_cmd,
+    build_multi_bg_command,
 )
 
 try:
@@ -209,6 +210,44 @@ class TestBuildSubtitleTrackCmd(unittest.TestCase):
         cmd = _build_subtitle_track_cmd("subs.concat", "track.mov", fps=24)
         vf = cmd[cmd.index("-vf") + 1]
         self.assertIn("fps=24", vf)
+
+
+class TestBuildMultiBgCommand(unittest.TestCase):
+    """Multi-clip background: input count == distinct clips, not duration."""
+
+    def _count_inputs(self, cmd):
+        return sum(1 for a in cmd if a == "-i")
+
+    def test_input_count_equals_clip_count(self):
+        clips = ["a.mp4", "b.mp4", "c.mp4"]
+        cmd = build_multi_bg_command(clips, "out.mp4", 1920, 1080,
+                                     total_duration=60.0, clip_seconds=6)
+        self.assertEqual(self._count_inputs(cmd), 3)
+
+    def test_segments_cover_duration(self):
+        # 60s / 6s = 10 segments cycled across the clips.
+        clips = ["a.mp4", "b.mp4"]
+        cmd = build_multi_bg_command(clips, "out.mp4", 1920, 1080,
+                                     total_duration=60.0, clip_seconds=6)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=10", fc)
+
+    def test_ceil_division_for_partial_segment(self):
+        clips = ["a.mp4"]
+        cmd = build_multi_bg_command(clips, "out.mp4", 1080, 1920,
+                                     total_duration=20.0, clip_seconds=6)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=4", fc)  # ceil(20/6) == 4
+
+    def test_clips_are_looped(self):
+        cmd = build_multi_bg_command(["a.mp4"], "out.mp4", 1920, 1080, 12.0, 6)
+        self.assertIn("-stream_loop", cmd)
+
+    def test_duration_caps_output(self):
+        cmd = build_multi_bg_command(["a.mp4", "b.mp4"], "out.mp4",
+                                     1920, 1080, 30.0, 6)
+        self.assertIn("-t", cmd)
+        self.assertEqual(cmd[cmd.index("-t") + 1], "30.0")
 
 
 @unittest.skipUnless(_HAS_PIL, "Pillow not installed")

--- a/content-pipeline/video/assets/music/CREDITS.md
+++ b/content-pipeline/video/assets/music/CREDITS.md
@@ -1,0 +1,11 @@
+# Background Music Credits
+
+Chỉ dùng nhạc **royalty-free / Creative Commons** cho nền video. Mỗi track liệt
+kê tại đây kèm nguồn + giấy phép trước khi commit/sử dụng.
+
+| File | Nguồn | Giấy phép | Ghi chú |
+|------|-------|-----------|---------|
+| _(chưa có track nào)_ | | | Thêm file `.mp3` vào thư mục này rồi điền dòng tương ứng |
+
+> Gợi ý nguồn: YouTube Audio Library, Pixabay Music, Free Music Archive (CC0/CC-BY).
+> Bật bằng `ENABLE_BGM=1`. Âm lượng nhạc điều chỉnh qua `BGM_VOLUME_DB`.

--- a/content-pipeline/video/audio_mixer.py
+++ b/content-pipeline/video/audio_mixer.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""
+Audio Mixer — Trộn nhạc nền (BGM) dưới giọng đọc với ducking (P1).
+
+Giọng đọc luôn là chủ đạo: nhạc nền bị hạ âm lượng (BGM_VOLUME_DB) và tự giảm
+thêm khi có giọng (sidechain compress / "ducking"). Nhạc được loop để phủ hết
+độ dài giọng và cắt theo giọng (-shortest).
+
+Chỉ chạy khi config.ENABLE_BGM=1. Thiếu nhạc / lỗi → trả lại audio giọng gốc,
+không làm pipeline chết.
+"""
+
+import logging
+import os
+import random
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from video.video_composer import _run_ffmpeg
+
+logger = logging.getLogger(__name__)
+
+_MUSIC_EXTS = (".mp3", ".m4a", ".aac", ".wav", ".ogg")
+
+
+def pick_music(music_dir: str | None = None) -> str | None:
+    """Return a random royalty-free music file from the music dir, or None."""
+    music_dir = music_dir or getattr(config, "MUSIC_DIR", "")
+    if not music_dir or not os.path.isdir(music_dir):
+        return None
+    tracks = [
+        os.path.join(music_dir, f)
+        for f in sorted(os.listdir(music_dir))
+        if f.lower().endswith(_MUSIC_EXTS)
+    ]
+    if not tracks:
+        return None
+    return random.choice(tracks)
+
+
+def build_mix_command(voice_path: str, music_path: str, output_path: str,
+                      music_db: float = -18.0) -> list[str]:
+    """Build the ffmpeg command that mixes music under voice with ducking (pure).
+
+    - voice = input 0 (control / sidechain key), music = input 1.
+    - Music is looped (-stream_loop) and attenuated by ``music_db`` dB, then
+      sidechain-compressed by the voice so it dips when narration is present.
+    - Output length follows the voice (-shortest).
+    """
+    return [
+        "ffmpeg", "-y",
+        "-i", voice_path,
+        "-stream_loop", "-1", "-i", music_path,
+        "-filter_complex",
+        (
+            f"[1:a]volume={music_db}dB[bg];"
+            "[bg][0:a]sidechaincompress=threshold=0.03:ratio=8:attack=5:release=300[ducked];"
+            "[0:a][ducked]amix=inputs=2:duration=first:dropout_transition=0[a]"
+        ),
+        "-map", "[a]",
+        "-c:a", "aac", "-b:a", "192k",
+        "-shortest",
+        output_path,
+    ]
+
+
+def mix_background_music(voice_path: str, output_path: str,
+                         music_path: str | None = None,
+                         music_db: float | None = None) -> str:
+    """Mix BGM under the narration. Returns the mixed path, or voice on failure.
+
+    Always returns a usable audio path so callers can use it unconditionally.
+    """
+    if music_path is None:
+        music_path = pick_music()
+    if not music_path or not os.path.exists(music_path):
+        logger.info("No background music available — using narration only")
+        return voice_path
+    if music_db is None:
+        music_db = getattr(config, "BGM_VOLUME_DB", -18.0)
+
+    cmd = build_mix_command(voice_path, music_path, output_path, music_db)
+    result = _run_ffmpeg(cmd, output_path)
+    if result is None:
+        logger.warning("BGM mix failed — using narration only")
+        return voice_path
+    logger.info("Mixed BGM '%s' under narration", os.path.basename(music_path))
+    return output_path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print(f"Music dir: {config.MUSIC_DIR}")
+    print(f"Picked: {pick_music()}")

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -179,6 +179,55 @@ def get_background(keywords: list[str] | None = None,
     return None
 
 
+def get_backgrounds(keywords: list[str] | None = None,
+                    orientation: str = "landscape",
+                    audio_duration: float = 0.0,
+                    count: int = 1) -> list[str]:
+    """Return up to *count* distinct background clips (multi-clip mode, P1).
+
+    Reuses the cache + download + fallback logic of get_background. For count<=1
+    this is equivalent to a single-element get_background result.
+
+    Returns a (possibly empty) list of distinct file paths.
+    """
+    if count <= 1:
+        single = get_background(keywords, orientation, audio_duration)
+        return [single] if single else []
+
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    queries = list(keywords or []) + SEARCH_QUERIES
+    collected: list[str] = []
+
+    # Pass 1: cached clips for this orientation.
+    for query in queries:
+        cached = _cached_path(query, orientation)
+        if os.path.exists(cached) and cached not in collected:
+            collected.append(cached)
+        if len(collected) >= count:
+            return collected[:count]
+
+    # Pass 2: download more until we reach count.
+    if config.PEXELS_API_KEY:
+        for query in queries:
+            if len(collected) >= count:
+                break
+            path = _search_and_download(query, orientation)
+            if path is None and _last_pexels_error == "auth":
+                logger.error("Pexels API key invalid — stopping multi-bg download")
+                break
+            if path and path not in collected:
+                collected.append(path)
+
+    # Pass 3: fall back to any single cached clip so we never return empty
+    # when something usable exists.
+    if not collected:
+        fallback = _any_cached(orientation, audio_duration)
+        if fallback:
+            collected.append(fallback)
+
+    return collected[:count]
+
+
 def download_font(force: bool = False) -> bool:
     """Download NotoSans-Bold.ttf from Google Fonts if not already present.
 

--- a/content-pipeline/video/subtitle_aligner.py
+++ b/content-pipeline/video/subtitle_aligner.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+"""
+Subtitle Aligner — Căn timing phụ đề theo audio bằng faster-whisper (P1).
+
+Khác với subtitle_generator (chia timing theo tỉ lệ số từ, có thể trôi), module
+này lấy **timing thực tế** từ Whisper word-timestamps, nhưng GIỮ NGUYÊN text
+script gốc (không dùng transcript của Whisper) để bảo toàn:
+  - Chính tả tiếng Việt (Whisper có thể nghe sai)
+  - Cách hiển thị số/ký hiệu trong script
+
+Cơ chế: forced-alignment đơn giản — chia script thành cùng các segment như
+subtitle_generator, rồi gán cho mỗi segment khoảng thời gian của đúng số từ
+tương ứng trong chuỗi word-timestamps của Whisper.
+
+faster-whisper là dependency tuỳ chọn. Thiếu thư viện / lỗi / timeout → trả None
+để caller fallback về word-count, pipeline không bao giờ chết.
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from video.subtitle_generator import _split_into_segments
+
+logger = logging.getLogger(__name__)
+
+# Cache the loaded model between videos (loading is the slow part).
+_MODEL = None
+_MODEL_SIZE = None
+
+
+def align(audio_path: str, script_text: str,
+          model_size: str | None = None) -> list[tuple[float, float, str]] | None:
+    """Return audio-aligned subtitle entries, or None to signal fallback.
+
+    Args:
+        audio_path: Narration audio to transcribe for timing.
+        script_text: Original script — its text is what gets displayed.
+        model_size: Override Whisper model size (default config.WHISPER_MODEL_SIZE).
+
+    Returns:
+        List of (start, end, text) using script text + Whisper timing, or None
+        if alignment is unavailable (missing lib, error, empty transcription).
+    """
+    if not os.path.exists(audio_path):
+        logger.error("Audio not found for alignment: %s", audio_path)
+        return None
+
+    segments = _split_into_segments(script_text)
+    if not segments:
+        return None
+
+    words = _transcribe(audio_path, model_size)
+    if not words:
+        logger.info("Whisper produced no word timings — falling back")
+        return None
+
+    entries = _map_segments_to_words(segments, words)
+    return entries or None
+
+
+def _map_segments_to_words(
+    segments: list[str],
+    words: list[tuple[str, float, float]],
+) -> list[tuple[float, float, str]]:
+    """Assign each script segment the time span of its word run (pure).
+
+    Walks the Whisper word list, consuming as many words as the segment has,
+    and uses the first word's start and last word's end as the segment timing.
+    Guarantees non-decreasing, non-overlapping, start<=end timing.
+    """
+    result: list[tuple[float, float, str]] = []
+    wi = 0
+    n = len(words)
+    prev_end = 0.0
+
+    for seg in segments:
+        if wi >= n:
+            break
+        count = max(1, len(seg.split()))
+        start = words[wi][1]
+        end_idx = min(wi + count, n) - 1
+        end = words[end_idx][2]
+
+        start = max(start, prev_end)
+        if end < start:
+            end = start
+        result.append((start, end, seg))
+        prev_end = end
+        wi = end_idx + 1
+
+    return result
+
+
+def _get_model(model_size: str):
+    """Load (and cache) a faster-whisper model. Returns None if unavailable."""
+    global _MODEL, _MODEL_SIZE
+    if _MODEL is not None and _MODEL_SIZE == model_size:
+        return _MODEL
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        logger.warning(
+            "faster-whisper not installed — Whisper subtitle alignment "
+            "unavailable. Install with: pip install faster-whisper"
+        )
+        return None
+    try:
+        # CPU + int8 keeps it light enough for a Mac Mini.
+        _MODEL = WhisperModel(model_size, device="cpu", compute_type="int8")
+        _MODEL_SIZE = model_size
+        return _MODEL
+    except Exception as e:
+        logger.error("Failed to load Whisper model %r: %s", model_size, e)
+        return None
+
+
+def _transcribe(audio_path: str,
+                model_size: str | None = None) -> list[tuple[str, float, float]] | None:
+    """Transcribe audio to a flat list of (word, start, end). None on failure."""
+    size = model_size or getattr(config, "WHISPER_MODEL_SIZE", "base")
+    model = _get_model(size)
+    if model is None:
+        return None
+    try:
+        seg_iter, _info = model.transcribe(
+            audio_path, language="vi", word_timestamps=True
+        )
+        words: list[tuple[str, float, float]] = []
+        for seg in seg_iter:
+            for w in (getattr(seg, "words", None) or []):
+                words.append((w.word.strip(), float(w.start), float(w.end)))
+        return words or None
+    except Exception as e:
+        logger.error("Whisper transcription failed: %s", e)
+        return None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print(f"Whisper model size: {getattr(config, 'WHISPER_MODEL_SIZE', 'base')}")
+    try:
+        import faster_whisper  # noqa: F401
+        print("faster-whisper: installed")
+    except ImportError:
+        print("faster-whisper: NOT installed (pipeline will fall back to word-count)")

--- a/content-pipeline/video/subtitle_aligner.py
+++ b/content-pipeline/video/subtitle_aligner.py
@@ -58,29 +58,60 @@ def align(audio_path: str, script_text: str,
         logger.info("Whisper produced no word timings — falling back")
         return None
 
-    entries = _map_segments_to_words(segments, words)
+    # The audio was synthesised from the TTS-normalized text (e.g. "50%" →
+    # "năm mươi phần trăm"), so Whisper emits the *expanded* words. Count words
+    # per segment from the normalized form to consume the right number of
+    # Whisper timestamps, while still displaying the original segment text.
+    spoken_counts = [_spoken_word_count(seg) for seg in segments]
+
+    entries = _map_segments_to_words(segments, words, spoken_counts)
+
+    # If Whisper produced fewer words than the script needs, only a prefix of
+    # the segments gets timed. Rather than ship subtitles that stop partway
+    # through the video, fall back to the full-coverage word-count path.
+    if len(entries) < len(segments):
+        logger.info(
+            "Whisper mapped only %d/%d segments — falling back to word-count",
+            len(entries), len(segments),
+        )
+        return None
+
     return entries or None
+
+
+def _spoken_word_count(segment: str) -> int:
+    """Number of spoken words a segment expands to after TTS normalization."""
+    try:
+        from video.text_preprocessor import preprocess_for_tts
+        spoken = preprocess_for_tts(segment)
+    except Exception:
+        spoken = segment
+    return max(1, len((spoken or segment).split()))
 
 
 def _map_segments_to_words(
     segments: list[str],
     words: list[tuple[str, float, float]],
+    counts: list[int] | None = None,
 ) -> list[tuple[float, float, str]]:
     """Assign each script segment the time span of its word run (pure).
 
-    Walks the Whisper word list, consuming as many words as the segment has,
-    and uses the first word's start and last word's end as the segment timing.
-    Guarantees non-decreasing, non-overlapping, start<=end timing.
+    Walks the Whisper word list, consuming ``counts[i]`` words for segment i
+    (defaulting to the segment's own word count), and uses the first word's
+    start and last word's end as the segment timing. Guarantees non-decreasing,
+    non-overlapping, start<=end timing. Stops early if the words run out, so the
+    caller can detect partial coverage.
     """
     result: list[tuple[float, float, str]] = []
     wi = 0
     n = len(words)
     prev_end = 0.0
 
-    for seg in segments:
+    for i, seg in enumerate(segments):
         if wi >= n:
             break
-        count = max(1, len(seg.split()))
+        count = counts[i] if counts is not None else max(1, len(seg.split()))
+        count = max(1, count)
         start = words[wi][1]
         end_idx = min(wi + count, n) - 1
         end = words[end_idx][2]

--- a/content-pipeline/video/subtitle_generator.py
+++ b/content-pipeline/video/subtitle_generator.py
@@ -39,35 +39,62 @@ def generate_srt(text: str, audio_duration: float, output_path: str) -> str | No
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-    segments = _split_into_segments(text)
-    if not segments:
+    entries = build_wordcount_entries(text, audio_duration)
+    if not entries:
         logger.error("No segments generated from text")
         return None
 
-    # Count total words for proportional timing
+    return write_entries_srt(entries, output_path)
+
+
+def build_wordcount_entries(text: str,
+                            audio_duration: float) -> list[tuple[float, float, str]]:
+    """Build subtitle entries with timing proportional to word count (legacy).
+
+    Pure function (no I/O) — returns a list of (start, end, text) tuples.
+    """
+    segments = _split_into_segments(text)
+    if not segments:
+        return []
+
     word_counts = [len(seg.split()) for seg in segments]
-    total_words = sum(word_counts)
+    total_words = sum(word_counts) or 1
 
-    srt_lines = []
+    entries: list[tuple[float, float, str]] = []
     current_time = 0.0
-
-    for i, (segment, wcount) in enumerate(zip(segments, word_counts), 1):
-        # Duration proportional to word count
+    for segment, wcount in zip(segments, word_counts):
         segment_duration = (wcount / total_words) * audio_duration
         start = current_time
         end = current_time + segment_duration
+        entries.append((start, end, segment))
+        current_time = end
+    return entries
 
+
+def write_entries_srt(entries: list[tuple[float, float, str]],
+                      output_path: str) -> str | None:
+    """Write pre-computed (start, end, text) entries to an SRT file.
+
+    Shared by the legacy word-count path and the Whisper-aligned path (P1) so
+    both produce identical SRT formatting.
+    """
+    if not entries:
+        logger.error("No subtitle entries to write")
+        return None
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    srt_lines = []
+    for i, (start, end, text) in enumerate(entries, 1):
         srt_lines.append(str(i))
         srt_lines.append(f"{_format_time(start)} --> {_format_time(end)}")
-        srt_lines.append(segment)
-        srt_lines.append("")  # blank line between entries
-
-        current_time = end
+        srt_lines.append(text)
+        srt_lines.append("")
 
     try:
         with open(output_path, "w", encoding="utf-8") as f:
             f.write("\n".join(srt_lines))
-        logger.info("SRT saved: %s (%d segments, %.1fs)", output_path, len(segments), audio_duration)
+        logger.info("SRT saved: %s (%d segments)", output_path, len(entries))
         return output_path
     except OSError as e:
         logger.error("Failed to write SRT: %s", e)

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -50,15 +50,33 @@ def text_to_speech(text: str, output_path: str) -> str | None:
     return _tts_single(text, output_path)
 
 
-def _build_opener_with_ssl() -> object:
-    """Build a urllib opener that uses a permissive SSL context for all HTTPS requests.
+def _build_opener(insecure: bool | None = None) -> object:
+    """Build a urllib opener for the TTS endpoint.
 
-    Using build_opener ensures the permissive context is also applied to any
-    HTTP→HTTPS redirects, not just the initial request.
+    Secure by default: verifies the server certificate against the system CA
+    store (and any HTTP→HTTPS redirect inherits the same context, which urllib
+    does not do for the global default context).
+
+    TLS verification is disabled ONLY when explicitly opted in via
+    ``config.TTS_ALLOW_INSECURE_SSL`` (env ``TTS_ALLOW_INSECURE_SSL=1``). This
+    exists for a known self-signed endpoint; it is a MITM risk, so it logs a
+    warning whenever active.
+
+    Args:
+        insecure: Override the config flag (used in tests). When None, reads
+            ``config.TTS_ALLOW_INSECURE_SSL``.
     """
-    ssl_ctx = ssl.create_default_context()
-    ssl_ctx.check_hostname = False
-    ssl_ctx.verify_mode = ssl.CERT_NONE
+    if insecure is None:
+        insecure = getattr(config, "TTS_ALLOW_INSECURE_SSL", False)
+
+    ssl_ctx = ssl.create_default_context()  # verify ON, check_hostname ON
+    if insecure:
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+        logger.warning(
+            "TTS SSL verification DISABLED (TTS_ALLOW_INSECURE_SSL=1) — "
+            "connection is vulnerable to MITM. Use only for a trusted endpoint."
+        )
     return build_opener(HTTPSHandler(context=ssl_ctx))
 
 
@@ -88,9 +106,10 @@ def _tts_single(text: str, output_path: str) -> str | None:
 
     url = config.TTS_API_URL
 
-    # Build opener with permissive SSL context so it also applies to HTTP→HTTPS
-    # redirects (urllib doesn't reuse a custom ssl context across redirects by default).
-    opener = _build_opener_with_ssl()
+    # Build opener with a verifying SSL context (secure by default) that also
+    # applies to HTTP→HTTPS redirects. Verification is only disabled when
+    # TTS_ALLOW_INSECURE_SSL is explicitly set.
+    opener = _build_opener()
 
     last_exc: Exception | None = None
     for attempt in range(1, TTS_MAX_RETRIES + 1):

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -91,9 +91,9 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
             return _compose_without_subtitles(bg_video, audio_path, output_path,
                                               width, height, audio_duration)
 
-        return _compose_with_overlay(bg_video, audio_path, output_path,
-                                     width, height, audio_duration,
-                                     subtitle_entries, sub_pngs)
+        return _compose_with_subtitles(bg_video, audio_path, output_path,
+                                       width, height, audio_duration,
+                                       subtitle_entries, sub_pngs, tmpdir)
 
 
 # ---------------------------------------------------------------------------
@@ -120,76 +120,157 @@ def _generate_solid_background(output_path: str, width: int, height: int,
         return None
 
 
-def _compose_without_subtitles(bg_video: str, audio_path: str, output_path: str,
-                                width: int, height: int, audio_duration: float) -> str | None:
-    """Compose video without subtitle overlay."""
-    cmd = [
-        "ffmpeg", "-y",
-        "-stream_loop", "-1",
-        "-i", bg_video,
-        "-i", audio_path,
+def build_compose_command(bg_video: str, audio_path: str, output_path: str,
+                          width: int, height: int, audio_duration: float,
+                          subtitle_track: str | None = None) -> list[str]:
+    """Build the final ffmpeg compose command (pure — no I/O, unit-testable).
+
+    The number of ffmpeg inputs is CONSTANT regardless of how many subtitle
+    lines the video has: 2 (bg + audio) without subtitles, or 3 with a single
+    pre-rendered subtitle track. This is the O(1) replacement for the old
+    one-input-per-subtitle-line approach.
+
+    Args:
+        subtitle_track: Path to a single transparent subtitle video (e.g. the
+            qtrle .mov produced by the subtitle-track pass). None → no overlay.
+    """
+    scale_pad = (f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+                 f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:black")
+
+    cmd = ["ffmpeg", "-y", "-stream_loop", "-1", "-i", bg_video, "-i", audio_path]
+
+    if subtitle_track:
+        cmd += ["-i", subtitle_track]  # input 2: single subtitle track
+        cmd += [
+            "-filter_complex",
+            f"[0:v]{scale_pad}[base];[base][2:v]overlay=shortest=0[v]",
+            "-map", "[v]", "-map", "1:a",
+        ]
+    else:
+        cmd += ["-vf", scale_pad, "-map", "0:v", "-map", "1:a"]
+
+    cmd += [
         "-t", str(audio_duration),
-        "-vf", f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
-               f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:black",
-        "-map", "0:v",
-        "-map", "1:a",
         "-c:v", "libx264", "-preset", "medium", "-crf", "23",
         "-c:a", "aac", "-b:a", "128k",
         "-movflags", "+faststart",
         "-shortest",
         output_path,
     ]
+    return cmd
+
+
+def build_subtitle_concat(subtitle_entries: list[tuple[float, float, str]],
+                          png_paths: list[str], blank_png: str,
+                          audio_duration: float, concat_path: str) -> str:
+    """Write an ffconcat playlist describing the subtitle timeline.
+
+    Each subtitle PNG is shown for its window; gaps (and the head/tail) are
+    filled with a fully-transparent blank PNG. This lets a SINGLE ffmpeg
+    concat-demuxer pass build one transparent subtitle track — the image paths
+    live in the playlist file, not on the command line, so command length is
+    O(1) in the number of subtitles.
+
+    Returns the path written. Pure-ish (writes one text file; no ffmpeg).
+    """
+    lines = ["ffconcat version 1.0"]
+    cursor = 0.0
+    last_file = blank_png
+
+    for (start, end, _text), png in zip(subtitle_entries, png_paths):
+        if start > cursor + 1e-3:
+            lines.append(f"file '{blank_png}'")
+            lines.append(f"duration {start - cursor:.3f}")
+        dur = max(0.0, end - start)
+        lines.append(f"file '{png}'")
+        lines.append(f"duration {dur:.3f}")
+        last_file = png
+        cursor = end
+
+    if audio_duration > cursor + 1e-3:
+        lines.append(f"file '{blank_png}'")
+        lines.append(f"duration {audio_duration - cursor:.3f}")
+        last_file = blank_png
+
+    # concat-demuxer quirk: the final entry's duration is only honoured if the
+    # last file is listed once more after its duration directive.
+    lines.append(f"file '{last_file}'")
+
+    with open(concat_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    return concat_path
+
+
+def _build_subtitle_track_cmd(concat_path: str, out_path: str,
+                              fps: int = 30) -> list[str]:
+    """Build the ffmpeg command that renders the transparent subtitle track.
+
+    Uses qtrle (lossless, alpha-capable) so the overlay preserves transparency.
+    """
+    return [
+        "ffmpeg", "-y",
+        "-f", "concat", "-safe", "0", "-i", concat_path,
+        "-vf", f"fps={fps},format=rgba",
+        "-c:v", "qtrle",
+        out_path,
+    ]
+
+
+def _build_blank_png(width: int, height: int, tmpdir: str) -> str | None:
+    """Create a fully-transparent WxH PNG used to fill subtitle gaps."""
+    try:
+        from PIL import Image
+    except ImportError:
+        logger.error("Pillow not installed — cannot build blank subtitle frame")
+        return None
+    path = os.path.join(tmpdir, "blank.png")
+    Image.new("RGBA", (width, height), (0, 0, 0, 0)).save(path, "PNG")
+    return path
+
+
+def _compose_without_subtitles(bg_video: str, audio_path: str, output_path: str,
+                                width: int, height: int, audio_duration: float) -> str | None:
+    """Compose video without any subtitle overlay (2 ffmpeg inputs)."""
+    cmd = build_compose_command(bg_video, audio_path, output_path,
+                                width, height, audio_duration)
     return _run_ffmpeg(cmd, output_path)
 
 
-def _compose_with_overlay(bg_video: str, audio_path: str, output_path: str,
-                          width: int, height: int, audio_duration: float,
-                          subtitle_entries: list[tuple[float, float, str]],
-                          sub_pngs: list[str]) -> str | None:
-    """Compose video with Pillow-rendered subtitle PNGs overlaid via ffmpeg overlay filter."""
-    # Build ffmpeg inputs: bg video, audio, then one PNG per subtitle entry
-    cmd = [
-        "ffmpeg", "-y",
-        "-stream_loop", "-1", "-i", bg_video,   # input 0: background
-        "-i", audio_path,                         # input 1: audio
-    ]
-    for png_path in sub_pngs:
-        cmd += ["-loop", "1", "-i", png_path]     # inputs 2+N: subtitle PNGs
+def _compose_with_subtitles(bg_video: str, audio_path: str, output_path: str,
+                            width: int, height: int, audio_duration: float,
+                            subtitle_entries: list[tuple[float, float, str]],
+                            sub_pngs: list[str], tmpdir: str) -> str | None:
+    """Compose video by overlaying a single pre-built transparent subtitle track.
 
-    # Build filter_complex chain
-    # Step 1: scale + pad background
-    filter_parts = [
-        f"[0:v]scale={width}:{height}:force_original_aspect_ratio=decrease,"
-        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:black[scaled]"
-    ]
+    Two passes, both O(1) in command-line inputs:
+    1. Build one transparent subtitle .mov from the per-line PNGs via the
+       concat demuxer (image paths live in a playlist file).
+    2. Overlay that single track onto the scaled/padded background + audio.
 
-    # Step 2: chain overlay for each subtitle entry
-    current_label = "scaled"
-    for i, (start, end, _text) in enumerate(subtitle_entries):
-        input_idx = i + 2  # inputs 0 and 1 are bg+audio
-        next_label = f"v{i+1}" if i < len(subtitle_entries) - 1 else "vout"
-        filter_parts.append(
-            f"[{current_label}][{input_idx}:v]overlay=enable='between(t,{start:.3f},{end:.3f})'[{next_label}]"
-        )
-        current_label = next_label
+    Falls back to a subtitle-free compose if the track cannot be built, so the
+    pipeline never dies on subtitle issues.
+    """
+    blank_png = _build_blank_png(width, height, tmpdir)
+    if blank_png is None:
+        return _compose_without_subtitles(bg_video, audio_path, output_path,
+                                          width, height, audio_duration)
 
-    filter_complex = ";".join(filter_parts)
+    concat_path = os.path.join(tmpdir, "subtitles.concat")
+    build_subtitle_concat(subtitle_entries, sub_pngs, blank_png,
+                          audio_duration, concat_path)
 
-    cmd += [
-        "-filter_complex", filter_complex,
-        "-map", f"[{current_label}]",
-        "-map", "1:a",
-        "-t", str(audio_duration),
-        "-c:v", "libx264", "-preset", "medium", "-crf", "23",
-        "-c:a", "aac", "-b:a", "128k",
-        "-movflags", "+faststart",
-        "-shortest",
-        output_path,
-    ]
-
-    logger.info("Composing video with %d subtitle overlays (%.1fs)...",
+    track_path = os.path.join(tmpdir, "subtitle_track.mov")
+    logger.info("Building subtitle track for %d lines (%.1fs)...",
                 len(subtitle_entries), audio_duration)
-    logger.debug("filter_complex:\n%s", filter_complex)
+    if _run_ffmpeg(_build_subtitle_track_cmd(concat_path, track_path),
+                   track_path) is None:
+        logger.warning("Subtitle track build failed — composing without subtitles")
+        return _compose_without_subtitles(bg_video, audio_path, output_path,
+                                          width, height, audio_duration)
+
+    cmd = build_compose_command(bg_video, audio_path, output_path,
+                                width, height, audio_duration,
+                                subtitle_track=track_path)
     return _run_ffmpeg(cmd, output_path)
 
 

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -64,28 +64,6 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
         width, height = 1920, 1080
         default_bg = config.BG_VIDEO_LANDSCAPE
 
-    # Multi-clip background (P1): pre-combine into one track when ≥2 clips.
-    _combined_bg = None
-    if bg_videos:
-        usable = [c for c in bg_videos if c and os.path.exists(c)]
-        if len(usable) >= 2:
-            _dur = get_audio_duration(audio_path)
-            _combined_bg = _combine_backgrounds(usable, width, height, _dur,
-                                                config.BG_CLIP_SECONDS)
-        if bg_video is None and usable:
-            bg_video = usable[0]
-    if _combined_bg:
-        bg_video = _combined_bg
-
-    if bg_video is None:
-        bg_video = default_bg
-
-    if not os.path.exists(bg_video):
-        logger.warning("Background video not found: %s — generating solid-color fallback", bg_video)
-        bg_video = _generate_solid_background(bg_video, width, height)
-        if bg_video is None:
-            logger.error("Failed to generate fallback background")
-            return None
     if not os.path.exists(audio_path):
         logger.error("Audio file not found: %s", audio_path)
         return None
@@ -98,6 +76,31 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
         return None
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        # Multi-clip background (P1): pre-combine ≥2 clips into one track written
+        # inside tmpdir so the large intermediate is auto-cleaned afterwards.
+        if bg_videos:
+            usable = [c for c in bg_videos if c and os.path.exists(c)]
+            if len(usable) >= 2:
+                combined = _combine_backgrounds(usable, width, height,
+                                                audio_duration,
+                                                config.BG_CLIP_SECONDS, tmpdir)
+                if combined:
+                    bg_video = combined
+                elif bg_video is None:
+                    bg_video = usable[0]
+            elif bg_video is None and usable:
+                bg_video = usable[0]
+
+        if bg_video is None:
+            bg_video = default_bg
+
+        if not os.path.exists(bg_video):
+            logger.warning("Background video not found: %s — generating solid-color fallback", bg_video)
+            bg_video = _generate_solid_background(bg_video, width, height)
+            if bg_video is None:
+                logger.error("Failed to generate fallback background")
+                return None
+
         subtitle_entries = _parse_srt(subtitle_path)
         if not subtitle_entries:
             logger.warning("No subtitle entries found — composing without subtitles")
@@ -223,12 +226,17 @@ def build_multi_bg_command(clips: list[str], output_path: str,
 
 
 def _combine_backgrounds(clips: list[str], width: int, height: int,
-                         total_duration: float, clip_seconds: int) -> str | None:
-    """Run the multi-bg pre-pass; returns combined path or None on failure."""
+                         total_duration: float, clip_seconds: int,
+                         tmpdir: str) -> str | None:
+    """Run the multi-bg pre-pass; returns combined path or None on failure.
+
+    The combined track is written into *tmpdir* (the compose TemporaryDirectory)
+    so it is removed automatically once composition finishes — avoiding leftover
+    multi-hundred-MB intermediates accumulating in the system temp directory.
+    """
     if total_duration <= 0:
         return None
-    out = os.path.join(tempfile.gettempdir(),
-                       f"combined_bg_{os.getpid()}_{len(clips)}.mp4")
+    out = os.path.join(tmpdir, "combined_bg.mp4")
     cmd = build_multi_bg_command(clips, out, width, height, total_duration,
                                  clip_seconds)
     logger.info("Combining %d background clips into one track...", len(clips))

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -36,7 +36,8 @@ _FALLBACK_FONTS = [
 
 
 def compose_video(audio_path: str, subtitle_path: str, output_path: str,
-                  video_type: str = "long", bg_video: str | None = None) -> str | None:
+                  video_type: str = "long", bg_video: str | None = None,
+                  bg_videos: list[str] | None = None) -> str | None:
     """Compose final video from audio + background + subtitles.
 
     Args:
@@ -45,21 +46,39 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
         output_path: Path to save output video (.mp4).
         video_type: "long" (16:9 landscape) or "short" (9:16 vertical).
         bg_video: Path to background video. If None, uses default from config.
+        bg_videos: Optional list of clips for multi-clip background (P1). When
+            it has >1 entry, they are pre-combined into one background track
+            (keeping the final compose at a constant input count). Falls back to
+            ``bg_video`` / the first clip on failure.
 
     Returns:
         Path to the video file, or None on failure.
     """
-    # Select background and settings based on type
+    # Select dimensions/fontsize based on type
     if video_type == "short":
-        if bg_video is None:
-            bg_video = config.BG_VIDEO_PORTRAIT
         fontsize = config.SUBTITLE_FONTSIZE_SHORT
         width, height = 1080, 1920
+        default_bg = config.BG_VIDEO_PORTRAIT
     else:
-        if bg_video is None:
-            bg_video = config.BG_VIDEO_LANDSCAPE
         fontsize = config.SUBTITLE_FONTSIZE_LONG
         width, height = 1920, 1080
+        default_bg = config.BG_VIDEO_LANDSCAPE
+
+    # Multi-clip background (P1): pre-combine into one track when ≥2 clips.
+    _combined_bg = None
+    if bg_videos:
+        usable = [c for c in bg_videos if c and os.path.exists(c)]
+        if len(usable) >= 2:
+            _dur = get_audio_duration(audio_path)
+            _combined_bg = _combine_backgrounds(usable, width, height, _dur,
+                                                config.BG_CLIP_SECONDS)
+        if bg_video is None and usable:
+            bg_video = usable[0]
+    if _combined_bg:
+        bg_video = _combined_bg
+
+    if bg_video is None:
+        bg_video = default_bg
 
     if not os.path.exists(bg_video):
         logger.warning("Background video not found: %s — generating solid-color fallback", bg_video)
@@ -158,6 +177,62 @@ def build_compose_command(bg_video: str, audio_path: str, output_path: str,
         output_path,
     ]
     return cmd
+
+
+def build_multi_bg_command(clips: list[str], output_path: str,
+                           width: int, height: int, total_duration: float,
+                           clip_seconds: int = 6) -> list[str]:
+    """Build the ffmpeg command that combines clips into one background (pure).
+
+    Cuts a *clip_seconds* window from each clip (looping inputs so short clips
+    still fill the window), scales/pads to WxH, and concatenates enough cycled
+    segments to cover *total_duration*. Number of ffmpeg inputs == number of
+    distinct clips (bounded by BG_CLIP_COUNT), independent of total duration.
+    """
+    if clip_seconds <= 0:
+        clip_seconds = 6
+    n_clips = len(clips)
+    segs_needed = max(1, -(-int(total_duration) // clip_seconds))  # ceil division
+
+    cmd = ["ffmpeg", "-y"]
+    for clip in clips:
+        cmd += ["-stream_loop", "-1", "-i", clip]
+
+    scale_pad = (f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+                 f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:black")
+    parts = []
+    labels = []
+    for k in range(segs_needed):
+        idx = k % n_clips
+        parts.append(
+            f"[{idx}:v]trim=duration={clip_seconds},setpts=PTS-STARTPTS,"
+            f"{scale_pad}[s{k}]"
+        )
+        labels.append(f"[s{k}]")
+    parts.append("".join(labels) + f"concat=n={segs_needed}:v=1:a=0[bgout]")
+
+    cmd += [
+        "-filter_complex", ";".join(parts),
+        "-map", "[bgout]",
+        "-t", str(total_duration),
+        "-c:v", "libx264", "-preset", "medium", "-crf", "23",
+        "-pix_fmt", "yuv420p",
+        output_path,
+    ]
+    return cmd
+
+
+def _combine_backgrounds(clips: list[str], width: int, height: int,
+                         total_duration: float, clip_seconds: int) -> str | None:
+    """Run the multi-bg pre-pass; returns combined path or None on failure."""
+    if total_duration <= 0:
+        return None
+    out = os.path.join(tempfile.gettempdir(),
+                       f"combined_bg_{os.getpid()}_{len(clips)}.mp4")
+    cmd = build_multi_bg_command(clips, out, width, height, total_duration,
+                                 clip_seconds)
+    logger.info("Combining %d background clips into one track...", len(clips))
+    return _run_ffmpeg(cmd, out)
 
 
 def build_subtitle_concat(subtitle_entries: list[tuple[float, float, str]],


### PR DESCRIPTION
Triển khai **P0** và **P1** của hybrid roadmap (`docs/current/video-enhancement/`). Mọi nâng cấp đứng sau **feature flag**, mặc định = hành vi cũ → không hồi quy, rollback gọn.

## P0 — Stabilize & Secure

**V0.1 Security (TTS TLS):** bỏ `CERT_NONE` mặc định trong `video/tts_client.py`. Giờ verify cert theo CA hệ thống; chỉ tắt khi opt-in `TTS_ALLOW_INSECURE_SSL=1` (log cảnh báo MITM). Test xác minh context ở cả 2 chế độ + token không bị log.

**V0.2 Composer O(N)→O(1):** thay vì 1 input ffmpeg / dòng phụ đề, phụ đề gộp thành **một track trong suốt** (concat-demuxer các PNG → 1 overlay qtrle). Builder thuần `build_compose_command` / `build_subtitle_concat` / `_build_subtitle_track_cmd` được unit-test → số input cố định bất kể số dòng phụ đề. `compose_video()` giữ nguyên chữ ký; fallback compose không phụ đề khi track lỗi.

**V0.3 Flags:** `config` thêm `SUBTITLE_TIMING_MODE`/`BACKGROUND_MODE`/`TTS_PROVIDER`/`COMPOSER_ENGINE`/`ENABLE_BGM`/`TTS_ALLOW_INSECURE_SSL` + `validate_flags()` (wired vào pipeline startup). Doc ở `.env.example` + `CLAUDE.md`.

## P1 — Quality Uplift

**V1.1 Whisper timing:** `video/subtitle_aligner.py` lấy timing word-level từ faster-whisper nhưng **giữ text script gốc** (bảo toàn chính tả VN + số đã chuẩn hoá). `_map_segments_to_words` thuần/tested. faster-whisper là optional (lazy import); thiếu lib/lỗi/rỗng → tự fallback word-count. `subtitle_generator` refactor để chia sẻ `write_entries_srt`.

**V1.2 Multi-clip background:** `get_backgrounds()` gom N clip; `build_multi_bg_command` pre-combine thành 1 track nền (input = số clip, độc lập duration) rồi đưa vào compose O(1). `BACKGROUND_MODE=multi` bật; fallback single khi lỗi.

**V1.3 Background music:** `video/audio_mixer.py` trộn nhạc royalty-free dưới giọng với ducking (`build_mix_command` thuần/tested). `ENABLE_BGM` bật; thiếu nhạc/lỗi → chỉ giọng. Caption Telegram báo có nhạc nền. Thêm `assets/music/` + `CREDITS.md`.

## Test & an toàn
- **152 unit test pass** (`python3 -m unittest discover -s tests`).
- Mọi flag default = legacy; `py_compile` + import-check sạch.
- Nguyên tắc xuyên suốt: consistency (facade + flags), performance (O(1) composer, Whisper CPU int8 + fallback), security (TLS verify mặc định, không log secret), UX (Telegram vẫn là cổng duyệt, thêm nhãn BGM).

> Lưu ý: check `create-pr` có thể đỏ do `PAT_TOKEN` hết hạn (hạ tầng, không liên quan thay đổi này).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0154AKd2xWdqEuHpAwQTHL2H)_