### PR TITLE
Per-format subtitles: burn short, upload caption track for long

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,13 @@ Các flag bật/tắt nâng cấp video, mặc định = hành vi cũ (xem
 | `TTS_PROVIDER` | `nuitruc` | `nuitruc` (cũ) \| `edge` (P2) |
 | `COMPOSER_ENGINE` | `ffmpeg` | `ffmpeg` (default) \| `moviepy` (P2) |
 | `ENABLE_BGM` | `0` | `1` để trộn nhạc nền (P1) |
+| `BURN_SUBTITLES` | `all` | `all` \| `short_only` (chỉ nung sub cho short, long upload caption track) \| `none` |
 | `TTS_ALLOW_INSECURE_SSL` | `0` | **Security:** chỉ bật cho endpoint TLS tự ký tin cậy; mặc định verify cert |
+
+**Phụ đề theo định dạng:** với `BURN_SUBTITLES=short_only`, video **short** được nung
+phụ đề (xem tắt tiếng trên TikTok/Shorts), còn video **long** không nung mà upload
+SRT làm **caption track** lên YouTube (`captions.insert`, người xem bật/tắt). Nên
+dùng kèm `SUBTITLE_TIMING_MODE=whisper` để timing bám audio.
 
 `config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
 fallback về hành vi cũ.

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -32,6 +32,10 @@ EDGE_VOICE=vi-VN-HoaiMyNeural
 COMPOSER_ENGINE=ffmpeg
 # Background music under narration: 1 to enable (P1)
 ENABLE_BGM=0
+# Subtitle burn-in policy: all (legacy) | short_only | none
+# Recommended: short_only — burn into short (TikTok/Shorts, watched sound-off),
+# and upload an SRT caption track to YouTube for long videos instead.
+BURN_SUBTITLES=all
 # SECURITY: set to 1 ONLY for a trusted self-signed TTS endpoint. Default 0
 # keeps TLS certificate verification ON. Enabling it exposes the call to MITM.
 TTS_ALLOW_INSECURE_SSL=0

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -82,6 +82,12 @@ EDGE_VOICE = os.getenv("EDGE_VOICE", "vi-VN-HoaiMyNeural")  # or vi-VN-NamMinhNe
 COMPOSER_ENGINE = os.getenv("COMPOSER_ENGINE", "ffmpeg")
 # ENABLE_BGM: mix royalty-free background music under narration (P1)
 ENABLE_BGM = os.getenv("ENABLE_BGM", "0") == "1"
+# BURN_SUBTITLES: which video types get hard-burned subtitles.
+#   all (legacy)  — burn into every video
+#   short_only    — burn only short (TikTok/Shorts, watched sound-off); long
+#                   videos skip burn-in and upload an SRT caption track to YouTube
+#   none          — never burn (rely on caption tracks / platform CC)
+BURN_SUBTITLES = os.getenv("BURN_SUBTITLES", "all")
 # TTS_ALLOW_INSECURE_SSL: disable TLS verification for the TTS endpoint.
 # SECURITY: only enable for a known self-signed endpoint you trust. Default OFF.
 TTS_ALLOW_INSECURE_SSL = os.getenv("TTS_ALLOW_INSECURE_SSL", "0") == "1"
@@ -100,7 +106,21 @@ _FLAG_CHOICES = {
     "BACKGROUND_MODE": {"single", "multi"},
     "TTS_PROVIDER": {"nuitruc", "edge"},
     "COMPOSER_ENGINE": {"ffmpeg", "moviepy"},
+    "BURN_SUBTITLES": {"all", "short_only", "none"},
 }
+
+
+def should_burn_subtitles(video_type: str) -> bool:
+    """Whether to hard-burn subtitles for this video type (per BURN_SUBTITLES).
+
+    Unknown values fall back to legacy "all" (burn everything).
+    """
+    mode = BURN_SUBTITLES
+    if mode == "none":
+        return False
+    if mode == "short_only":
+        return video_type == "short"
+    return True
 
 
 def validate_flags(logger=None):
@@ -116,6 +136,7 @@ def validate_flags(logger=None):
         "BACKGROUND_MODE": BACKGROUND_MODE,
         "TTS_PROVIDER": TTS_PROVIDER,
         "COMPOSER_ENGINE": COMPOSER_ENGINE,
+        "BURN_SUBTITLES": BURN_SUBTITLES,
     }
     for name, value in current.items():
         allowed = _FLAG_CHOICES[name]

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -331,17 +331,24 @@ def _create_video(narrative: str, video_type: str, date_str: str,
             logger.warning("No background found — compose_video will use default")
 
     video_path = os.path.join(base_dir, f"video_{video_id}.mp4")
+    # Subtitle policy: burn in only for video types selected by BURN_SUBTITLES.
+    # The SRT is still generated/stored above so long videos can upload it as a
+    # YouTube caption track at publish time instead of burning it in.
+    burn = config.should_burn_subtitles(video_type)
+    burn_srt = srt_path if burn else None
+    if not burn:
+        logger.info("Burn-in disabled for %s video — will use caption track", video_type)
     # Composer engine selector (P2): MoviePy optional, FFmpeg default.
     if config.COMPOSER_ENGINE == "moviepy":
         from video.composer_moviepy import compose as compose_fn
     else:
         compose_fn = compose_video
-    result = compose_fn(audio_path, srt_path, video_path,
+    result = compose_fn(audio_path, burn_srt, video_path,
                         video_type=video_type, bg_video=bg_video,
                         bg_videos=bg_videos)
     if not result and config.COMPOSER_ENGINE == "moviepy":
         logger.warning("MoviePy compose failed — falling back to ffmpeg engine")
-        result = compose_video(audio_path, srt_path, video_path,
+        result = compose_video(audio_path, burn_srt, video_path,
                                video_type=video_type, bg_video=bg_video,
                                bg_videos=bg_videos)
     if not result:
@@ -425,13 +432,20 @@ def _publish_to_platform(video: dict, platform: str) -> str | None:
     video_path = video["video_path"]
 
     if platform == "youtube":
-        from publisher.youtube_uploader import upload_video
-        return upload_video(
+        from publisher.youtube_uploader import upload_video, upload_caption
+        url = upload_video(
             video_path,
             title=video.get("youtube_title", "AI 5 Phút Mỗi Ngày"),
             description=video.get("youtube_description", ""),
             is_short=False,
         )
+        # When subtitles weren't burned into this (long) video, attach the SRT
+        # as a viewer-toggleable caption track instead.
+        if url and not config.should_burn_subtitles(video.get("video_type", "long")):
+            srt = video.get("subtitle_path")
+            if srt and os.path.exists(srt):
+                upload_caption(url, srt)
+        return url
     elif platform == "youtube_shorts":
         from publisher.youtube_uploader import upload_video
         return upload_video(

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -60,7 +60,7 @@ import config
 from storage.database import (
     init_db, get_top_analyzed_articles, insert_video,
     update_video_paths, update_video_status, get_video,
-    update_video_publish_url,
+    update_video_publish_url, set_video_subtitles_burned,
 )
 from collectors.rss_collector import collect_all_feeds
 from collectors.twitter_collector import collect_all_twitter
@@ -355,9 +355,11 @@ def _create_video(narrative: str, video_type: str, date_str: str,
         logger.error("Video composition failed for video %d", video_id)
         return None
 
-    # Update paths in DB
+    # Update paths in DB. Persist the burn decision made at render time so
+    # publish-time caption logic doesn't depend on the current BURN_SUBTITLES.
     update_video_paths(video_id, audio_path=audio_path,
                        subtitle_path=srt_path, video_path=video_path)
+    set_video_subtitles_burned(video_id, burn)
     update_video_status(video_id, "ready")
 
     # Step 6: Send for approval via Telegram
@@ -439,12 +441,32 @@ def _publish_to_platform(video: dict, platform: str) -> str | None:
             description=video.get("youtube_description", ""),
             is_short=False,
         )
-        # When subtitles weren't burned into this (long) video, attach the SRT
-        # as a viewer-toggleable caption track instead.
-        if url and not config.should_burn_subtitles(video.get("video_type", "long")):
+        if not url:
+            return None
+
+        # Use the burn decision recorded at render time; only fall back to the
+        # current config for legacy rows that predate the persisted flag.
+        burned_flag = video.get("subtitles_burned")
+        if burned_flag is None:
+            burned = config.should_burn_subtitles(video.get("video_type", "long"))
+        else:
+            burned = bool(burned_flag)
+
+        # No burned-in subtitles → the caption track IS the subtitles, so a
+        # failed/absent upload means the public video would have none. Treat
+        # that as a publish failure so it's surfaced instead of silently
+        # shipping an uncaptioned video.
+        if not burned:
             srt = video.get("subtitle_path")
-            if srt and os.path.exists(srt):
-                upload_caption(url, srt)
+            if not srt or not os.path.exists(srt):
+                logger.error("Video %d has no SRT for its caption track — "
+                             "publish flagged as failed", video["id"])
+                return None
+            if not upload_caption(url, srt):
+                logger.error("Caption upload failed for no-burn video %d "
+                             "(uploaded at %s) — publish flagged as failed",
+                             video["id"], url)
+                return None
         return url
     elif platform == "youtube_shorts":
         from publisher.youtube_uploader import upload_video

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -38,6 +38,11 @@ def _video_id_from_url(url_or_id: str) -> str:
     return s  # already a bare id
 
 
+def _has_required_scopes(granted) -> bool:
+    """True if all scopes in SCOPES were granted to the saved token."""
+    return set(SCOPES).issubset(set(granted or []))
+
+
 def _get_authenticated_service():
     """Build authenticated YouTube API service."""
     from google.oauth2.credentials import Credentials
@@ -49,6 +54,15 @@ def _get_authenticated_service():
 
     if os.path.exists(token_file):
         creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+        # A token minted before youtube.force-ssl was added only has
+        # youtube.upload; refreshing keeps the old scopes, so caption upload
+        # would fail. Force a full re-auth when required scopes are missing.
+        if creds and not _has_required_scopes(getattr(creds, "scopes", None)):
+            logger.warning(
+                "Saved YouTube token is missing required scopes (need %s) — "
+                "re-authenticating to grant caption-upload permission.", SCOPES,
+            )
+            creds = None
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -19,7 +19,23 @@ import config
 
 logger = logging.getLogger(__name__)
 
-SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    # Required for captions().insert (uploading a caption/subtitle track).
+    "https://www.googleapis.com/auth/youtube.force-ssl",
+]
+
+
+def _video_id_from_url(url_or_id: str) -> str:
+    """Extract the YouTube video id from a youtu.be/watch URL or raw id."""
+    if not url_or_id:
+        return ""
+    s = url_or_id.strip()
+    if "youtu.be/" in s:
+        return s.rsplit("youtu.be/", 1)[1].split("?")[0].split("/")[0]
+    if "watch?v=" in s:
+        return s.split("watch?v=", 1)[1].split("&")[0]
+    return s  # already a bare id
 
 
 def _get_authenticated_service():
@@ -115,6 +131,50 @@ def upload_video(video_path: str, title: str, description: str,
     except Exception as e:
         logger.error("YouTube upload failed: %s", e)
         return None
+
+
+def upload_caption(video_url_or_id: str, srt_path: str,
+                   language: str = "vi", name: str = "Tiếng Việt") -> bool:
+    """Upload an SRT file as a caption track for an existing YouTube video.
+
+    Lets long videos ship accurate, viewer-toggleable captions (the script text
+    we control) instead of burning subtitles into the frame. Returns True on
+    success.
+    """
+    video_id = _video_id_from_url(video_url_or_id)
+    if not video_id:
+        logger.error("upload_caption: could not resolve video id from %r", video_url_or_id)
+        return False
+    if not srt_path or not os.path.exists(srt_path):
+        logger.error("upload_caption: SRT not found: %s", srt_path)
+        return False
+
+    from googleapiclient.http import MediaFileUpload
+
+    service = _get_authenticated_service()
+    if not service:
+        return False
+
+    try:
+        media = MediaFileUpload(srt_path, mimetype="application/octet-stream",
+                                resumable=False)
+        service.captions().insert(
+            part="snippet",
+            body={
+                "snippet": {
+                    "videoId": video_id,
+                    "language": language,
+                    "name": name,
+                    "isDraft": False,
+                }
+            },
+            media_body=media,
+        ).execute()
+        logger.info("Caption track uploaded for video %s (%s)", video_id, language)
+        return True
+    except Exception as e:
+        logger.error("Caption upload failed for %s: %s", video_id, e)
+        return False
 
 
 if __name__ == "__main__":

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -63,9 +63,15 @@ def init_db():
                 approved_at TIMESTAMP,
                 published_at TIMESTAMP,
                 publish_url TEXT,
+                subtitles_burned INTEGER,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
+        # Migration: add subtitles_burned to pre-existing DBs (NULL = unknown,
+        # so legacy rows fall back to config inference at publish time).
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(videos)")}
+        if "subtitles_burned" not in cols:
+            conn.execute("ALTER TABLE videos ADD COLUMN subtitles_burned INTEGER")
         # Indexes for frequently queried columns
         conn.execute("CREATE INDEX IF NOT EXISTS idx_articles_status ON articles(status)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_articles_ai_score ON articles(ai_score)")
@@ -391,6 +397,21 @@ def update_video_publish_url(video_id: int, url: str):
     conn = get_connection()
     try:
         conn.execute("UPDATE videos SET publish_url = ? WHERE id = ?", (url, video_id))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def set_video_subtitles_burned(video_id: int, burned: bool):
+    """Record whether subtitles were hard-burned into this video at render time.
+
+    Persisted so publish-time logic (caption-track upload) uses the decision made
+    when the MP4 was rendered, not whatever BURN_SUBTITLES happens to be later.
+    """
+    conn = get_connection()
+    try:
+        conn.execute("UPDATE videos SET subtitles_burned = ? WHERE id = ?",
+                     (1 if burned else 0, video_id))
         conn.commit()
     finally:
         conn.close()

--- a/content-pipeline/tests/test_config_flags.py
+++ b/content-pipeline/tests/test_config_flags.py
@@ -5,6 +5,7 @@ import importlib
 import os
 import sys
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -18,7 +19,8 @@ class TestFlagDefaults(unittest.TestCase):
         # Reload config with a clean env so defaults are deterministic.
         self._saved = {}
         for key in ("SUBTITLE_TIMING_MODE", "BACKGROUND_MODE", "TTS_PROVIDER",
-                    "COMPOSER_ENGINE", "ENABLE_BGM", "TTS_ALLOW_INSECURE_SSL"):
+                    "COMPOSER_ENGINE", "ENABLE_BGM", "TTS_ALLOW_INSECURE_SSL",
+                    "BURN_SUBTITLES"):
             self._saved[key] = os.environ.pop(key, None)
         importlib.reload(config)
 
@@ -47,6 +49,33 @@ class TestFlagDefaults(unittest.TestCase):
 
     def test_insecure_ssl_default_off(self):
         self.assertFalse(config.TTS_ALLOW_INSECURE_SSL)
+
+    def test_burn_subtitles_default_all(self):
+        self.assertEqual(config.BURN_SUBTITLES, "all")
+
+
+class TestShouldBurnSubtitles(unittest.TestCase):
+    def _with_mode(self, mode):
+        return patch.object(config, "BURN_SUBTITLES", mode)
+
+    def test_all_burns_both(self):
+        with self._with_mode("all"):
+            self.assertTrue(config.should_burn_subtitles("short"))
+            self.assertTrue(config.should_burn_subtitles("long"))
+
+    def test_short_only(self):
+        with self._with_mode("short_only"):
+            self.assertTrue(config.should_burn_subtitles("short"))
+            self.assertFalse(config.should_burn_subtitles("long"))
+
+    def test_none_burns_nothing(self):
+        with self._with_mode("none"):
+            self.assertFalse(config.should_burn_subtitles("short"))
+            self.assertFalse(config.should_burn_subtitles("long"))
+
+    def test_unknown_falls_back_to_all(self):
+        with self._with_mode("bogus"):
+            self.assertTrue(config.should_burn_subtitles("long"))
 
 
 class TestValidateFlags(unittest.TestCase):

--- a/content-pipeline/tests/test_database_video_flags.py
+++ b/content-pipeline/tests/test_database_video_flags.py
@@ -1,0 +1,55 @@
+"""Tests for the persisted subtitles_burned flag on videos (DB roundtrip)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+
+
+class TestSubtitlesBurnedFlag(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        self.vid = db.insert_video("long", "Một script thử nghiệm.")
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_column_exists(self):
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(videos)")}
+        finally:
+            conn.close()
+        self.assertIn("subtitles_burned", cols)
+
+    def test_default_is_none(self):
+        # NULL = unknown → publish falls back to config inference (legacy rows).
+        self.assertIsNone(db.get_video(self.vid)["subtitles_burned"])
+
+    def test_set_true(self):
+        db.set_video_subtitles_burned(self.vid, True)
+        self.assertEqual(db.get_video(self.vid)["subtitles_burned"], 1)
+
+    def test_set_false(self):
+        db.set_video_subtitles_burned(self.vid, False)
+        self.assertEqual(db.get_video(self.vid)["subtitles_burned"], 0)
+
+    def test_init_db_idempotent(self):
+        # Running init_db again must not error or drop the flag.
+        db.set_video_subtitles_burned(self.vid, True)
+        db.init_db()
+        self.assertEqual(db.get_video(self.vid)["subtitles_burned"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_youtube_uploader.py
+++ b/content-pipeline/tests/test_youtube_uploader.py
@@ -11,7 +11,26 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from publisher.youtube_uploader import _video_id_from_url, upload_caption
+from publisher.youtube_uploader import (
+    _video_id_from_url, upload_caption, _has_required_scopes, SCOPES,
+)
+
+
+class TestHasRequiredScopes(unittest.TestCase):
+    def test_all_scopes_present(self):
+        self.assertTrue(_has_required_scopes(SCOPES))
+
+    def test_superset_ok(self):
+        self.assertTrue(_has_required_scopes(SCOPES + ["https://extra/scope"]))
+
+    def test_missing_force_ssl_fails(self):
+        # A token minted before caption upload only had youtube.upload.
+        self.assertFalse(
+            _has_required_scopes(["https://www.googleapis.com/auth/youtube.upload"])
+        )
+
+    def test_none_fails(self):
+        self.assertFalse(_has_required_scopes(None))
 
 
 class TestVideoIdFromUrl(unittest.TestCase):

--- a/content-pipeline/tests/test_youtube_uploader.py
+++ b/content-pipeline/tests/test_youtube_uploader.py
@@ -1,0 +1,48 @@
+"""Tests for publisher.youtube_uploader caption helpers (caption-track upload).
+
+The Google API client is never invoked here — we test the pure id parser and the
+guard paths of upload_caption that run before any network/auth call.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from publisher.youtube_uploader import _video_id_from_url, upload_caption
+
+
+class TestVideoIdFromUrl(unittest.TestCase):
+    def test_youtu_be(self):
+        self.assertEqual(_video_id_from_url("https://youtu.be/abc123"), "abc123")
+
+    def test_youtu_be_with_query(self):
+        self.assertEqual(_video_id_from_url("https://youtu.be/abc123?t=10"), "abc123")
+
+    def test_watch_url(self):
+        self.assertEqual(
+            _video_id_from_url("https://www.youtube.com/watch?v=xyz789&list=1"),
+            "xyz789",
+        )
+
+    def test_bare_id_passthrough(self):
+        self.assertEqual(_video_id_from_url("rawid"), "rawid")
+
+    def test_empty(self):
+        self.assertEqual(_video_id_from_url(""), "")
+
+
+class TestUploadCaptionGuards(unittest.TestCase):
+    def test_no_video_id_returns_false(self):
+        self.assertFalse(upload_caption("", "/whatever.srt"))
+
+    def test_missing_srt_returns_false(self):
+        self.assertFalse(
+            upload_caption("https://youtu.be/abc123", "/no/such/file.srt")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -35,7 +35,7 @@ _FALLBACK_FONTS = [
 ]
 
 
-def compose_video(audio_path: str, subtitle_path: str, output_path: str,
+def compose_video(audio_path: str, subtitle_path: str | None, output_path: str,
                   video_type: str = "long", bg_video: str | None = None,
                   bg_videos: list[str] | None = None) -> str | None:
     """Compose final video from audio + background + subtitles.
@@ -101,9 +101,14 @@ def compose_video(audio_path: str, subtitle_path: str, output_path: str,
                 logger.error("Failed to generate fallback background")
                 return None
 
-        subtitle_entries = _parse_srt(subtitle_path)
+        # subtitle_path may be None when burn-in is disabled for this video type
+        # (e.g. long videos using an uploaded caption track instead).
+        subtitle_entries = _parse_srt(subtitle_path) if subtitle_path else []
         if not subtitle_entries:
-            logger.warning("No subtitle entries found — composing without subtitles")
+            if subtitle_path:
+                logger.warning("No subtitle entries found — composing without subtitles")
+            else:
+                logger.info("Subtitle burn-in disabled — composing without subtitles")
             return _compose_without_subtitles(bg_video, audio_path, output_path,
                                               width, height, audio_duration)
 


### PR DESCRIPTION
Triển khai quyết định: **giữ phụ đề nung cho short, chuyển long sang caption track YouTube** + dùng Whisper cho timing.

## Vì sao
- Short (TikTok/Shorts) xem **tắt tiếng** + không có CC đáng tin → phụ đề nung là bắt buộc.
- Long (YouTube) có nút CC → upload SRT làm **caption track** chính xác (chữ mình kiểm soát), người xem bật/tắt, khung hình sạch.

## Thay đổi
- `config`: flag mới **`BURN_SUBTITLES`** (`all` | `short_only` | `none`) + `should_burn_subtitles(video_type)` + validation. Default vẫn `all` (legacy).
- `video_composer.compose_video`: nhận `subtitle_path=None` → dựng không nung phụ đề (gọn, không log "file not found").
- `youtube_uploader`: thêm scope `force-ssl`, `_video_id_from_url`, **`upload_caption()`** (`captions.insert`).
- `main`: luôn sinh SRT; chỉ **nung** khi policy cho phép; khi publish video long không-nung thì **đính SRT làm caption track**.

## Cách bật (khuyến nghị)
```
SUBTITLE_TIMING_MODE=whisper   # timing bám audio (cho cả short burned & long caption)
BURN_SUBTITLES=short_only
# pip install faster-whisper
```
Lưu ý: `captions.insert` cần scope `youtube.force-ssl` → lần publish đầu sẽ yêu cầu **re-auth OAuth** (token sinh lại 1 lần).

## Test
- **198 unit test pass**. Mới thêm: `should_burn_subtitles` (all/short_only/none/unknown), `_video_id_from_url` (youtu.be/watch/bare/empty), guard của `upload_caption` (thiếu id / thiếu SRT).
- Default = legacy (`all`) → không hồi quy.

> Check `create-pr` có thể đỏ do `PAT_TOKEN` hết hạn (hạ tầng, không liên quan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0154AKd2xWdqEuHpAwQTHL2H)_