### PR TITLE
chore(tts): set nuitruc voice_id default to preset_my_duyen

### DIFF
--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -10,7 +10,7 @@ PEXELS_API_KEY=...
 # --- TTS (Núi Trúc) ---
 TTS_API_URL=http://tts.nuitruc.ai/api/tts
 TTS_API_KEY=
-TTS_VOICE_ID=voice1
+TTS_VOICE_ID=preset_my_duyen
 TTS_VOICE_SPEED=1.0
 # HTTP tuning (issue #58). On a stalled endpoint the client now fails fast and
 # the provider fallback chain takes over, so keep TTS_TIMEOUT modest. Raise it

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -49,7 +49,7 @@ DB_PATH = os.path.join(os.path.dirname(__file__), "storage", "content.db")
 # --- Video Pipeline ---
 TTS_API_URL = os.getenv("TTS_API_URL", "http://tts.nuitruc.ai/api/tts")
 TTS_API_KEY = os.getenv("TTS_API_KEY", "")           # Optional
-TTS_VOICE_ID = os.getenv("TTS_VOICE_ID", "voice1")
+TTS_VOICE_ID = os.getenv("TTS_VOICE_ID", "preset_my_duyen")
 TTS_VOICE_SPEED = float(os.getenv("TTS_VOICE_SPEED", "1.0"))
 # TTS HTTP tuning (issue #58). A black-hole endpoint (TCP connect OK but no
 # response) used to stall the whole cron window: 400s timeout × 3 retries

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -179,7 +179,7 @@ def _submit_job(opener, text: str) -> str | None:
     """POST /submit and return the job id, or None on failure."""
     payload = json.dumps({
         "text": text,
-        "voice_id": config.TTS_VOICE_ID or "voice1",
+        "voice_id": config.TTS_VOICE_ID or "preset_my_duyen",
         "speed": config.TTS_VOICE_SPEED,
     }).encode("utf-8")
     body = _open_with_retry(opener, _endpoint("submit"), data=payload,


### PR DESCRIPTION
## Thay đổi

Đổi giọng đọc mặc định của Núi Trúc TTS từ `voice1` sang `preset_my_duyen`.

| File | Thay đổi |
|------|----------|
| `config.py` | `TTS_VOICE_ID` default: `voice1` → `preset_my_duyen` |
| `video/tts_client.py` | fallback `voice_id` trong payload `POST /submit`: `or "voice1"` → `or "preset_my_duyen"` |
| `.env.example` | `TTS_VOICE_ID=preset_my_duyen` |

Payload gửi lên nuitruc `/submit` giờ là `{"text": ..., "voice_id": "preset_my_duyen", "speed": ...}`. Vẫn có thể override qua biến môi trường `TTS_VOICE_ID` trong `.env`.

## Test
- `tests/test_tts_client.py` + `tests/test_config_flags.py` — 34 test pass (các test này patch `TTS_VOICE_ID` tường minh nên không phụ thuộc default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F94nvFTzD92g4qgjhiQhGV)_