### PR TITLE
fix(tts): fail fast on stalled TTS endpoint + real edge fallback (#58)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,15 @@ Các flag bật/tắt nâng cấp video, mặc định = hành vi cũ (xem
 | `TTS_PROVIDER` | `nuitruc` | `nuitruc` (cũ) \| `edge` (P2) |
 | `COMPOSER_ENGINE` | `ffmpeg` | `ffmpeg` (default) \| `moviepy` (P2) |
 | `ENABLE_BGM` | `0` | `1` để trộn nhạc nền (P1) |
+| `TTS_TIMEOUT` | `120` | Socket timeout mỗi request TTS (giây). Timeout = **fail fast**, không retry (issue #58) |
+| `TTS_MAX_RETRIES` | `3` | Số retry cho lỗi HTTP transient nhanh (429/5xx). **Không** áp dụng cho timeout |
+| `TTS_RETRY_DELAY` | `5` | Backoff ban đầu giữa các retry (giây), exponential |
 | `TTS_ALLOW_INSECURE_SSL` | `0` | **Security:** chỉ bật cho endpoint TLS tự ký tin cậy; mặc định verify cert |
+
+**TTS resilience (issue #58):** khi endpoint primary (nuitruc) treo/không phản hồi,
+client fail nhanh (không retry timeout) để fallback chain trong `video.tts.factory`
+chuyển sang `edge` ngay — pipeline vẫn ra video thay vì block ~20 phút rồi hỏng.
+Vì vậy `edge-tts` được cài mặc định (xem `requirements.txt`) làm provider dự phòng.
 
 `config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
 fallback về hành vi cũ.

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -12,6 +12,13 @@ TTS_API_URL=http://tts.nuitruc.ai/api/tts
 TTS_API_KEY=
 TTS_VOICE_ID=voice1
 TTS_VOICE_SPEED=1.0
+# HTTP tuning (issue #58). On a stalled endpoint the client now fails fast and
+# the provider fallback chain takes over, so keep TTS_TIMEOUT modest. Raise it
+# only for a genuinely slow self-hosted backend. Timeouts are NOT retried;
+# TTS_MAX_RETRIES applies to fast transient HTTP errors (429/5xx) only.
+TTS_TIMEOUT=120
+TTS_MAX_RETRIES=3
+TTS_RETRY_DELAY=5
 
 # --- YouTube ---
 YOUTUBE_CLIENT_SECRETS=/path/to/client_secret.json

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -51,6 +51,14 @@ TTS_API_URL = os.getenv("TTS_API_URL", "http://tts.nuitruc.ai/api/tts")
 TTS_API_KEY = os.getenv("TTS_API_KEY", "")           # Optional
 TTS_VOICE_ID = os.getenv("TTS_VOICE_ID", "voice1")
 TTS_VOICE_SPEED = float(os.getenv("TTS_VOICE_SPEED", "1.0"))
+# TTS HTTP tuning (issue #58). A black-hole endpoint (TCP connect OK but no
+# response) used to stall the whole cron window: 400s timeout × 3 retries
+# ≈ 20 min before the fallback provider even ran. Defaults now fail fast and let
+# the provider fallback chain (factory) take over. Raise TTS_TIMEOUT only if you
+# run a genuinely slow self-hosted backend.
+TTS_TIMEOUT = int(os.getenv("TTS_TIMEOUT", "120"))        # per-request socket timeout (s)
+TTS_MAX_RETRIES = int(os.getenv("TTS_MAX_RETRIES", "3"))  # retries for fast transient HTTP errors
+TTS_RETRY_DELAY = int(os.getenv("TTS_RETRY_DELAY", "5"))  # initial backoff (s), exponential
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY", "")     # Free API key from pexels.com/api
 
 # Video output

--- a/content-pipeline/requirements.txt
+++ b/content-pipeline/requirements.txt
@@ -7,18 +7,21 @@ google-auth-oauthlib>=1.1.0
 Pillow>=9.0
 requests>=2.28
 
+# TTS fallback provider (issue #58). Free Microsoft neural voices incl.
+# Vietnamese (vi-VN). Kept installed (not optional) so that when the primary
+# nuitruc endpoint is down, the factory fallback chain can still produce audio
+# and the pipeline keeps shipping videos instead of failing the whole run.
+edge-tts>=6.1
+
 # Optional (P1): Whisper subtitle alignment. Only needed when
 # SUBTITLE_TIMING_MODE=whisper; the pipeline falls back to word-count timing
 # if this is not installed. Heavy dependency — install explicitly:
 #   pip install faster-whisper
 # faster-whisper>=1.0
 
-# Optional (P2): extra TTS provider / composer engine / web UI. Each is lazy-
-# imported and the pipeline falls back gracefully when absent. Install only what
-# you enable:
-#   pip install edge-tts     # TTS_PROVIDER=edge (free Vietnamese voices)
+# Optional (P2): composer engine / web UI. Each is lazy-imported and the
+# pipeline falls back gracefully when absent. Install only what you enable:
 #   pip install moviepy      # COMPOSER_ENGINE=moviepy
 #   pip install streamlit    # local web preview: streamlit run webui/app.py
-# edge-tts>=6.1
 # moviepy>=2.0
 # streamlit>=1.30

--- a/content-pipeline/tests/test_tts_client.py
+++ b/content-pipeline/tests/test_tts_client.py
@@ -10,7 +10,8 @@ import os
 import ssl
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -74,6 +75,69 @@ class TestNoSecretLogging(unittest.TestCase):
         joined = "\n".join(cm.output)
         self.assertNotIn("super-secret-token", joined)
         self.assertNotIn("Bearer super-secret-token", joined)
+
+
+class TestErrorClassification(unittest.TestCase):
+    """Issue #58: a stalled endpoint must NOT be retried; fast 5xx may be."""
+
+    def test_timeout_is_not_retryable(self):
+        self.assertFalse(tts._is_retryable(TimeoutError("timed out")))
+        self.assertFalse(tts._is_retryable(URLError(TimeoutError("timed out"))))
+
+    def test_ssl_error_is_not_retryable(self):
+        self.assertFalse(tts._is_retryable(ssl.SSLError("handshake")))
+
+    def test_transient_http_codes_are_retryable(self):
+        for code in (429, 500, 502, 503, 504):
+            err = HTTPError("http://x", code, "busy", {}, None)
+            self.assertTrue(tts._is_retryable(err), code)
+
+    def test_client_http_error_is_not_retryable(self):
+        err = HTTPError("http://x", 400, "bad", {}, None)
+        self.assertFalse(tts._is_retryable(err))
+
+    def test_is_timeout_detects_wrapped_and_bare(self):
+        self.assertTrue(tts._is_timeout(TimeoutError("t")))
+        self.assertTrue(tts._is_timeout(URLError(TimeoutError("t"))))
+        self.assertFalse(tts._is_timeout(URLError(ConnectionResetError())))
+        self.assertFalse(tts._is_timeout(None))
+
+
+class TestFailFastOnTimeout(unittest.TestCase):
+    def test_timeout_is_not_retried(self):
+        """A black-hole timeout fails after ONE attempt (no 3×400s stall)."""
+        opener = MagicMock()
+        opener.open.side_effect = TimeoutError("timed out")
+        with patch.object(tts, "TTS_MAX_RETRIES", 3), \
+             patch.object(tts, "_build_opener", return_value=opener), \
+             patch.object(tts.time, "sleep") as sleep, \
+             patch.multiple(tts.config, TTS_API_URL="https://tts.example/api",
+                            TTS_API_KEY="", TTS_VOICE_ID="voice1",
+                            TTS_VOICE_SPEED=1.0, TTS_ALLOW_INSECURE_SSL=False):
+            with self.assertLogs(tts.logger, level="ERROR") as cm:
+                result = tts._tts_single("xin chào", "/tmp/_tts_timeout.mp3")
+        self.assertIsNone(result)
+        self.assertEqual(opener.open.call_count, 1)   # no retry
+        sleep.assert_not_called()                     # no backoff burned
+        self.assertTrue(any("failing over" in m for m in cm.output))
+
+
+class TestRetryTransientHttp(unittest.TestCase):
+    def test_503_is_retried_with_backoff(self):
+        """Fast 5xx still retries up to TTS_MAX_RETRIES (cheap, often recovers)."""
+        opener = MagicMock()
+        opener.open.side_effect = HTTPError("https://tts.example/api", 503,
+                                            "busy", {}, None)
+        with patch.object(tts, "TTS_MAX_RETRIES", 3), \
+             patch.object(tts, "_build_opener", return_value=opener), \
+             patch.object(tts.time, "sleep") as sleep, \
+             patch.multiple(tts.config, TTS_API_URL="https://tts.example/api",
+                            TTS_API_KEY="", TTS_VOICE_ID="voice1",
+                            TTS_VOICE_SPEED=1.0, TTS_ALLOW_INSECURE_SSL=False):
+            result = tts._tts_single("xin chào", "/tmp/_tts_503.mp3")
+        self.assertIsNone(result)
+        self.assertEqual(opener.open.call_count, 3)   # all attempts used
+        self.assertEqual(sleep.call_count, 2)         # backoff between attempts
 
 
 if __name__ == "__main__":

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -6,7 +6,8 @@ TTS Client — Wrapper cho Núi Trúc TTS API.
 API: http://tts.nuitruc.ai/api/tts
 - POST JSON: {"text": "...", "voice_id": "voice1", "speed": 1.0}
 - Output: WAV (Content-Type: audio/wav)
-- Timeout: 400s — gửi full article text trong 1 request
+- Timeout: config.TTS_TIMEOUT (default 120s) — fail fast on a stalled endpoint so
+  the provider fallback chain (video.tts.factory) can take over (issue #58).
 """
 
 import json
@@ -24,9 +25,11 @@ import config
 
 logger = logging.getLogger(__name__)
 
-TTS_TIMEOUT = 400  # backend handles chunking; allow extra time for long scripts
-TTS_MAX_RETRIES = 3         # Số lần retry khi gặp lỗi tạm thời (503, 500, timeout)
-TTS_RETRY_DELAY = 5         # Giây chờ ban đầu giữa các retry (exponential backoff)
+# HTTP tuning lives in config (env-overridable). Bound here as module globals so
+# tests can patch them and the retry loop reads a single source of truth.
+TTS_TIMEOUT = config.TTS_TIMEOUT        # per-request socket timeout (s)
+TTS_MAX_RETRIES = config.TTS_MAX_RETRIES  # retries for fast transient HTTP errors
+TTS_RETRY_DELAY = config.TTS_RETRY_DELAY  # initial backoff (s), exponential
 
 
 def text_to_speech(text: str, output_path: str) -> str | None:
@@ -77,20 +80,40 @@ def _build_opener(insecure: bool | None = None) -> object:
     return build_opener(HTTPSHandler(context=ssl_ctx))
 
 
-def _is_transient_error(exc: Exception) -> bool:
-    """Return True for errors worth retrying (server down, overloaded, timeout)."""
-    if isinstance(exc, HTTPError):
-        return exc.code in (429, 500, 502, 503, 504)
-    if isinstance(exc, (TimeoutError, ssl.SSLError)):
+def _is_retryable(exc: Exception) -> bool:
+    """Return True only for *fast* transient errors worth retrying on the same URL.
+
+    Retrying a timeout (or SSL error) is deliberately excluded: the reported
+    failure mode (issue #58) is a stalled endpoint — TCP connects but no response
+    — so a retry would just burn another full TTS_TIMEOUT and blow the cron
+    window. Resilience against a dead endpoint comes from the provider fallback
+    chain (video.tts.factory), not from re-hitting the same dead URL. HTTP
+    429/5xx, by contrast, return quickly, so retrying them with backoff is cheap
+    and often succeeds.
+    """
+    return isinstance(exc, HTTPError) and exc.code in (429, 500, 502, 503, 504)
+
+
+def _is_timeout(exc: Exception | None) -> bool:
+    """Return True if *exc* is (or wraps) a socket timeout.
+
+    ``socket.timeout`` is an alias of ``TimeoutError`` since Python 3.10, and
+    urllib surfaces read/connect timeouts as ``URLError`` wrapping it.
+    """
+    if isinstance(exc, TimeoutError):
         return True
     if isinstance(exc, URLError):
-        reason = getattr(exc, "reason", None)
-        return isinstance(reason, (TimeoutError, ssl.SSLError))
+        return isinstance(getattr(exc, "reason", None), TimeoutError)
     return False
 
 
 def _tts_single(text: str, output_path: str) -> str | None:
-    """Call TTS API for a single text chunk with retry + SSL fallback."""
+    """Call the TTS API for one text chunk.
+
+    Retries only fast transient HTTP errors (429/5xx) with exponential backoff;
+    timeouts and SSL errors fail fast so the provider fallback chain can take
+    over (issue #58). Returns the output path on success, else None.
+    """
     payload = json.dumps({
         "text": text,
         "voice_id": config.TTS_VOICE_ID or "voice1",
@@ -122,20 +145,25 @@ def _tts_single(text: str, output_path: str) -> str | None:
 
         except (ssl.SSLError, URLError, HTTPError, OSError) as e:
             last_exc = e
-            if _is_transient_error(e) and attempt < TTS_MAX_RETRIES:
+            if _is_retryable(e) and attempt < TTS_MAX_RETRIES:
                 wait = TTS_RETRY_DELAY * (2 ** (attempt - 1))
                 logger.warning("TTS attempt %d/%d failed (%s), retrying in %ds...",
                                attempt, TTS_MAX_RETRIES, e, wait)
                 time.sleep(wait)
                 continue
-            # Non-transient or last attempt — break out and report
+            # Timeout / SSL / non-retryable error — fail fast so the factory can
+            # fall back to the next provider instead of stalling the cron window.
             break
 
         except Exception as e:
             last_exc = e
             break
 
-    logger.error("TTS API failed: %s", last_exc)
+    if _is_timeout(last_exc):
+        logger.error("TTS endpoint timed out after %ds (%s) — failing over to "
+                     "next provider", TTS_TIMEOUT, config.TTS_API_URL)
+    else:
+        logger.error("TTS API failed: %s", last_exc)
     return None
 
 


### PR DESCRIPTION
Closes #58.

## Vấn đề

Pipeline bị block ~21 phút ở Phase 3 rồi **không tạo được video nào** khi endpoint TTS `nuitruc` trở thành "black hole" (TCP connect OK nhưng không trả response).

## Root cause (3 nguyên nhân chồng nhau)

1. **Timeout dài × retry vô nghĩa** — `TTS_TIMEOUT=400s` áp dụng cho cả *time-to-first-byte*, và `TimeoutError` bị coi là transient → retry 3 lần ≈ 20 phút trước khi fallback chạy.
2. **Fallback bị khoá sau primary chậm** — chuỗi `nuitruc → edge` chỉ chạy *sau khi* nuitruc đốt hết budget retry, nên đúng tình huống cần cứu thì fallback lại bị chặn.
3. **edge-tts là optional chưa cài** — provider dự phòng thực ra là no-op → "không có video nào".

## Thay đổi

- **Performance / response speed:** chỉ retry lỗi HTTP transient nhanh (429/5xx); timeout và SSL error **fail fast** để factory failover ngay sang provider kế. Log rõ `"failing over to next provider"` khi timeout.
- **Consistency / config:** đưa `TTS_TIMEOUT` / `TTS_MAX_RETRIES` / `TTS_RETRY_DELAY` vào `config.py` (env-overridable); hạ default timeout `400s → 120s`. Tài liệu hoá trong `.env.example` và `CLAUDE.md`.
- **Resilience:** cài `edge-tts` mặc định (`requirements.txt`) để fallback chain thực sự ra audio → pipeline vẫn ship video khi nuitruc chết.
- **Security:** giữ nguyên SSL secure-by-default; không log API key (test cũ vẫn pass).

## Tests

- Thêm test: timeout **không** retry (1 attempt, không backoff); HTTP 503 **vẫn** retry với backoff; phân loại `_is_retryable` / `_is_timeout`.
- Toàn bộ suite: **193 tests OK** (2 skipped).

## Tác động hành vi

Worst case khi endpoint chết giảm từ ~20 phút (rồi hỏng) xuống một lần timeout đơn (≤120s) rồi tự động chuyển sang Edge TTS và hoàn thành video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWxjDFUCDFic2KRDbtPkAE)_