### PR TITLE
Video enhancement P2: multi-provider TTS, MoviePy engine, local web review UI

### DIFF
--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -26,6 +26,8 @@ SUBTITLE_TIMING_MODE=wordcount
 BACKGROUND_MODE=single
 # TTS provider: nuitruc (legacy) | edge (P2, Edge TTS vi-VN)
 TTS_PROVIDER=nuitruc
+# Edge TTS voice (P2): vi-VN-HoaiMyNeural (nữ) | vi-VN-NamMinhNeural (nam)
+EDGE_VOICE=vi-VN-HoaiMyNeural
 # Composer engine: ffmpeg (default) | moviepy (P2)
 COMPOSER_ENGINE=ffmpeg
 # Background music under narration: 1 to enable (P1)

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -76,6 +76,8 @@ SUBTITLE_TIMING_MODE = os.getenv("SUBTITLE_TIMING_MODE", "wordcount")
 BACKGROUND_MODE = os.getenv("BACKGROUND_MODE", "single")
 # TTS_PROVIDER: "nuitruc" (legacy) | "edge" (P2, Edge TTS vi-VN)
 TTS_PROVIDER = os.getenv("TTS_PROVIDER", "nuitruc")
+# Edge TTS voice (P2) — used when TTS_PROVIDER=edge or as a fallback provider.
+EDGE_VOICE = os.getenv("EDGE_VOICE", "vi-VN-HoaiMyNeural")  # or vi-VN-NamMinhNeural
 # COMPOSER_ENGINE: "ffmpeg" (legacy/default) | "moviepy" (P2)
 COMPOSER_ENGINE = os.getenv("COMPOSER_ENGINE", "ffmpeg")
 # ENABLE_BGM: mix royalty-free background music under narration (P1)

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -331,9 +331,19 @@ def _create_video(narrative: str, video_type: str, date_str: str,
             logger.warning("No background found — compose_video will use default")
 
     video_path = os.path.join(base_dir, f"video_{video_id}.mp4")
-    result = compose_video(audio_path, srt_path, video_path,
-                           video_type=video_type, bg_video=bg_video,
-                           bg_videos=bg_videos)
+    # Composer engine selector (P2): MoviePy optional, FFmpeg default.
+    if config.COMPOSER_ENGINE == "moviepy":
+        from video.composer_moviepy import compose as compose_fn
+    else:
+        compose_fn = compose_video
+    result = compose_fn(audio_path, srt_path, video_path,
+                        video_type=video_type, bg_video=bg_video,
+                        bg_videos=bg_videos)
+    if not result and config.COMPOSER_ENGINE == "moviepy":
+        logger.warning("MoviePy compose failed — falling back to ffmpeg engine")
+        result = compose_video(audio_path, srt_path, video_path,
+                               video_type=video_type, bg_video=bg_video,
+                               bg_videos=bg_videos)
     if not result:
         logger.error("Video composition failed for video %d", video_id)
         return None

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -289,32 +289,23 @@ def _handle_update(update: dict, publish_callback):
     if text.startswith("/approve_"):
         try:
             video_id = int(text.split("_", 1)[1])
-            video = get_video(video_id)
-            if not video:
-                _send_text(f"⚠️ Video {video_id} không tồn tại.")
-                return
-            if video["status"] != "pending_approval":
-                _send_text(f"⚠️ Video {video_id} không ở trạng thái chờ duyệt (status={video['status']}).")
-                return
-
-            update_video_status(video_id, "approved")
-            _send_text(f"✅ Video {video_id} đã duyệt! Đang upload...")
-            logger.info("Video %d approved — triggering publish", video_id)
-
-            # Publish immediately
-            publish_callback(video_id)
-
         except (ValueError, IndexError):
             _send_text("⚠️ Lệnh không hợp lệ. Dùng: /approve_<số>")
+            return
+        from video.review_service import approve
+        # review_service performs the state transition + publish atomically.
+        ok, msg = approve(video_id, publish_callback=publish_callback)
+        _send_text(("✅ " if ok else "⚠️ ") + msg + (" Đang upload..." if ok else ""))
 
     elif text.startswith("/reject_"):
         try:
             video_id = int(text.split("_", 1)[1])
-            update_video_status(video_id, "rejected")
-            _send_text(f"❌ Video {video_id} đã bị từ chối.")
-            logger.info("Video %d rejected", video_id)
         except (ValueError, IndexError):
             _send_text("⚠️ Lệnh không hợp lệ. Dùng: /reject_<số>")
+            return
+        from video.review_service import reject
+        ok, msg = reject(video_id)
+        _send_text(("❌ " if ok else "⚠️ ") + msg)
 
     elif text.startswith("/script_"):
         try:

--- a/content-pipeline/requirements.txt
+++ b/content-pipeline/requirements.txt
@@ -12,3 +12,13 @@ requests>=2.28
 # if this is not installed. Heavy dependency — install explicitly:
 #   pip install faster-whisper
 # faster-whisper>=1.0
+
+# Optional (P2): extra TTS provider / composer engine / web UI. Each is lazy-
+# imported and the pipeline falls back gracefully when absent. Install only what
+# you enable:
+#   pip install edge-tts     # TTS_PROVIDER=edge (free Vietnamese voices)
+#   pip install moviepy      # COMPOSER_ENGINE=moviepy
+#   pip install streamlit    # local web preview: streamlit run webui/app.py
+# edge-tts>=6.1
+# moviepy>=2.0
+# streamlit>=1.30

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -351,6 +351,30 @@ def update_video_status(video_id: int, status: str):
         conn.close()
 
 
+def claim_video_status(video_id: int, new_status: str, expected_status: str) -> bool:
+    """Atomically move a video from *expected_status* to *new_status*.
+
+    Returns True only if THIS call performed the transition (exactly one row
+    matched). Prevents races where two reviewers (Telegram + Web UI) both
+    approve the same pending video and trigger duplicate publishes.
+    """
+    conn = get_connection()
+    try:
+        extra = ""
+        if new_status == "approved":
+            extra = ", approved_at = CURRENT_TIMESTAMP"
+        elif new_status == "published":
+            extra = ", published_at = CURRENT_TIMESTAMP"
+        cur = conn.execute(
+            f"UPDATE videos SET status = ?{extra} WHERE id = ? AND status = ?",
+            (new_status, video_id, expected_status),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    finally:
+        conn.close()
+
+
 def update_video_telegram_id(video_id: int, message_id: str):
     """Store Telegram message ID for approval tracking."""
     conn = get_connection()

--- a/content-pipeline/tests/test_composer_moviepy.py
+++ b/content-pipeline/tests/test_composer_moviepy.py
@@ -11,7 +11,32 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from video.composer_moviepy import build_subtitle_specs, compose
+from video.composer_moviepy import (
+    build_subtitle_specs, compose, plan_multi_bg_segments,
+)
+
+
+class TestPlanMultiBgSegments(unittest.TestCase):
+    def test_cycles_clip_indices(self):
+        # 30s / 6s = 5 slots across 2 clips -> 0,1,0,1,0
+        self.assertEqual(
+            plan_multi_bg_segments(2, 30.0, 6), [0, 1, 0, 1, 0]
+        )
+
+    def test_ceil_division(self):
+        # ceil(20/6) == 4 slots
+        self.assertEqual(len(plan_multi_bg_segments(3, 20.0, 6)), 4)
+
+    def test_matches_ffmpeg_segment_count(self):
+        # Same cadence the FFmpeg engine uses (build_multi_bg_command).
+        from video.video_composer import build_multi_bg_command
+        cmd = build_multi_bg_command(["a", "b"], "o.mp4", 1920, 1080, 30.0, 6)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn(f"concat=n={len(plan_multi_bg_segments(2, 30.0, 6))}", fc)
+
+    def test_empty_for_zero_clips_or_duration(self):
+        self.assertEqual(plan_multi_bg_segments(0, 30.0, 6), [])
+        self.assertEqual(plan_multi_bg_segments(2, 0, 6), [])
 
 
 class TestBuildSubtitleSpecs(unittest.TestCase):

--- a/content-pipeline/tests/test_composer_moviepy.py
+++ b/content-pipeline/tests/test_composer_moviepy.py
@@ -1,0 +1,54 @@
+"""Tests for video.composer_moviepy (P2 / V2.2).
+
+The MoviePy runtime is not exercised (optional, heavy dependency); we test the
+pure spec builder and the missing-dependency contract.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from video.composer_moviepy import build_subtitle_specs, compose
+
+
+class TestBuildSubtitleSpecs(unittest.TestCase):
+    def test_one_spec_per_entry(self):
+        entries = [(0.0, 2.0, "a"), (2.0, 5.0, "b")]
+        specs = build_subtitle_specs(entries, 1920, 1080, 48)
+        self.assertEqual(len(specs), 2)
+
+    def test_timing_and_duration(self):
+        specs = build_subtitle_specs([(1.0, 3.5, "hi")], 1920, 1080, 48)
+        self.assertEqual(specs[0]["start"], 1.0)
+        self.assertAlmostEqual(specs[0]["duration"], 2.5)
+        self.assertEqual(specs[0]["text"], "hi")
+
+    def test_bottom_centered_position(self):
+        specs = build_subtitle_specs([(0.0, 1.0, "x")], 1080, 1920, 64)
+        pos = specs[0]["position"]
+        self.assertEqual(pos[0], "center")
+        self.assertEqual(pos[1], int(1920 * 0.78))
+
+    def test_width_constrained(self):
+        specs = build_subtitle_specs([(0.0, 1.0, "x")], 1920, 1080, 48)
+        self.assertEqual(specs[0]["size"][0], int(1920 * 0.8))
+
+    def test_empty_entries(self):
+        self.assertEqual(build_subtitle_specs([], 1920, 1080, 48), [])
+
+
+class TestComposeMissingDependency(unittest.TestCase):
+    @unittest.skipIf(
+        __import__("importlib").util.find_spec("moviepy") is not None,
+        "moviepy is installed; skipping missing-dependency test",
+    )
+    def test_returns_none_without_moviepy(self):
+        result = compose("a.mp3", "s.srt", "out.mp4", video_type="long")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_review_service.py
+++ b/content-pipeline/tests/test_review_service.py
@@ -1,0 +1,72 @@
+"""Tests for video.review_service (P2 / V2.3) — shared approve/reject logic."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.review_service as rs
+
+
+class TestApprove(unittest.TestCase):
+    def test_missing_video(self):
+        with patch.object(rs, "get_video", return_value=None):
+            ok, msg = rs.approve(7)
+        self.assertFalse(ok)
+        self.assertIn("không tồn tại", msg)
+
+    def test_wrong_status_blocked(self):
+        with patch.object(rs, "get_video",
+                          return_value={"id": 7, "status": "published"}), \
+             patch.object(rs, "update_video_status") as upd:
+            ok, msg = rs.approve(7)
+        self.assertFalse(ok)
+        upd.assert_not_called()
+
+    def test_approve_transitions_and_publishes(self):
+        publish = MagicMock()
+        with patch.object(rs, "get_video",
+                          return_value={"id": 7, "status": "pending_approval"}), \
+             patch.object(rs, "update_video_status") as upd:
+            ok, msg = rs.approve(7, publish_callback=publish)
+        self.assertTrue(ok)
+        upd.assert_called_once_with(7, "approved")
+        publish.assert_called_once_with(7)
+
+    def test_approve_without_callback(self):
+        with patch.object(rs, "get_video",
+                          return_value={"id": 7, "status": "pending_approval"}), \
+             patch.object(rs, "update_video_status"):
+            ok, _ = rs.approve(7)
+        self.assertTrue(ok)
+
+
+class TestReject(unittest.TestCase):
+    def test_missing_video(self):
+        with patch.object(rs, "get_video", return_value=None):
+            ok, _ = rs.reject(9)
+        self.assertFalse(ok)
+
+    def test_reject_transitions(self):
+        with patch.object(rs, "get_video",
+                          return_value={"id": 9, "status": "pending_approval"}), \
+             patch.object(rs, "update_video_status") as upd:
+            ok, _ = rs.reject(9)
+        self.assertTrue(ok)
+        upd.assert_called_once_with(9, "rejected")
+
+
+class TestListPending(unittest.TestCase):
+    def test_delegates_to_db(self):
+        with patch.object(rs, "get_videos_by_status",
+                          return_value=[{"id": 1}]) as q:
+            result = rs.list_pending()
+        self.assertEqual(result, [{"id": 1}])
+        q.assert_called_once_with("pending_approval")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_review_service.py
+++ b/content-pipeline/tests/test_review_service.py
@@ -19,27 +19,37 @@ class TestApprove(unittest.TestCase):
         self.assertIn("không tồn tại", msg)
 
     def test_wrong_status_blocked(self):
+        # claim fails (no row in pending_approval) -> no publish.
         with patch.object(rs, "get_video",
                           return_value={"id": 7, "status": "published"}), \
-             patch.object(rs, "update_video_status") as upd:
-            ok, msg = rs.approve(7)
+             patch.object(rs, "claim_video_status", return_value=False):
+            ok, msg = rs.approve(7, publish_callback=MagicMock())
         self.assertFalse(ok)
-        upd.assert_not_called()
 
     def test_approve_transitions_and_publishes(self):
         publish = MagicMock()
         with patch.object(rs, "get_video",
                           return_value={"id": 7, "status": "pending_approval"}), \
-             patch.object(rs, "update_video_status") as upd:
+             patch.object(rs, "claim_video_status", return_value=True) as claim:
             ok, msg = rs.approve(7, publish_callback=publish)
         self.assertTrue(ok)
-        upd.assert_called_once_with(7, "approved")
+        claim.assert_called_once_with(7, "approved", "pending_approval")
         publish.assert_called_once_with(7)
+
+    def test_lost_race_does_not_publish(self):
+        # Another reviewer already claimed it: claim returns False -> no publish.
+        publish = MagicMock()
+        with patch.object(rs, "get_video",
+                          return_value={"id": 7, "status": "pending_approval"}), \
+             patch.object(rs, "claim_video_status", return_value=False):
+            ok, _ = rs.approve(7, publish_callback=publish)
+        self.assertFalse(ok)
+        publish.assert_not_called()
 
     def test_approve_without_callback(self):
         with patch.object(rs, "get_video",
                           return_value={"id": 7, "status": "pending_approval"}), \
-             patch.object(rs, "update_video_status"):
+             patch.object(rs, "claim_video_status", return_value=True):
             ok, _ = rs.approve(7)
         self.assertTrue(ok)
 

--- a/content-pipeline/tests/test_tts_factory.py
+++ b/content-pipeline/tests/test_tts_factory.py
@@ -1,0 +1,102 @@
+"""Tests for the TTS provider factory + fallback chain (P2 / V2.1)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.tts.factory as factory
+from video.tts.factory import get_provider, synthesize, _provider_order
+
+
+class FakeProvider:
+    def __init__(self, name, result):
+        self.name = name
+        self.result = result
+        self.called = False
+
+    def synthesize(self, text, output_path):
+        self.called = True
+        return self.result
+
+
+class TestGetProvider(unittest.TestCase):
+    def test_nuitruc(self):
+        self.assertEqual(get_provider("nuitruc").name, "nuitruc")
+
+    def test_edge(self):
+        self.assertEqual(get_provider("edge").name, "edge")
+
+    def test_unknown_defaults_to_nuitruc(self):
+        self.assertEqual(get_provider("bogus").name, "nuitruc")
+
+
+class TestProviderOrder(unittest.TestCase):
+    def test_primary_first(self):
+        with patch.object(factory.config, "TTS_PROVIDER", "edge"):
+            order = _provider_order()
+        self.assertEqual(order[0], "edge")
+        self.assertIn("nuitruc", order)
+
+    def test_no_duplicates(self):
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"):
+            order = _provider_order()
+        self.assertEqual(len(order), len(set(order)))
+
+
+class TestSynthesizeFallback(unittest.TestCase):
+    def test_primary_success_skips_fallback(self):
+        primary = FakeProvider("nuitruc", "out.mp3")
+        secondary = FakeProvider("edge", "edge.mp3")
+        providers = {"nuitruc": primary, "edge": secondary}
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", side_effect=lambda n: providers[n]), \
+             patch("os.makedirs"):
+            result = synthesize("xin chào", "out.mp3")
+        self.assertEqual(result, "out.mp3")
+        self.assertTrue(primary.called)
+        self.assertFalse(secondary.called)
+
+    def test_falls_back_when_primary_fails(self):
+        primary = FakeProvider("nuitruc", None)
+        secondary = FakeProvider("edge", "edge.mp3")
+        providers = {"nuitruc": primary, "edge": secondary}
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", side_effect=lambda n: providers[n]), \
+             patch("os.makedirs"):
+            result = synthesize("xin chào", "out.mp3")
+        self.assertEqual(result, "edge.mp3")
+        self.assertTrue(secondary.called)
+
+    def test_all_fail_returns_none(self):
+        providers = {"nuitruc": FakeProvider("nuitruc", None),
+                     "edge": FakeProvider("edge", None)}
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", side_effect=lambda n: providers[n]), \
+             patch("os.makedirs"):
+            self.assertIsNone(synthesize("xin chào", "out.mp3"))
+
+    def test_text_passed_through_unmodified(self):
+        # The factory must NOT re-run preprocessing — text arrives already
+        # speech-normalized from upstream.
+        captured = {}
+
+        class Cap:
+            name = "nuitruc"
+
+            def synthesize(self, text, output_path):
+                captured["text"] = text
+                return output_path
+
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", return_value=Cap()), \
+             patch("os.makedirs"):
+            synthesize("năm mươi phần trăm", "out.mp3")
+        self.assertEqual(captured["text"], "năm mươi phần trăm")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_tts_factory.py
+++ b/content-pipeline/tests/test_tts_factory.py
@@ -46,6 +46,13 @@ class TestProviderOrder(unittest.TestCase):
             order = _provider_order()
         self.assertEqual(len(order), len(set(order)))
 
+    def test_unknown_provider_normalized(self):
+        # A typo must not add a bogus first attempt (which would double the
+        # slow nuitruc retry budget); it normalizes to nuitruc.
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitrucc"):
+            order = _provider_order()
+        self.assertEqual(order, ["nuitruc", "edge"])
+
 
 class TestSynthesizeFallback(unittest.TestCase):
     def test_primary_success_skips_fallback(self):

--- a/content-pipeline/video/composer_moviepy.py
+++ b/content-pipeline/video/composer_moviepy.py
@@ -45,6 +45,23 @@ def build_subtitle_specs(subtitle_entries: list[tuple[float, float, str]],
     return specs
 
 
+def plan_multi_bg_segments(n_clips: int, total_duration: float,
+                           clip_seconds: int) -> list[int]:
+    """Plan which clip index plays in each ~clip_seconds slot (pure).
+
+    Mirrors the FFmpeg engine's build_multi_bg_command cadence (clip index
+    = k % n_clips for ceil(total/clip_seconds) slots) so both engines switch
+    background clips at the same rhythm instead of letting one long clip
+    dominate the video.
+    """
+    if clip_seconds <= 0:
+        clip_seconds = 6
+    if n_clips <= 0 or total_duration <= 0:
+        return []
+    segs = max(1, -(-int(total_duration) // clip_seconds))  # ceil division
+    return [k % n_clips for k in range(segs)]
+
+
 def _dimensions(video_type: str) -> tuple[int, int, int]:
     if video_type == "short":
         return 1080, 1920, config.SUBTITLE_FONTSIZE_SHORT
@@ -86,10 +103,20 @@ def compose(audio_path: str, subtitle_path: str, output_path: str,
         audio = AudioFileClip(audio_path)
         duration = audio.duration
 
-        bg_clips = [VideoFileClip(c).resized((width, height)) for c in clips_in]
-        bg = (bg_clips[0] if len(bg_clips) == 1
-              else concatenate_videoclips(bg_clips, method="compose"))
-        bg = bg.with_effects(_loop_to(duration)).with_duration(duration)
+        sources = [VideoFileClip(c).resized((width, height)) for c in clips_in]
+        if len(sources) == 1:
+            bg = sources[0].with_effects(_loop_to(duration)).with_duration(duration)
+        else:
+            # Cut each slot to BG_CLIP_SECONDS and cycle clips, matching the
+            # FFmpeg engine's switching cadence.
+            clip_seconds = config.BG_CLIP_SECONDS
+            plan = plan_multi_bg_segments(len(sources), duration, clip_seconds)
+            segments = []
+            for idx in plan:
+                src = sources[idx]
+                seg_len = min(clip_seconds, src.duration or clip_seconds)
+                segments.append(src.subclipped(0, seg_len))
+            bg = concatenate_videoclips(segments, method="compose").with_duration(duration)
 
         layers = [bg]
         font = config.SUBTITLE_FONT if os.path.exists(config.SUBTITLE_FONT) else None

--- a/content-pipeline/video/composer_moviepy.py
+++ b/content-pipeline/video/composer_moviepy.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""
+MoviePy Composer Engine (P2, optional) — alternative to the FFmpeg composer.
+
+Same signature as video_composer.compose_video so the two are interchangeable
+via COMPOSER_ENGINE. MoviePy gives a layer/timeline model that is nicer for
+animated subtitles/transitions; it is heavier, so FFmpeg stays the default.
+
+MoviePy is an optional dependency (lazy import). If it is missing or anything
+fails, compose() returns None and the caller can fall back.
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from video.video_composer import _parse_srt
+
+logger = logging.getLogger(__name__)
+
+
+def build_subtitle_specs(subtitle_entries: list[tuple[float, float, str]],
+                         width: int, height: int,
+                         fontsize: int) -> list[dict]:
+    """Build MoviePy TextClip specs from SRT entries (pure, unit-testable).
+
+    Returns one dict per subtitle line with text/start/duration/fontsize and a
+    bottom-centred position (~78% of frame height), mirroring the FFmpeg layout.
+    """
+    specs = []
+    y = int(height * 0.78)
+    for start, end, text in subtitle_entries:
+        duration = max(0.0, end - start)
+        specs.append({
+            "text": text,
+            "start": start,
+            "duration": duration,
+            "fontsize": fontsize,
+            "position": ("center", y),
+            "size": (int(width * 0.8), None),
+        })
+    return specs
+
+
+def _dimensions(video_type: str) -> tuple[int, int, int]:
+    if video_type == "short":
+        return 1080, 1920, config.SUBTITLE_FONTSIZE_SHORT
+    return 1920, 1080, config.SUBTITLE_FONTSIZE_LONG
+
+
+def compose(audio_path: str, subtitle_path: str, output_path: str,
+            video_type: str = "long", bg_video: str | None = None,
+            bg_videos: list[str] | None = None) -> str | None:
+    """Compose a video with MoviePy. Returns output path or None on failure."""
+    try:
+        from moviepy import (  # MoviePy 2.x
+            AudioFileClip, VideoFileClip, TextClip, CompositeVideoClip,
+            concatenate_videoclips,
+        )
+    except ImportError:
+        logger.warning(
+            "moviepy not installed — COMPOSER_ENGINE=moviepy unavailable. "
+            "Install with: pip install moviepy"
+        )
+        return None
+
+    if not os.path.exists(audio_path):
+        logger.error("Audio not found: %s", audio_path)
+        return None
+
+    width, height, fontsize = _dimensions(video_type)
+
+    # Choose background source(s).
+    clips_in = [c for c in (bg_videos or []) if c and os.path.exists(c)]
+    if not clips_in and bg_video and os.path.exists(bg_video):
+        clips_in = [bg_video]
+    if not clips_in:
+        logger.error("No usable background for moviepy compose")
+        return None
+
+    try:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        audio = AudioFileClip(audio_path)
+        duration = audio.duration
+
+        bg_clips = [VideoFileClip(c).resized((width, height)) for c in clips_in]
+        bg = (bg_clips[0] if len(bg_clips) == 1
+              else concatenate_videoclips(bg_clips, method="compose"))
+        bg = bg.with_effects(_loop_to(duration)).with_duration(duration)
+
+        layers = [bg]
+        font = config.SUBTITLE_FONT if os.path.exists(config.SUBTITLE_FONT) else None
+        for spec in build_subtitle_specs(_parse_srt(subtitle_path),
+                                         width, height, fontsize):
+            txt = (TextClip(text=spec["text"], font=font,
+                            font_size=spec["fontsize"], color="white",
+                            stroke_color="black", stroke_width=2,
+                            size=spec["size"], method="caption")
+                   .with_start(spec["start"])
+                   .with_duration(spec["duration"])
+                   .with_position(spec["position"]))
+            layers.append(txt)
+
+        final = CompositeVideoClip(layers, size=(width, height)).with_audio(audio)
+        final.write_videofile(output_path, codec="libx264", audio_codec="aac",
+                              fps=30, preset="medium")
+        logger.info("MoviePy composed: %s", output_path)
+        return output_path
+    except Exception as e:
+        logger.error("MoviePy compose failed: %s", e)
+        return None
+
+
+def _loop_to(duration: float):
+    """Return a MoviePy loop effect covering *duration* (2.x vfx.Loop)."""
+    from moviepy import vfx
+    return [vfx.Loop(duration=duration)]

--- a/content-pipeline/video/review_service.py
+++ b/content-pipeline/video/review_service.py
@@ -14,7 +14,7 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from storage.database import (
-    get_video, update_video_status, get_videos_by_status,
+    get_video, update_video_status, get_videos_by_status, claim_video_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -28,17 +28,23 @@ def list_pending() -> list[dict]:
 def approve(video_id: int, publish_callback=None) -> tuple[bool, str]:
     """Approve a pending video and (optionally) trigger publishing.
 
-    Returns (ok, message). Guards against approving a video that is missing or
-    not in the pending_approval state, so a double-approve can't republish.
+    Returns (ok, message). The pending→approved transition is performed as an
+    atomic conditional update so that concurrent approvals (Telegram + Web UI)
+    cannot both claim the same video and publish it twice — only the caller that
+    actually flips the row proceeds to publish.
     """
     video = get_video(video_id)
     if not video:
         return False, f"Video {video_id} không tồn tại."
-    if video.get("status") != "pending_approval":
-        return False, (f"Video {video_id} không ở trạng thái chờ duyệt "
-                       f"(status={video.get('status')}).")
 
-    update_video_status(video_id, "approved")
+    claimed = claim_video_status(video_id, "approved", "pending_approval")
+    if not claimed:
+        # Either already handled, or another reviewer just claimed it.
+        current = get_video(video_id)
+        status = current.get("status") if current else "?"
+        return False, (f"Video {video_id} không ở trạng thái chờ duyệt "
+                       f"(status={status}).")
+
     logger.info("Video %d approved via review_service", video_id)
     if publish_callback is not None:
         publish_callback(video_id)

--- a/content-pipeline/video/review_service.py
+++ b/content-pipeline/video/review_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""
+Review Service (P2) — single source of truth for approve/reject of videos.
+
+Shared by the Telegram bot and the optional Web UI so both go through identical
+state transitions and the same publish path. Pure DB/state logic — no network,
+no Telegram, no Streamlit — so it is easy to unit-test.
+"""
+
+import logging
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import (
+    get_video, update_video_status, get_videos_by_status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def list_pending() -> list[dict]:
+    """Return videos awaiting approval."""
+    return get_videos_by_status("pending_approval")
+
+
+def approve(video_id: int, publish_callback=None) -> tuple[bool, str]:
+    """Approve a pending video and (optionally) trigger publishing.
+
+    Returns (ok, message). Guards against approving a video that is missing or
+    not in the pending_approval state, so a double-approve can't republish.
+    """
+    video = get_video(video_id)
+    if not video:
+        return False, f"Video {video_id} không tồn tại."
+    if video.get("status") != "pending_approval":
+        return False, (f"Video {video_id} không ở trạng thái chờ duyệt "
+                       f"(status={video.get('status')}).")
+
+    update_video_status(video_id, "approved")
+    logger.info("Video %d approved via review_service", video_id)
+    if publish_callback is not None:
+        publish_callback(video_id)
+    return True, f"Video {video_id} đã duyệt."
+
+
+def reject(video_id: int) -> tuple[bool, str]:
+    """Reject a video. Returns (ok, message)."""
+    video = get_video(video_id)
+    if not video:
+        return False, f"Video {video_id} không tồn tại."
+    update_video_status(video_id, "rejected")
+    logger.info("Video %d rejected via review_service", video_id)
+    return True, f"Video {video_id} đã bị từ chối."

--- a/content-pipeline/video/tts/__init__.py
+++ b/content-pipeline/video/tts/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+"""TTS provider package (P2) — đa-provider với fallback chain.
+
+`tts_client.text_to_speech` là facade gọi vào `factory.synthesize`, chọn provider
+theo `config.TTS_PROVIDER` và tự fallback sang provider còn lại nếu lỗi. Nhờ vậy
+phần còn lại của pipeline không phụ thuộc vào một endpoint TTS duy nhất.
+"""

--- a/content-pipeline/video/tts/base.py
+++ b/content-pipeline/video/tts/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Base interface for TTS providers (P2)."""
+
+import abc
+
+
+class TTSProvider(abc.ABC):
+    """A text-to-speech backend.
+
+    Implementations receive text that has ALREADY been normalized for speech
+    (numbers/symbols expanded by text_preprocessor upstream) — they must not
+    re-process it. They write audio to ``output_path`` and return that path on
+    success, or None on failure (so the factory can try the next provider).
+    """
+
+    name: str = "base"
+
+    @abc.abstractmethod
+    def synthesize(self, text: str, output_path: str) -> str | None:
+        """Synthesize *text* to ``output_path``; return the path or None."""
+        raise NotImplementedError

--- a/content-pipeline/video/tts/edge.py
+++ b/content-pipeline/video/tts/edge.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Edge TTS provider (P2) — free Microsoft neural voices, incl. Vietnamese.
+
+Uses the optional `edge-tts` package (lazy import). Voices: vi-VN-HoaiMyNeural
+(female) / vi-VN-NamMinhNeural (male). Receives speech-normalized text from
+upstream, so Vietnamese numbers are already expanded correctly.
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+import config
+from video.tts.base import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _speed_to_rate(speed: float) -> str:
+    """Convert a 1.0-relative speed to an edge-tts rate string like '+10%'."""
+    pct = int(round((speed - 1.0) * 100))
+    return f"{pct:+d}%"
+
+
+class EdgeProvider(TTSProvider):
+    name = "edge"
+
+    def synthesize(self, text: str, output_path: str) -> str | None:
+        try:
+            import asyncio
+            import edge_tts
+        except ImportError:
+            logger.warning(
+                "edge-tts not installed — Edge provider unavailable. "
+                "Install with: pip install edge-tts"
+            )
+            return None
+
+        voice = getattr(config, "EDGE_VOICE", "vi-VN-HoaiMyNeural")
+        rate = _speed_to_rate(getattr(config, "TTS_VOICE_SPEED", 1.0))
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+        async def _run():
+            communicate = edge_tts.Communicate(text, voice, rate=rate)
+            await communicate.save(output_path)
+
+        try:
+            asyncio.run(_run())
+        except Exception as e:
+            logger.error("Edge TTS synthesis failed: %s", e)
+            return None
+
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+            logger.info("Edge TTS saved: %s (voice=%s)", output_path, voice)
+            return output_path
+        logger.error("Edge TTS produced no audio")
+        return None

--- a/content-pipeline/video/tts/factory.py
+++ b/content-pipeline/video/tts/factory.py
@@ -24,12 +24,17 @@ def get_provider(name: str):
 
 
 def _provider_order() -> list[str]:
-    """Configured primary first, then the remaining known providers."""
+    """Configured primary first, then the remaining known providers.
+
+    An unknown/misspelled TTS_PROVIDER is normalized to the default ("nuitruc")
+    so a config typo doesn't add a bogus first attempt that doubles the slow
+    HTTP retry budget before the real fallback runs.
+    """
     primary = getattr(config, "TTS_PROVIDER", "nuitruc")
-    order = [primary] + [p for p in _KNOWN if p != primary]
-    # De-dupe while keeping order (in case primary isn't a known name).
-    seen = set()
-    return [p for p in order if not (p in seen or seen.add(p))]
+    if primary not in _KNOWN:
+        logger.warning("Unknown TTS_PROVIDER %r — using 'nuitruc'", primary)
+        primary = "nuitruc"
+    return [primary] + [p for p in _KNOWN if p != primary]
 
 
 def synthesize(text: str, output_path: str) -> str | None:

--- a/content-pipeline/video/tts/factory.py
+++ b/content-pipeline/video/tts/factory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""TTS factory + fallback chain (P2)."""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+import config
+
+logger = logging.getLogger(__name__)
+
+_KNOWN = ("nuitruc", "edge")
+
+
+def get_provider(name: str):
+    """Return a provider instance for *name* (defaults to nuitruc)."""
+    if name == "edge":
+        from video.tts.edge import EdgeProvider
+        return EdgeProvider()
+    from video.tts.nuitruc import NuiTrucProvider
+    return NuiTrucProvider()
+
+
+def _provider_order() -> list[str]:
+    """Configured primary first, then the remaining known providers."""
+    primary = getattr(config, "TTS_PROVIDER", "nuitruc")
+    order = [primary] + [p for p in _KNOWN if p != primary]
+    # De-dupe while keeping order (in case primary isn't a known name).
+    seen = set()
+    return [p for p in order if not (p in seen or seen.add(p))]
+
+
+def synthesize(text: str, output_path: str) -> str | None:
+    """Synthesize via the configured provider, falling back to the others.
+
+    The text is assumed already speech-normalized (preprocess_for_tts ran
+    upstream); providers must not re-process it.
+    """
+    if output_path:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    for name in _provider_order():
+        provider = get_provider(name)
+        result = provider.synthesize(text, output_path)
+        if result:
+            return result
+        logger.warning("TTS provider %r failed — trying next", name)
+
+    logger.error("All TTS providers failed")
+    return None

--- a/content-pipeline/video/tts/nuitruc.py
+++ b/content-pipeline/video/tts/nuitruc.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Núi Trúc TTS provider (P2) — wraps the existing tts_client HTTP logic.
+
+This is the legacy/default provider. It delegates to tts_client._tts_single so
+the secure SSL handling (P0) and retry logic stay in one place.
+"""
+
+import logging
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+import config
+from video.tts.base import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+
+class NuiTrucProvider(TTSProvider):
+    name = "nuitruc"
+
+    def synthesize(self, text: str, output_path: str) -> str | None:
+        if not config.TTS_API_URL:
+            logger.error("TTS_API_URL not configured — nuitruc unavailable")
+            return None
+        # Reuse the hardened HTTP call (secure SSL + retry) from tts_client.
+        from video.tts_client import _tts_single
+        return _tts_single(text, output_path)

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -30,24 +30,21 @@ TTS_RETRY_DELAY = 5         # Giây chờ ban đầu giữa các retry (exponent
 
 
 def text_to_speech(text: str, output_path: str) -> str | None:
-    """Convert text to speech audio file.
+    """Convert text to speech audio file (facade over the TTS provider factory).
 
-    Gửi full article text trong 1 request duy nhất tới TTS API.
+    Dispatches to the provider chosen by ``config.TTS_PROVIDER`` and falls back
+    to the other providers on failure (P2). Text is expected to be already
+    speech-normalized by the caller (preprocess_for_tts).
 
     Args:
         text: Script text to convert.
-        output_path: Path to save final audio file (.mp3).
+        output_path: Path to save final audio file.
 
     Returns:
         Path to the audio file, or None on failure.
     """
-    if not config.TTS_API_URL:
-        logger.error("TTS_API_URL not configured")
-        return None
-
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-
-    return _tts_single(text, output_path)
+    from video.tts.factory import synthesize
+    return synthesize(text, output_path)
 
 
 def _build_opener(insecure: bool | None = None) -> object:

--- a/content-pipeline/webui/app.py
+++ b/content-pipeline/webui/app.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""
+Web preview UI (P2, OPTIONAL, local-only) — thin Streamlit front-end for the
+daily approval queue. Complements (does NOT replace) the Telegram approval flow.
+
+Run locally only:
+    streamlit run webui/app.py --server.address 127.0.0.1
+
+Security: bind to 127.0.0.1 only; never expose publicly. No secrets are rendered
+client-side. All state changes go through video.review_service (the same path
+the Telegram bot uses), so the two surfaces can't diverge.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _publish(video_id: int) -> None:
+    """Publish via the main pipeline callback (imported lazily)."""
+    from main import publish_video
+    publish_video(video_id)
+
+
+def render() -> None:  # pragma: no cover - requires Streamlit runtime
+    import streamlit as st
+    from video.review_service import list_pending, approve, reject
+
+    st.set_page_config(page_title="Duyệt video — AI 5 Phút", layout="wide")
+    st.title("🎬 Hàng chờ duyệt video")
+    st.caption("Local-only · dùng chung trạng thái với Telegram bot")
+
+    pending = list_pending()
+    if not pending:
+        st.success("✨ Không có video nào đang chờ duyệt.")
+        return
+
+    for video in pending:
+        vid = video["id"]
+        title = video.get("youtube_title") or video.get("tiktok_caption") or ""
+        with st.expander(f"#{vid} — {title}", expanded=True):
+            path = video.get("video_path")
+            if path and os.path.exists(path):
+                st.video(path)
+            else:
+                st.warning("Không tìm thấy file video.")
+            st.text_area("Script", video.get("script_text", ""),
+                         height=200, key=f"script_{vid}")
+            col1, col2 = st.columns(2)
+            if col1.button("✅ Duyệt & đăng", key=f"approve_{vid}"):
+                ok, msg = approve(vid, publish_callback=_publish)
+                (st.success if ok else st.error)(msg)
+            if col2.button("❌ Từ chối", key=f"reject_{vid}"):
+                ok, msg = reject(vid)
+                (st.success if ok else st.error)(msg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    render()

--- a/docs/current/video-enhancement/README.md
+++ b/docs/current/video-enhancement/README.md
@@ -82,9 +82,9 @@
 
 | # | Phase | Mục tiêu | Rủi ro | Estimate | Status |
 |---|-------|----------|--------|----------|--------|
-| 0 | [Stabilize & Secure](phase-0-detailed.md) — [issues](phase-0-issues.md) | Sửa SSL TTS, hạ composer O(N)→O(1), feature-flag scaffold, hoàn thiện test nền | Thấp | ~4–5 ngày | 📋 |
-| 1 | [Quality Uplift](phase-1-detailed.md) — [issues](phase-1-issues.md) | Whisper subtitle timing + multi-clip background + nhạc nền | Trung bình | ~6–8 ngày | 📋 |
-| 2 | [Extensibility](phase-2-detailed.md) — [issues](phase-2-issues.md) | TTS đa-provider (Núi Trúc + Edge), engine MoviePy tuỳ chọn, web preview tuỳ chọn | Trung bình–cao | ~8–10 ngày | 📋 |
+| 0 | [Stabilize & Secure](phase-0-detailed.md) — [issues](phase-0-issues.md) | Sửa SSL TTS, hạ composer O(N)→O(1), feature-flag scaffold, hoàn thiện test nền | Thấp | ~4–5 ngày | ✅ done (PR #56) |
+| 1 | [Quality Uplift](phase-1-detailed.md) — [issues](phase-1-issues.md) | Whisper subtitle timing + multi-clip background + nhạc nền | Trung bình | ~6–8 ngày | ✅ done (PR #56) |
+| 2 | [Extensibility](phase-2-detailed.md) — [issues](phase-2-issues.md) | TTS đa-provider (Núi Trúc + Edge), engine MoviePy tuỳ chọn, web preview tuỳ chọn | Trung bình–cao | ~8–10 ngày | ✅ done |
 
 **Tổng:** ~18–23 ngày làm việc (solo).
 


### PR DESCRIPTION
Hoàn tất **P2** của hybrid roadmap (`docs/current/video-enhancement/phase-2-*`). Tất cả đứng sau feature flag / dependency tuỳ chọn, mặc định = hành vi cũ.

## V2.1 — TTS đa-provider (Núi Trúc + Edge)
- `video/tts/` package: `base.py` (interface), `nuitruc.py`, `edge.py`, `factory.py`.
- `tts_client.text_to_speech` thành **facade** gọi `factory.synthesize` → chọn theo `TTS_PROVIDER` và **fallback** sang provider còn lại khi lỗi.
- `NuiTrucProvider` tái dùng đường HTTP đã hardened (SSL secure của P0). `EdgeProvider` dùng edge-tts (lazy import) với giọng `vi-VN-HoaiMyNeural`/`NamMinhNeural`.
- Preprocessing số tiếng Việt vẫn chạy upstream → Edge cũng đọc số đúng (khác MPT).

## V2.2 — MoviePy engine (tuỳ chọn)
- `video/composer_moviepy.py` cùng chữ ký `compose_video`; chọn qua `COMPOSER_ENGINE=moviepy`, **tự fallback** về ffmpeg nếu lỗi/thiếu lib.
- `build_subtitle_specs` thuần/tested; MoviePy lazy-import.

## V2.3 — Web review UI (local-only, tuỳ chọn)
- Tách `video/review_service.py` (approve/reject/list) làm **một nguồn sự thật**; Telegram bot route qua service này (hành vi không đổi).
- `webui/app.py` — Streamlit local-only (bind `127.0.0.1`), dùng chung `review_service` + `publish_video`. Không expose ra ngoài, không secret client-side.

## Test & an toàn
- **180 unit test pass** (`python3 -m unittest discover -s tests`).
- Smoke-test fallback chain: nuitruc lỗi → edge → None, đều graceful.
- `EDGE_VOICE` thêm vào config; deps tuỳ chọn (edge-tts/moviepy/streamlit) ghi trong `requirements.txt` + `.env.example`.
- Mọi flag default = legacy; không hồi quy pipeline cũ.

> Check `create-pr` có thể đỏ do `PAT_TOKEN` hết hạn (hạ tầng, không liên quan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0154AKd2xWdqEuHpAwQTHL2H)_