### PR TITLE
fix(telegram) + feat(tts): không kẹt video khi gửi file lỗi (#60) + Núi Trúc async TTS cho script dài

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,15 +251,27 @@ Các flag bật/tắt nâng cấp video, mặc định = hành vi cũ (xem
 | `TTS_PROVIDER` | `nuitruc` | `nuitruc` (cũ) \| `edge` (P2) |
 | `COMPOSER_ENGINE` | `ffmpeg` | `ffmpeg` (default) \| `moviepy` (P2) |
 | `ENABLE_BGM` | `0` | `1` để trộn nhạc nền (P1) |
-| `TTS_TIMEOUT` | `120` | Socket timeout mỗi request TTS (giây). Timeout = **fail fast**, không retry (issue #58) |
+| `TTS_TIMEOUT` | `120` | Socket timeout khi tải `/result` (giây). Timeout = **fail fast**, không retry (issue #58) |
 | `TTS_MAX_RETRIES` | `3` | Số retry cho lỗi HTTP transient nhanh (429/5xx). **Không** áp dụng cho timeout |
 | `TTS_RETRY_DELAY` | `5` | Backoff ban đầu giữa các retry (giây), exponential |
+| `TTS_REQUEST_TIMEOUT` | `30` | Socket timeout cho `/submit` và mỗi lần poll `/status` (giây) |
+| `TTS_POLL_INTERVAL` | `12` | Khoảng cách giữa các lần poll `/status` (giây) |
+| `TTS_POLL_TIMEOUT` | `600` | Tổng thời gian chờ tối đa 1 job; quá hạn → fallback provider |
+| `TTS_POLL_MAX_FAILURES` | `3` | Số lần poll `/status` lỗi liên tiếp trước khi fallback (fail fast) |
 | `TTS_ALLOW_INSECURE_SSL` | `0` | **Security:** chỉ bật cho endpoint TLS tự ký tin cậy; mặc định verify cert |
 
 **TTS resilience (issue #58):** khi endpoint primary (nuitruc) treo/không phản hồi,
 client fail nhanh (không retry timeout) để fallback chain trong `video.tts.factory`
 chuyển sang `edge` ngay — pipeline vẫn ra video thay vì block ~20 phút rồi hỏng.
 Vì vậy `edge-tts` được cài mặc định (xem `requirements.txt`) làm provider dự phòng.
+
+**TTS async job (script dài):** nuitruc dùng API bất đồng bộ thay cho `/api/tts`
+đồng bộ (vốn timeout với script dài): `POST {base}/submit` → poll
+`GET {base}/status/<job_id>` mỗi `TTS_POLL_INTERVAL`s đến khi `done`/`error` →
+tải `GET {base}/result/<job_id>` **một lần** (gọi lần 2 ra 404 vì job đã bị xoá —
+bình thường). Toàn bộ bị chặn bởi `TTS_REQUEST_TIMEOUT` / `TTS_POLL_TIMEOUT` /
+`TTS_POLL_MAX_FAILURES` để job treo vẫn fail fast sang `edge` (giữ tinh thần #58).
+Các endpoint con suy ra từ `TTS_API_URL` nên không cần đổi config URL.
 
 `config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
 fallback về hành vi cũ.

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -59,6 +59,14 @@ TTS_VOICE_SPEED = float(os.getenv("TTS_VOICE_SPEED", "1.0"))
 TTS_TIMEOUT = int(os.getenv("TTS_TIMEOUT", "120"))        # per-request socket timeout (s)
 TTS_MAX_RETRIES = int(os.getenv("TTS_MAX_RETRIES", "3"))  # retries for fast transient HTTP errors
 TTS_RETRY_DELAY = int(os.getenv("TTS_RETRY_DELAY", "5"))  # initial backoff (s), exponential
+# Núi Trúc async job API: long scripts no longer fit the old synchronous
+# /api/tts (it timed out). The client now submits a job, polls /status, then
+# downloads /result. These knobs bound the polling so a job that never finishes
+# fails over to the next provider (issue #58) instead of stalling the cron run.
+TTS_REQUEST_TIMEOUT = int(os.getenv("TTS_REQUEST_TIMEOUT", "30"))  # submit/status socket timeout (s)
+TTS_POLL_INTERVAL = int(os.getenv("TTS_POLL_INTERVAL", "12"))      # seconds between status polls
+TTS_POLL_TIMEOUT = int(os.getenv("TTS_POLL_TIMEOUT", "600"))       # max total wait for a job (s)
+TTS_POLL_MAX_FAILURES = int(os.getenv("TTS_POLL_MAX_FAILURES", "3"))  # consecutive poll errors before failover
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY", "")     # Free API key from pexels.com/api
 
 # Video output

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -26,6 +26,10 @@ from storage.database import (
 logger = logging.getLogger(__name__)
 
 TELEGRAM_MAX_LENGTH = 4096
+# Telegram Bot API caps file uploads at 50 MB. Beyond this, sendVideo is
+# guaranteed to fail (Broken pipe / 413), so we skip the doomed upload instead
+# of reading the whole file into memory and blocking ~120s on a dead request.
+TELEGRAM_MAX_FILE_BYTES = 50 * 1024 * 1024
 
 # Store last update_id to avoid re-processing
 _OFFSET_FILE = os.path.join(os.path.dirname(__file__), ".telegram_offset")
@@ -65,6 +69,10 @@ def send_video_for_approval(video_id: int) -> bool:
         config, "ENABLE_BGM", False) else ""
 
     # --- Step 1: Send the script text as the review artifact ---
+    # The script IS the primary review artifact, so its successful delivery is
+    # what makes the video reviewable — NOT the (size-limited, flaky) video
+    # upload below. We capture the send result to drive the status transition.
+    script_sent = False
     script_text = video.get("script_text", "")
     if script_text:
         word_count = len(script_text.split())
@@ -84,8 +92,11 @@ def send_video_for_approval(video_id: int) -> bool:
             f"  ✅ /approve_{video_id}\n"
             f"  ❌ /reject_{video_id}"
         )
-        _send_text(script_header)
-        logger.info("Script text sent for review (video %d, %d words)", video_id, word_count)
+        script_sent = _send_text(script_header)
+        if script_sent:
+            logger.info("Script text sent for review (video %d, %d words)", video_id, word_count)
+        else:
+            logger.error("Failed to send script text for video %d", video_id)
     else:
         logger.warning("Video %d has no script_text — sending video only", video_id)
 
@@ -105,9 +116,36 @@ def send_video_for_approval(video_id: int) -> bool:
     msg_id = _send_video_file(video_path, caption)
     if msg_id:
         update_video_telegram_id(video_id, str(msg_id))
+
+    # --- Step 3: Set status based on whether the video is actually reviewable ---
+    # The reviewer can act as long as they received the script OR the video.
+    # Decoupling the status from the video upload fixes issue #60: a too-large
+    # or broken-pipe video upload must NOT strand the video at status=ready,
+    # which would make /approve_<id> fail with "không ở trạng thái chờ duyệt".
+    reviewable = script_sent or bool(msg_id)
+    if reviewable:
         update_video_status(video_id, "pending_approval")
-        logger.info("Video %d sent for approval (msg_id=%s)", video_id, msg_id)
+        if not msg_id:
+            # Script reached the reviewer but the video file did not. Tell them
+            # explicitly so they don't wait for a video that will never arrive,
+            # and remind them they can still act on the script alone.
+            _send_text(
+                f"⚠️ Không gửi được FILE VIDEO #{video_id} qua Telegram "
+                f"(quá lớn >50MB hoặc lỗi mạng).\n"
+                f"Script ở trên là bản duyệt chính — bạn vẫn có thể duyệt:\n"
+                f"  ✅ /approve_{video_id}\n"
+                f"  ❌ /reject_{video_id}"
+            )
+        logger.info(
+            "Video %d set to pending_approval (video_file_sent=%s)", video_id, bool(msg_id)
+        )
         return True
+
+    # Neither the script nor the video reached the reviewer. Leave the status at
+    # 'ready' so the run can be retried, and report failure upstream.
+    logger.error(
+        "Video %d: neither script nor video could be delivered — staying 'ready'", video_id
+    )
     return False
 
 
@@ -362,6 +400,22 @@ def _send_video_file(video_path: str, caption: str) -> str | None:
     truncate at last newline and send the full caption as a follow-up text.
     """
     url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/sendVideo"
+
+    # Fail fast on oversized files: a >50MB upload is rejected by Telegram after
+    # we have already read the whole file into RAM and blocked up to 120s on a
+    # request that cannot succeed. Skipping it keeps the caller responsive and
+    # lets it fall back to script-only review (issue #60).
+    try:
+        size = os.path.getsize(video_path)
+    except OSError as e:
+        logger.error("Cannot stat video file %s: %s", video_path, e)
+        return None
+    if size > TELEGRAM_MAX_FILE_BYTES:
+        logger.error(
+            "Video %s is %.1f MB, over Telegram's %d MB bot limit — skipping upload",
+            video_path, size / 1024 / 1024, TELEGRAM_MAX_FILE_BYTES // 1024 // 1024,
+        )
+        return None
 
     # Telegram caption limit is 1024 chars
     caption_remainder = ""

--- a/content-pipeline/tests/test_telegram_approval.py
+++ b/content-pipeline/tests/test_telegram_approval.py
@@ -1,0 +1,143 @@
+"""Tests for send_video_for_approval status handling (issue #60).
+
+The video file upload is size-limited and flaky; the *script text* is the real
+review artifact. These tests pin down that the pending_approval transition is
+driven by reviewability (script OR video delivered), not by the video upload
+alone — so a failed/oversized video upload never strands a video at status=ready.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import notifier.telegram_bot as tb
+
+
+def _video(**over):
+    base = {
+        "id": 97,
+        "video_type": "long",
+        "video_path": "/tmp/video_97.mp4",
+        "script_text": "Xin chào, đây là script thật.",
+        "youtube_title": "AI trong 5 phút",
+        "scheduled_platform": "youtube",
+        "scheduled_date": "2026-06-27",
+    }
+    base.update(over)
+    return base
+
+
+class TestSendVideoForApproval(unittest.TestCase):
+    def setUp(self):
+        # Common patches: valid creds, existing file, no-op telegram_id write.
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.cfg.TELEGRAM_CHAT_ID = "123"
+        self.cfg.ENABLE_BGM = False
+        self.addCleanup(self.p_cfg.stop)
+
+        self.p_exists = patch.object(tb.os.path, "exists", return_value=True)
+        self.p_exists.start()
+        self.addCleanup(self.p_exists.stop)
+
+        self.p_tgid = patch.object(tb, "update_video_telegram_id")
+        self.p_tgid.start()
+        self.addCleanup(self.p_tgid.stop)
+
+    def test_video_upload_fails_but_script_sent_sets_pending(self):
+        """Core issue #60: video upload fails, script ok -> pending_approval."""
+        with patch.object(tb, "get_video", return_value=_video()), \
+             patch.object(tb, "_send_text", return_value=True) as send_text, \
+             patch.object(tb, "_send_video_file", return_value=None), \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+
+        self.assertTrue(result)
+        upd.assert_called_once_with(97, "pending_approval")
+        # Reviewer is notified the video file could not be delivered.
+        notice_sent = any("Không gửi được FILE VIDEO" in c.args[0]
+                          for c in send_text.call_args_list)
+        self.assertTrue(notice_sent)
+
+    def test_video_upload_succeeds_sets_pending_no_notice(self):
+        with patch.object(tb, "get_video", return_value=_video()), \
+             patch.object(tb, "_send_text", return_value=True) as send_text, \
+             patch.object(tb, "_send_video_file", return_value="555") as sendvid, \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+
+        self.assertTrue(result)
+        upd.assert_called_once_with(97, "pending_approval")
+        sendvid.assert_called_once()
+        # No failure notice when the video went through.
+        self.assertFalse(any("Không gửi được FILE VIDEO" in c.args[0]
+                             for c in send_text.call_args_list))
+
+    def test_no_script_but_video_sent_sets_pending(self):
+        with patch.object(tb, "get_video", return_value=_video(script_text="")), \
+             patch.object(tb, "_send_text", return_value=True), \
+             patch.object(tb, "_send_video_file", return_value="555"), \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+
+        self.assertTrue(result)
+        upd.assert_called_once_with(97, "pending_approval")
+
+    def test_both_fail_stays_ready_returns_false(self):
+        """If neither artifact reaches the reviewer, do NOT mark pending."""
+        with patch.object(tb, "get_video", return_value=_video()), \
+             patch.object(tb, "_send_text", return_value=False), \
+             patch.object(tb, "_send_video_file", return_value=None), \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+
+        self.assertFalse(result)
+        upd.assert_not_called()
+
+    def test_missing_video_returns_false(self):
+        with patch.object(tb, "get_video", return_value=None), \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+        self.assertFalse(result)
+        upd.assert_not_called()
+
+    def test_missing_file_returns_false_stays_ready(self):
+        self.p_exists.stop()  # make os.path.exists return real (False) for /tmp path
+        with patch.object(tb.os.path, "exists", return_value=False), \
+             patch.object(tb, "get_video", return_value=_video()), \
+             patch.object(tb, "update_video_status") as upd:
+            result = tb.send_video_for_approval(97)
+        self.assertFalse(result)
+        upd.assert_not_called()
+
+
+class TestSendVideoFileSizeGuard(unittest.TestCase):
+    @patch.object(tb, "config")
+    def test_oversized_file_skipped(self, cfg):
+        cfg.TELEGRAM_BOT_TOKEN = "token"
+        cfg.TELEGRAM_CHAT_ID = "123"
+        with patch.object(tb.os.path, "getsize",
+                          return_value=tb.TELEGRAM_MAX_FILE_BYTES + 1), \
+             patch.object(tb, "urlopen") as urlopen:
+            result = tb._send_video_file("/tmp/big.mp4", "caption")
+        self.assertIsNone(result)
+        urlopen.assert_not_called()  # never attempted the doomed upload
+
+    @patch.object(tb, "config")
+    def test_unstattable_file_returns_none(self, cfg):
+        cfg.TELEGRAM_BOT_TOKEN = "token"
+        cfg.TELEGRAM_CHAT_ID = "123"
+        with patch.object(tb.os.path, "getsize", side_effect=OSError("nope")), \
+             patch.object(tb, "urlopen") as urlopen:
+            result = tb._send_video_file("/tmp/gone.mp4", "caption")
+        self.assertIsNone(result)
+        urlopen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_tts_client.py
+++ b/content-pipeline/tests/test_tts_client.py
@@ -5,10 +5,12 @@ any network calls.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import ssl
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
@@ -138,6 +140,149 @@ class TestRetryTransientHttp(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(opener.open.call_count, 3)   # all attempts used
         self.assertEqual(sleep.call_count, 2)         # backoff between attempts
+
+
+class _FakeResp:
+    """Minimal context-manager HTTP response."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeOpener:
+    """Dispatch opener.open() by URL substring to queued bytes/exceptions.
+
+    routes maps a URL substring to a list of items; each call to open() consumes
+    the next item (the last item repeats once the queue is down to one), so a
+    route can model a status that progresses processing -> done.
+    """
+
+    def __init__(self, routes):
+        self.routes = {k: list(v) for k, v in routes.items()}
+        self.calls = []  # full URLs opened, in order
+
+    def open(self, req, timeout=None):
+        url = req.full_url
+        self.calls.append(url)
+        for sub, seq in self.routes.items():
+            if sub in url:
+                item = seq.pop(0) if len(seq) > 1 else seq[0]
+                if isinstance(item, Exception):
+                    raise item
+                return _FakeResp(item)
+        raise AssertionError(f"no fake route for {url}")
+
+    def count(self, sub):
+        return sum(1 for u in self.calls if sub in u)
+
+
+def _json(obj):
+    return json.dumps(obj).encode("utf-8")
+
+
+class _AsyncFlowBase(unittest.TestCase):
+    """Common config patching for the async job-flow tests."""
+
+    def setUp(self):
+        self.cfg = patch.multiple(
+            tts.config,
+            TTS_API_URL="http://tts.nuitruc.ai/api/tts",
+            TTS_API_KEY="",
+            TTS_VOICE_ID="voice8",
+            TTS_VOICE_SPEED=1.0,
+            TTS_ALLOW_INSECURE_SSL=False,
+        )
+        self.cfg.start()
+        self.addCleanup(self.cfg.stop)
+        # Never sleep for real in poll/backoff loops.
+        self.sleep = patch.object(tts.time, "sleep").start()
+        self.addCleanup(patch.stopall)
+        self.out = tempfile.NamedTemporaryFile(suffix=".wav", delete=False).name
+        self.addCleanup(lambda: os.path.exists(self.out) and os.remove(self.out))
+
+    def _run(self, opener):
+        with patch.object(tts, "_build_opener", return_value=opener):
+            return tts._tts_single("xin chào thế giới", self.out)
+
+
+class TestAsyncHappyPath(_AsyncFlowBase):
+    def test_submit_poll_result(self):
+        opener = _FakeOpener({
+            "/submit": [_json({"job_id": "abc"})],
+            "/status/abc": [_json({"status": "processing"}),
+                            _json({"status": "done"})],
+            "/result/abc": [b"WAVDATA"],
+        })
+        result = self._run(opener)
+        self.assertEqual(result, self.out)
+        with open(self.out, "rb") as f:
+            self.assertEqual(f.read(), b"WAVDATA")
+        # /result fetched exactly once (one-shot job).
+        self.assertEqual(opener.count("/result/abc"), 1)
+        # Polled status at least twice (processing then done).
+        self.assertGreaterEqual(opener.count("/status/abc"), 2)
+
+
+class TestAsyncFailureModes(_AsyncFlowBase):
+    def test_status_error_fails_over_without_fetching_result(self):
+        opener = _FakeOpener({
+            "/submit": [_json({"job_id": "abc"})],
+            "/status/abc": [_json({"status": "error"})],
+            "/result/abc": [b"SHOULD-NOT-FETCH"],
+        })
+        result = self._run(opener)
+        self.assertIsNone(result)
+        self.assertEqual(opener.count("/result/abc"), 0)
+
+    def test_poll_timeout_fails_over(self):
+        with patch.object(tts, "TTS_POLL_TIMEOUT", -1):  # deadline already past
+            opener = _FakeOpener({
+                "/submit": [_json({"job_id": "abc"})],
+                "/status/abc": [_json({"status": "processing"})],
+                "/result/abc": [b"NOPE"],
+            })
+            result = self._run(opener)
+        self.assertIsNone(result)
+        self.assertEqual(opener.count("/result/abc"), 0)
+
+    def test_status_max_failures_fails_over(self):
+        with patch.object(tts, "TTS_POLL_MAX_FAILURES", 2), \
+             patch.object(tts, "TTS_MAX_RETRIES", 1):
+            opener = _FakeOpener({
+                "/submit": [_json({"job_id": "abc"})],
+                "/status/abc": [OSError("boom")],  # every poll fails
+                "/result/abc": [b"NOPE"],
+            })
+            result = self._run(opener)
+        self.assertIsNone(result)
+        self.assertEqual(opener.count("/status/abc"), 2)  # capped
+        self.assertEqual(opener.count("/result/abc"), 0)
+
+    def test_submit_without_job_id_fails(self):
+        opener = _FakeOpener({"/submit": [_json({"detail": "nope"})]})
+        result = self._run(opener)
+        self.assertIsNone(result)
+        self.assertEqual(opener.count("/status"), 0)
+
+
+class TestEndpointBuilder(unittest.TestCase):
+    def test_builds_suburls(self):
+        with patch.object(tts.config, "TTS_API_URL", "http://x/api/tts"):
+            self.assertEqual(tts._endpoint("submit"), "http://x/api/tts/submit")
+            self.assertEqual(tts._endpoint("status/7"), "http://x/api/tts/status/7")
+
+    def test_tolerates_trailing_slash(self):
+        with patch.object(tts.config, "TTS_API_URL", "http://x/api/tts/"):
+            self.assertEqual(tts._endpoint("result/7"), "http://x/api/tts/result/7")
 
 
 if __name__ == "__main__":

--- a/content-pipeline/video/tts/nuitruc.py
+++ b/content-pipeline/video/tts/nuitruc.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 """Núi Trúc TTS provider (P2) — wraps the existing tts_client HTTP logic.
 
-This is the legacy/default provider. It delegates to tts_client._tts_single so
-the secure SSL handling (P0) and retry logic stay in one place.
+This is the default provider. It delegates to tts_client._tts_single, which now
+drives the async job API (submit -> poll /status -> download /result) so long
+scripts no longer time out, while the secure SSL handling (P0), retry logic and
+fail-fast bounds (issue #58) stay in one place.
 """
 
 import logging

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 """
-TTS Client — Wrapper cho Núi Trúc TTS API.
+TTS Client — Wrapper cho Núi Trúc TTS API (async job flow).
 
-API: http://tts.nuitruc.ai/api/tts
-- POST JSON: {"text": "...", "voice_id": "voice1", "speed": 1.0}
-- Output: WAV (Content-Type: audio/wav)
-- Timeout: config.TTS_TIMEOUT (default 120s) — fail fast on a stalled endpoint so
-  the provider fallback chain (video.tts.factory) can take over (issue #58).
+Base URL: config.TTS_API_URL (default http://tts.nuitruc.ai/api/tts)
+
+Long scripts no longer fit the old synchronous POST /api/tts (it timed out), so
+the client uses the async job API derived from the same base URL:
+
+  1. POST {base}/submit        {"text", "voice_id", "speed"} -> {"job_id": ...}
+  2. GET  {base}/status/<id>   poll every TTS_POLL_INTERVAL s until "done"/"error"
+  3. GET  {base}/result/<id>   download the WAV (one-shot; 404 on a 2nd call)
+
+All steps are bounded (TTS_REQUEST_TIMEOUT per request, TTS_POLL_TIMEOUT overall,
+TTS_POLL_MAX_FAILURES consecutive poll errors) so a stalled/never-finishing job
+fails fast and the provider fallback chain (video.tts.factory) takes over
+instead of stalling the cron window (issue #58).
 """
 
 import json
@@ -27,9 +35,14 @@ logger = logging.getLogger(__name__)
 
 # HTTP tuning lives in config (env-overridable). Bound here as module globals so
 # tests can patch them and the retry loop reads a single source of truth.
-TTS_TIMEOUT = config.TTS_TIMEOUT        # per-request socket timeout (s)
+TTS_TIMEOUT = config.TTS_TIMEOUT        # result-download socket timeout (s)
 TTS_MAX_RETRIES = config.TTS_MAX_RETRIES  # retries for fast transient HTTP errors
 TTS_RETRY_DELAY = config.TTS_RETRY_DELAY  # initial backoff (s), exponential
+# Async job-flow knobs (mirrored as module globals so tests can patch them).
+TTS_REQUEST_TIMEOUT = config.TTS_REQUEST_TIMEOUT  # submit/status socket timeout (s)
+TTS_POLL_INTERVAL = config.TTS_POLL_INTERVAL      # seconds between status polls
+TTS_POLL_TIMEOUT = config.TTS_POLL_TIMEOUT        # max total wait for a job (s)
+TTS_POLL_MAX_FAILURES = config.TTS_POLL_MAX_FAILURES  # consecutive poll errors before failover
 
 
 def text_to_speech(text: str, output_path: str) -> str | None:
@@ -107,64 +120,156 @@ def _is_timeout(exc: Exception | None) -> bool:
     return False
 
 
-def _tts_single(text: str, output_path: str) -> str | None:
-    """Call the TTS API for one text chunk.
+def _endpoint(path: str) -> str:
+    """Build an async-API sub-endpoint URL from the configured TTS base URL.
 
-    Retries only fast transient HTTP errors (429/5xx) with exponential backoff;
-    timeouts and SSL errors fail fast so the provider fallback chain can take
-    over (issue #58). Returns the output path on success, else None.
+    ``config.TTS_API_URL`` is the base (default http://tts.nuitruc.ai/api/tts);
+    the job API exposes ``/submit``, ``/status/<id>`` and ``/result/<id>`` under
+    it. A trailing slash on the base is tolerated.
     """
-    payload = json.dumps({
-        "text": text,
-        "voice_id": config.TTS_VOICE_ID or "voice1",
-        "speed": config.TTS_VOICE_SPEED,
-    }).encode("utf-8")
+    base = (config.TTS_API_URL or "").rstrip("/")
+    return f"{base}/{path.lstrip('/')}"
 
+
+def _headers() -> dict:
+    """Common request headers (adds bearer auth when TTS_API_KEY is set)."""
     headers = {"Content-Type": "application/json"}
     if config.TTS_API_KEY:
         headers["Authorization"] = f"Bearer {config.TTS_API_KEY}"
+    return headers
 
-    url = config.TTS_API_URL
 
-    # Build opener with a verifying SSL context (secure by default) that also
-    # applies to HTTP→HTTPS redirects. Verification is only disabled when
-    # TTS_ALLOW_INSECURE_SSL is explicitly set.
-    opener = _build_opener()
+def _open_with_retry(opener, url: str, *, data: bytes | None, timeout: int,
+                     what: str) -> bytes | None:
+    """Run one HTTP request through the shared retry / fail-fast loop.
 
+    Retries only fast transient HTTP errors (429/5xx) with exponential backoff;
+    timeouts, SSL and other errors fail fast so the provider fallback chain can
+    take over (issue #58). Returns the raw response body on success, else None.
+    Errors are logged without leaking the Authorization header.
+    """
     last_exc: Exception | None = None
     for attempt in range(1, TTS_MAX_RETRIES + 1):
         try:
-            req = Request(url, data=payload, headers=headers)
-            with opener.open(req, timeout=TTS_TIMEOUT) as resp:
-                with open(output_path, "wb") as f:
-                    f.write(resp.read())
-
-            size_kb = os.path.getsize(output_path) / 1024
-            logger.info("TTS chunk saved: %s (%.1f KB)", output_path, size_kb)
-            return output_path
-
+            req = Request(url, data=data, headers=_headers())
+            with opener.open(req, timeout=timeout) as resp:
+                return resp.read()
         except (ssl.SSLError, URLError, HTTPError, OSError) as e:
             last_exc = e
             if _is_retryable(e) and attempt < TTS_MAX_RETRIES:
                 wait = TTS_RETRY_DELAY * (2 ** (attempt - 1))
-                logger.warning("TTS attempt %d/%d failed (%s), retrying in %ds...",
-                               attempt, TTS_MAX_RETRIES, e, wait)
+                logger.warning("TTS %s attempt %d/%d failed (%s), retrying in %ds...",
+                               what, attempt, TTS_MAX_RETRIES, e, wait)
                 time.sleep(wait)
                 continue
-            # Timeout / SSL / non-retryable error — fail fast so the factory can
-            # fall back to the next provider instead of stalling the cron window.
             break
-
         except Exception as e:
             last_exc = e
             break
 
     if _is_timeout(last_exc):
-        logger.error("TTS endpoint timed out after %ds (%s) — failing over to "
-                     "next provider", TTS_TIMEOUT, config.TTS_API_URL)
+        logger.error("TTS %s timed out after %ds — failing over to next provider",
+                     what, timeout)
     else:
-        logger.error("TTS API failed: %s", last_exc)
+        logger.error("TTS %s failed: %s", what, last_exc)
     return None
+
+
+def _submit_job(opener, text: str) -> str | None:
+    """POST /submit and return the job id, or None on failure."""
+    payload = json.dumps({
+        "text": text,
+        "voice_id": config.TTS_VOICE_ID or "voice1",
+        "speed": config.TTS_VOICE_SPEED,
+    }).encode("utf-8")
+    body = _open_with_retry(opener, _endpoint("submit"), data=payload,
+                            timeout=TTS_REQUEST_TIMEOUT, what="submit")
+    if body is None:
+        return None
+    try:
+        data = json.loads(body)
+        job_id = data.get("job_id") or data.get("id")
+    except (ValueError, AttributeError):
+        job_id = None
+    if not job_id:
+        logger.error("TTS submit returned no job_id (body: %.200r)", body)
+        return None
+    logger.info("TTS job submitted: %s", job_id)
+    return str(job_id)
+
+
+def _await_job(opener, job_id: str) -> bool:
+    """Poll /status until the job is done. Return True on success, else False.
+
+    Bounded by TTS_POLL_TIMEOUT overall and TTS_POLL_MAX_FAILURES consecutive
+    poll errors, so a stalled status endpoint fails over fast (issue #58).
+    """
+    deadline = time.monotonic() + TTS_POLL_TIMEOUT
+    consecutive_failures = 0
+    while True:
+        body = _open_with_retry(opener, _endpoint(f"status/{job_id}"), data=None,
+                                timeout=TTS_REQUEST_TIMEOUT, what="status")
+        if body is None:
+            consecutive_failures += 1
+            if consecutive_failures >= TTS_POLL_MAX_FAILURES:
+                logger.error("TTS status polling failed %d× for job %s — failing over",
+                             consecutive_failures, job_id)
+                return False
+        else:
+            consecutive_failures = 0
+            try:
+                status = json.loads(body).get("status")
+            except (ValueError, AttributeError):
+                status = None
+            if status == "done":
+                return True
+            if status == "error":
+                logger.error("TTS job %s reported status=error — failing over", job_id)
+                return False
+            logger.debug("TTS job %s status=%s — still polling", job_id, status)
+
+        if time.monotonic() >= deadline:
+            logger.error("TTS job %s not done within %ds — failing over to next provider",
+                         job_id, TTS_POLL_TIMEOUT)
+            return False
+        time.sleep(TTS_POLL_INTERVAL)
+
+
+def _tts_single(text: str, output_path: str) -> str | None:
+    """Synthesize one text chunk via the Núi Trúc async job API.
+
+    submit -> poll /status -> download /result (one-shot). Returns the output
+    path on success, else None so the factory can fall back to the next provider.
+    The /result download is fetched into memory then written, and is retried only
+    on transient 5xx (which means it was NOT delivered, so the one-shot job is not
+    yet consumed) — never after a successful 200.
+    """
+    # Secure-by-default opener (verifies TLS unless TTS_ALLOW_INSECURE_SSL).
+    opener = _build_opener()
+
+    job_id = _submit_job(opener, text)
+    if not job_id:
+        return None
+
+    if not _await_job(opener, job_id):
+        return None
+
+    body = _open_with_retry(opener, _endpoint(f"result/{job_id}"), data=None,
+                            timeout=TTS_TIMEOUT, what="result")
+    if body is None:
+        logger.error("TTS result download failed for job %s", job_id)
+        return None
+
+    try:
+        with open(output_path, "wb") as f:
+            f.write(body)
+    except OSError as e:
+        logger.error("Failed to write TTS audio to %s: %s", output_path, e)
+        return None
+
+    size_kb = os.path.getsize(output_path) / 1024
+    logger.info("TTS chunk saved: %s (%.1f KB) [job %s]", output_path, size_kb, job_id)
+    return output_path
 
 
 def get_audio_duration(audio_path: str) -> float:


### PR DESCRIPTION
PR này gồm **2 thay đổi**.

---

## 1. fix(telegram): không kẹt video ở `status=ready` khi gửi file thất bại (#60)

**Vấn đề:** `send_video_for_approval` gắn việc chuyển `ready → pending_approval` vào **thành công của bước gửi file video**. Telegram giới hạn upload qua bot là **50MB**, nên khi file quá lớn / Broken pipe, `msg_id = None` → `update_video_status(..., "pending_approval")` không bao giờ chạy → video kẹt ở `ready` → `/approve_<id>` báo *"không ở trạng thái chờ duyệt"*. Web UI (cũng đọc `pending_approval`) cũng không thấy.

**Root cause:** Script text mới là **bản duyệt chính**; bước gửi file video chỉ phụ và hay lỗi nhưng lại đang quyết định trạng thái — coupling sai.

**Cách sửa:**
- ✅ Set `pending_approval` khi **script HOẶC video** đã tới tay người duyệt.
- ✅ Chỉ giữ `ready` + trả `False` khi **cả hai** đều fail → vẫn retry được, không đánh dấu "chờ duyệt" giả.
- ✅ **UI/UX:** video gửi lỗi nhưng script ok → bot gửi thông báo rõ ràng kèm lệnh approve/reject.
- ✅ **Performance:** kiểm tra dung lượng vs giới hạn 50MB ngay trong `_send_video_file`, bỏ qua request chắc chắn fail (đọc cả file vào RAM rồi block ~120s).

Closes #60

---

## 2. feat(tts): Núi Trúc async job API cho script dài (submit → poll → result)

**Vấn đề:** `POST /api/tts` đồng bộ trả WAV trong 1 request → **timeout với script dài**.

**Cách sửa:** nuitruc dùng API bất đồng bộ suy ra từ chính `TTS_API_URL`:
1. `POST {base}/submit` → `{"job_id": ...}`
2. poll `GET {base}/status/<id>` mỗi `TTS_POLL_INTERVAL`s đến khi `done`/`error`
3. `GET {base}/result/<id>` tải WAV **một lần** (gọi lần 2 ra 404 — bình thường)

**Consistency / Performance / Security:**
- Toàn bộ HTTP nuitruc vẫn ở `tts_client.py`; tái dùng `_build_opener` (SSL an toàn mặc định), `_is_retryable`, `_is_timeout` qua vòng lặp chung `_open_with_retry`.
- Endpoint con suy ra từ `TTS_API_URL` → không đổi config URL.
- Giữ tinh thần fail-fast của #58: `TTS_REQUEST_TIMEOUT` (submit/status), `TTS_POLL_TIMEOUT` (tổng), `TTS_POLL_MAX_FAILURES` (số lần poll lỗi liên tiếp) — job treo sẽ fallback sang `edge` thay vì kẹt cron.
- `/result` tải vào RAM rồi ghi file; chỉ retry khi 5xx transient (chưa giao → job one-shot chưa bị tiêu) — **không** retry sau khi đã 200.

---

## Test

- `tests/test_telegram_approval.py` (mới): 4 kịch bản gửi + guard dung lượng file.
- `tests/test_tts_client.py`: thêm test async flow (happy path, status=error, poll timeout, cap lỗi poll liên tiếp, thiếu job_id, endpoint builder). Test SSL/retry/timeout/no-secret-logging cũ vẫn pass nguyên.
- **Toàn bộ 208 test pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)