### PR TITLE
Phase 1: multi-channel foundation (channel registry + DB migration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,39 @@ content-pipeline/
 │   ├── ai_scorer.py            # Chấm điểm 1-10 bằng Claude Haiku (rẻ)
 │   └── ai_analyzer.py          # Phân tích sâu bằng Claude Sonnet (bài tốt)
 ├── storage/
-│   └── database.py             # SQLite
+│   ├── database.py             # SQLite — CRUD cho articles/videos/stories
+│   ├── migrate.py              # Migration runner (up/down/status)
+│   └── migrations/             # File SQL versioned, vd 001_multi_track.sql
 ├── notifier/
 │   └── telegram_bot.py         # Gửi báo cáo sáng qua Telegram Bot API
+├── channels.py                 # Channel registry — nguồn sự thật cho mọi destination
 ├── config.py                   # API keys, keywords, thresholds
 ├── main.py                     # Orchestrator — chạy toàn bộ pipeline
 ├── requirements.txt
 └── .env                        # API keys (không commit lên git)
 ```
+
+---
+
+## Multi-channel architecture (Phase 1)
+
+Từ Phase 1, pipeline hỗ trợ nhiều kênh/nhiều track thay vì 1 kênh AI duy nhất
+(xem `docs/current/phase-1-detailed.md`).
+
+- **`channels.py`** là channel registry — nguồn sự thật duy nhất cho mọi
+  destination. `CHANNELS` có 3 entry: `ai_youtube`, `drama_youtube`,
+  `tiktok_main`. Dùng `get_channel(key)` để tra cứu (raise `ValueError` nếu
+  key sai). Module khác (uploader, scheduler) nên import từ đây thay vì
+  hard-code tên kênh — logic routing thực tế (chọn đúng channel để upload)
+  sẽ được nối dây ở Phase 5.
+- Mọi bài viết (`articles`) và video (`videos`) mang thêm 2 cột:
+  `track` (`'ai'` | `'drama'`, mặc định `'ai'` để không phá logic cũ) và
+  `destination` (khoá trong `channels.py`, `NULL` nếu chưa quyết định).
+- Bảng mới `stories` chuẩn bị cho track Drama (Phase 2): nội dung thô/rewritten,
+  `rubric_score`, `status`, `destination`.
+- Migration được áp dụng qua `python -m storage.migrate up` (chạy từ thư mục
+  `content-pipeline/`), không phải qua `init_db()` — xem
+  `storage/migrations/001_multi_track.sql`.
 
 ---
 
@@ -162,9 +187,19 @@ CREATE TABLE articles (
     urgency TEXT,               -- 'immediate', 'this_week', 'backlog'
     status TEXT DEFAULT 'pending', -- 'pending', 'used', 'skipped'
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    used_at TIMESTAMP
+    used_at TIMESTAMP,
+    -- Thêm ở migration 001_multi_track (storage/migrations/):
+    track TEXT NOT NULL DEFAULT 'ai',   -- 'ai' | 'drama'
+    destination TEXT                    -- khoá trong channels.py, NULL = chưa quyết định
 );
 ```
+
+`videos` (đã tồn tại từ Video Pipeline, xem `storage/database.py`) có cùng 2 cột
+`track`/`destination` thêm bởi migration 001. Bảng `stories` (mới, chuẩn bị cho
+track Drama — Phase 2) xem `storage/migrations/001_multi_track.sql`.
+
+Migration chạy qua `python -m storage.migrate up` (idempotent, tracked bởi bảng
+`_migrations`) — không chạy tự động trong `init_db()`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,37 @@ content-pipeline/
 │   ├── ai_scorer.py               # Chấm điểm 1-10 bằng Claude Haiku
 │   └── ai_analyzer.py             # Phân tích sâu bằng Claude Sonnet
 ├── storage/
-│   └── database.py                # SQLite CRUD
+│   ├── database.py                # SQLite CRUD
+│   ├── migrate.py                 # Migration runner (up/down/status)
+│   └── migrations/                # File SQL versioned
 ├── notifier/
 │   └── telegram_bot.py            # Gửi báo cáo qua Telegram Bot API
+├── channels.py                    # Channel registry (multi-channel, xem bên dưới)
 ├── config.py                      # Cấu hình tập trung
 ├── main.py                        # Pipeline orchestrator
 ├── requirements.txt
 └── .env                           # API keys (không commit)
 ```
+
+## Multi-channel architecture
+
+Từ Phase 1, pipeline hỗ trợ nhiều kênh thay vì 1 kênh AI duy nhất:
+
+- **`channels.py`** là registry duy nhất cho mọi destination (`ai_youtube`,
+  `drama_youtube`, `tiktok_main`). Dùng `get_channel(key)` để tra cứu.
+- Mỗi bài viết/video mang thêm `track` (`ai` | `drama`, mặc định `ai`) và
+  `destination` (khoá trong `channels.py`).
+- Áp dụng schema mới bằng migration runner:
+
+  ```bash
+  cd content-pipeline
+  python -m storage.migrate up       # áp dụng migration còn pending
+  python -m storage.migrate status   # xem migration nào đã/chưa apply
+  ```
+
+- Chi tiết thiết kế: [`docs/current/phase-1-detailed.md`](docs/current/phase-1-detailed.md).
+- Logic routing nội dung sang đúng channel để upload sẽ được nối dây ở Phase 5;
+  Phase 1 chỉ đặt khung schema + registry.
 
 ## Cài đặt
 

--- a/branding/README.md
+++ b/branding/README.md
@@ -1,0 +1,44 @@
+# Branding — Phase 1 (EPIC #1.3)
+
+Thư mục này chứa asset branding cho 2 kênh YouTube (`ai_youtube`,
+`drama_youtube`) và 1 tài khoản TikTok (`tiktok_main`), khớp với
+`content-pipeline/channels.py`.
+
+## Trạng thái
+
+EPIC #1.3 là task **thủ công** (không code) — phần này chỉ scaffold nội dung
+text (naming draft, description draft, bio draft) để người quyết định branding
+duyệt/chỉnh sửa. Các việc sau **cần làm thủ công ngoài phiên làm việc này**
+(không thể tự động hoá từ môi trường coding):
+
+- [ ] Chốt tên cuối cùng cho từng kênh (xem `naming.md` — 5 candidate/kênh,
+      cần kiểm tra tên trống trên YouTube/TikTok trước khi chốt).
+- [ ] Thiết kế avatar (800×800) + banner (2560×1440) — Midjourney/Ideogram +
+      Canva, hoặc thuê designer.
+- [ ] Đăng ký 2 kênh YouTube trên 2 Gmail riêng, tạo Brand Account (xem
+      `docs/current/oauth-setup.md`).
+- [ ] Đăng ký tài khoản TikTok, viết bio + link bio (Linktree/Beacons).
+- [ ] Upload avatar/banner/description lên từng kênh.
+
+## Cấu trúc
+
+```
+branding/
+├── naming.md                    # 5 tên đề xuất/kênh + rationale (draft)
+├── ai_youtube/
+│   ├── description.md           # Draft mô tả kênh YouTube AI
+│   ├── avatar.png               # (chưa có — cần thiết kế thủ công)
+│   └── banner.png               # (chưa có — cần thiết kế thủ công)
+├── drama_youtube/
+│   ├── description.md           # Draft mô tả kênh YouTube Drama
+│   ├── avatar.png               # (chưa có)
+│   └── banner.png               # (chưa có)
+└── tiktok/
+    └── bio.md                   # Draft bio TikTok (2 hashtag series + link bio)
+```
+
+## Liên kết
+
+- Thiết kế kỹ thuật: `docs/current/phase-1-detailed.md` mục 3.3.
+- Channel registry: `content-pipeline/channels.py`.
+- OAuth setup sau khi có kênh: `docs/current/oauth-setup.md`.

--- a/branding/ai_youtube/description.md
+++ b/branding/ai_youtube/description.md
@@ -1,0 +1,32 @@
+# Channel description draft — AI Đi Làm (`ai_youtube`)
+
+> Draft — chỉnh sửa tự do trước khi dán vào YouTube Studio → Tuỳ chỉnh → Mô tả.
+> Mục tiêu 200–400 ký tự, có keyword chính + lịch đăng + CTA (theo acceptance
+> criteria `phase-1-issues.md` EPIC #1.3).
+
+## Bản tiếng Việt (chính)
+
+```
+AI Đi Làm — kênh giúp người Việt đi làm văn phòng hiểu và dùng AI chỉ trong
+5 phút mỗi ngày. Không thuật ngữ khó hiểu, không lý thuyết dài dòng — chỉ tin
+tức AI mới nhất và cách áp dụng ngay vào công việc hàng ngày.
+
+📅 Lịch đăng: Thứ 2/4/6 — video ngắn (Shorts). Thứ 3/5/7 — video dài
+(phân tích sâu).
+
+🔔 Đăng ký kênh để không bỏ lỡ bản tin AI mỗi ngày!
+```
+
+*(≈ 340 ký tự — nằm trong khoảng khuyến nghị 200–400.)*
+
+## Keyword chính đã dùng
+
+`AI`, `trí tuệ nhân tạo`, `AI cho người đi làm`, `ChatGPT`, `năng suất`,
+`công cụ AI`
+
+## Việc còn lại (thủ công)
+
+- [ ] Duyệt/chỉnh nội dung theo giọng văn thật của kênh.
+- [ ] Dán vào YouTube Studio sau khi kênh được tạo (xem
+      `docs/current/oauth-setup.md`).
+- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh.

--- a/branding/drama_youtube/description.md
+++ b/branding/drama_youtube/description.md
@@ -1,0 +1,32 @@
+# Channel description draft — Chuyện Đời (`drama_youtube`)
+
+> Draft — chỉnh sửa tự do trước khi dán vào YouTube Studio → Tuỳ chỉnh → Mô tả.
+> Mục tiêu 200–400 ký tự, có keyword chính + lịch đăng + CTA (theo acceptance
+> criteria `phase-1-issues.md` EPIC #1.3). Nội dung Drama chi tiết thuộc
+> Phase 2 — draft này chỉ mô tả định vị kênh ở mức tổng quát.
+
+## Bản tiếng Việt (chính)
+
+```
+Chuyện Đời — những câu chuyện đời thường với cú twist bất ngờ, kể lại theo
+cách gần gũi, dễ xem. Mỗi video là một lát cắt cuộc sống, một bài học, hoặc
+một khoảnh khắc khiến bạn phải suy nghĩ lại.
+
+📅 Lịch đăng: Thứ 2/4/6 — video ngắn (Shorts). Thứ 3/5/7 — video dài.
+
+🔔 Đăng ký kênh để theo dõi những câu chuyện mới mỗi tuần!
+```
+
+*(≈ 300 ký tự — nằm trong khoảng khuyến nghị 200–400.)*
+
+## Keyword chính đã dùng
+
+`chuyện đời`, `drama`, `twist`, `kể chuyện`, `đời thường`
+
+## Việc còn lại (thủ công)
+
+- [ ] Duyệt/chỉnh nội dung sau khi Phase 2 chốt định hướng nội dung Drama cụ
+      thể hơn (rubric, nguồn chuyện, giọng kể).
+- [ ] Dán vào YouTube Studio sau khi kênh được tạo (xem
+      `docs/current/oauth-setup.md`).
+- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh.

--- a/branding/naming.md
+++ b/branding/naming.md
@@ -1,0 +1,62 @@
+# Naming — Draft (chưa chốt)
+
+> **Trạng thái: DRAFT.** Đây là bản brainstorm để người quyết định branding
+> chọn/chỉnh. Chưa kiểm tra tên nào còn trống trên YouTube/TikTok — bắt buộc
+> kiểm tra thủ công trước khi đăng ký kênh thật (search trực tiếp trên
+> youtube.com và tiktok.com, và domain nếu định mua link-in-bio riêng).
+
+## Kênh YouTube AI (`ai_youtube` trong `channels.py`)
+
+Định vị: AI cho dân văn phòng Việt Nam 22–35 tuổi, không rành kỹ thuật, "hiểu
+và dùng AI trong 5 phút".
+
+| # | Tên đề xuất | Lý do |
+|---|-------------|-------|
+| 1 | **AI Đi Làm** *(working title hiện tại)* | Ngắn, đúng định vị "AI cho người đi làm", dễ nhớ, dễ SEO tiếng Việt |
+| 2 | 5 Phút AI | Nhấn mạnh format ngắn gọn — lời hứa cốt lõi của kênh |
+| 3 | AI Văn Phòng | Rõ đối tượng, dễ tìm trên search |
+| 4 | AI Cho Người Bận Rộn | Nhấn insight "không có thời gian học AI" |
+| 5 | Sếp AI | Thân thiện, gợi tò mò, dễ tạo thumbnail/branding vui |
+
+**Đề xuất chốt:** giữ **AI Đi Làm** trừ khi kiểm tra trùng tên/nhãn hiệu.
+
+## Kênh YouTube Drama (`drama_youtube` trong `channels.py`)
+
+Định vị: nội dung Drama/Twist (kể chuyện, plot twist) — xem Phase 2 để biết
+chi tiết nội dung.
+
+| # | Tên đề xuất | Lý do |
+|---|-------------|-------|
+| 1 | **Chuyện Đời** *(working title hiện tại)* | Ngắn, trung tính, dễ mở rộng nhiều thể loại chuyện |
+| 2 | Góc Khuất | Gợi drama/bí mật, đúng tinh thần "twist" |
+| 3 | Chuyện Kể Đêm Khuya | Gợi hình ảnh storytelling, phù hợp video dài |
+| 4 | Twist Đời Thường | Nói thẳng chất "twist" của nội dung |
+| 5 | Drama Đời Thực | Rõ thể loại, dễ tìm kiếm |
+
+**Đề xuất chốt:** giữ **Chuyện Đời** trừ khi kiểm tra trùng tên/nhãn hiệu.
+
+## Tài khoản TikTok (`tiktok_main` trong `channels.py`)
+
+1 tài khoản mix cả 2 track, phân biệt bằng 2 hashtag series (xem
+`tiktok/bio.md`).
+
+| # | Handle đề xuất | Lý do |
+|---|-----------------|-------|
+| 1 | **@phuong.contentlab** *(working title hiện tại)* | Gắn với tên người sáng lập, dễ nhớ |
+| 2 | @aivadrama | Nói rõ 2 track (AI và Drama) trong 1 handle |
+| 3 | @contentlab.vn | Trung tính, dễ mở rộng track mới sau này |
+| 4 | @2phutmoingay | Nhấn format ngắn gọn, giống AI Đi Làm |
+| 5 | @phuong.aidrama | Kết hợp tên cá nhân + 2 track |
+
+**Đề xuất chốt:** giữ **@phuong.contentlab** trừ khi đã bị trùng trên TikTok.
+
+---
+
+## Việc còn lại (thủ công)
+
+- [ ] Search trực tiếp trên youtube.com/tiktok.com để xác nhận tên/handle
+      còn trống.
+- [ ] Chốt 1 tên/kênh, ghi quyết định cuối + lý do vào file này (thay phần
+      "Đề xuất chốt" ở trên bằng "ĐÃ CHỐT").
+- [ ] Cập nhật `content-pipeline/channels.py` field `"name"` nếu tên cuối
+      khác placeholder hiện tại.

--- a/branding/tiktok/bio.md
+++ b/branding/tiktok/bio.md
@@ -1,0 +1,31 @@
+# TikTok bio draft — `tiktok_main`
+
+> Draft — 1 tài khoản TikTok đăng cả 2 track (AI + Drama), phân biệt bằng 2
+> hashtag series riêng (theo acceptance criteria `phase-1-issues.md` EPIC
+> #1.3: "Bio chứa 2 hashtag series + link bio").
+
+## Bio draft (giới hạn ~80 ký tự của TikTok)
+
+```
+🤖 AI 5 phút mỗi ngày | 🎭 Chuyện đời có twist
+👇 Link các kênh YouTube
+```
+
+## Hashtag series
+
+- Track AI: `#AIDiLam` (gắn vào caption mọi video track `ai`)
+- Track Drama: `#ChuyenDoiTwist` (gắn vào caption mọi video track `drama`)
+
+## Link bio
+
+Dùng Linktree/Beacons trỏ tới:
+- Kênh YouTube AI (`ai_youtube`)
+- Kênh YouTube Drama (`drama_youtube`)
+
+## Việc còn lại (thủ công)
+
+- [ ] Đăng ký tài khoản TikTok thật, xác nhận handle còn trống (xem
+      `../naming.md`).
+- [ ] Tạo Linktree/Beacons, dán link vào phần bio TikTok.
+- [ ] Xác nhận 2 hashtag series không trùng hashtag đang được dùng phổ biến
+      cho nội dung khác (search trên TikTok trước khi chốt).

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -26,6 +26,24 @@ YOUTUBE_CLIENT_SECRETS=/path/to/client_secret.json
 # --- TikTok ---
 TIKTOK_ACCESS_TOKEN=...
 
+# --- Multi-channel (Phase 1 — Multi-channel Foundation) ---
+# Per-channel credentials referenced by content-pipeline/channels.py
+# (CHANNELS[key]["oauth_token_env"]). Upload routing that actually reads
+# these lands in Phase 5; for now they just need to exist so OAuth can be
+# set up per Brand Account ahead of time.
+#
+# YouTube: create a separate OAuth2 client (or reuse one client with a
+# per-channel token file) in Google Cloud Console > APIs & Services >
+# Credentials, authorizing against the correct Brand Account channel.
+YOUTUBE_AI_TOKEN=/path/to/ai_youtube_token.json
+YOUTUBE_AI_CHANNEL_ID=UC...
+YOUTUBE_DRAMA_TOKEN=/path/to/drama_youtube_token.json
+YOUTUBE_DRAMA_CHANNEL_ID=UC...
+# TikTok: TikTok Developer Portal > your app > Content Posting API scope.
+# One TikTok account carries both tracks (see channels.py "tiktok_main").
+TIKTOK_TOKEN=...
+TIKTOK_OPEN_ID=...
+
 # --- Video engine flags (default = legacy behaviour; see docs/current/video-enhancement/) ---
 # Subtitle timing: wordcount (legacy, proportional) | whisper (P1, audio-aligned)
 SUBTITLE_TIMING_MODE=wordcount

--- a/content-pipeline/channels.py
+++ b/content-pipeline/channels.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""
+Channel registry — nguồn sự thật duy nhất (single source of truth) cho mọi
+destination mà pipeline có thể đăng nội dung lên.
+
+Mọi module khác (uploader, scheduler, analytics, ...) nên `import channels`
+thay vì hard-code tên kênh / platform. Khi đổi tên kênh hoặc thêm kênh mới,
+chỉ cần sửa registry này.
+
+Xem docs/current/phase-1-detailed.md mục 3.1.
+"""
+
+from typing import TypedDict
+
+
+class Channel(TypedDict):
+    platform: str               # "youtube" | "tiktok"
+    track: str                  # "ai" | "drama" | "mixed"
+    name: str                   # Tên hiển thị (placeholder cho tới khi branding chốt)
+    format_long: bool           # Có đăng video dài không
+    format_shorts: bool         # Có đăng video ngắn/Shorts không
+    oauth_token_env: str        # Tên biến môi trường chứa OAuth token cho kênh này
+    tts_voice_profile: str      # Voice profile TTS mặc định cho kênh này
+
+
+# Channel registry - source of truth cho mọi destination
+CHANNELS: dict[str, Channel] = {
+    "ai_youtube": {
+        "platform": "youtube",
+        "track": "ai",
+        "name": "AI Đi Làm",                   # placeholder, user chốt
+        "format_long": True,
+        "format_shorts": True,
+        "oauth_token_env": "YOUTUBE_AI_TOKEN",
+        "tts_voice_profile": "neutral_female",
+    },
+    "drama_youtube": {
+        "platform": "youtube",
+        "track": "drama",
+        "name": "Chuyện Đời",                  # placeholder
+        "format_long": True,
+        "format_shorts": True,
+        "oauth_token_env": "YOUTUBE_DRAMA_TOKEN",
+        "tts_voice_profile": "storyteller_female",
+    },
+    "tiktok_main": {
+        "platform": "tiktok",
+        "track": "mixed",                      # cả 2 track đăng cùng tài khoản
+        "name": "@phuong.contentlab",          # placeholder
+        "format_long": False,
+        "format_shorts": True,
+        "oauth_token_env": "TIKTOK_TOKEN",
+        "tts_voice_profile": "auto",           # chọn theo track của video
+    },
+}
+
+
+def get_channel(key: str) -> Channel:
+    """Lookup a channel by its registry key.
+
+    Raises:
+        ValueError: nếu `key` không tồn tại trong registry.
+    """
+    if key not in CHANNELS:
+        raise ValueError(f"Channel {key} not in registry")
+    return CHANNELS[key]
+
+
+def channels_for_track(track: str) -> dict[str, Channel]:
+    """Tất cả channel nhận nội dung của `track` (bao gồm channel 'mixed')."""
+    return {
+        key: channel
+        for key, channel in CHANNELS.items()
+        if channel["track"] in (track, "mixed")
+    }
+
+
+def channels_for_platform(platform: str) -> dict[str, Channel]:
+    """Tất cả channel thuộc một platform (vd 'youtube', 'tiktok')."""
+    return {
+        key: channel
+        for key, channel in CHANNELS.items()
+        if channel["platform"] == platform
+    }
+
+
+if __name__ == "__main__":
+    for key, channel in CHANNELS.items():
+        print(f"{key}: {channel['name']} ({channel['platform']}, track={channel['track']})")

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -82,6 +82,17 @@ YOUTUBE_CLIENT_SECRETS = os.getenv("YOUTUBE_CLIENT_SECRETS", "")   # Path to OAu
 YOUTUBE_TOKEN_FILE = os.path.join(os.path.dirname(__file__), "publisher", ".youtube_token.json")
 TIKTOK_ACCESS_TOKEN = os.getenv("TIKTOK_ACCESS_TOKEN", "")
 
+# --- Multi-channel credentials (Phase 1 — Multi-channel Foundation) ---
+# Referenced by channels.py CHANNELS[key]["oauth_token_env"]; multi-channel
+# upload routing that reads these lands in Phase 5. Kept here (not hard-coded
+# per-destination) so channels.py remains the single source of truth.
+YOUTUBE_AI_TOKEN = os.getenv("YOUTUBE_AI_TOKEN", "")
+YOUTUBE_AI_CHANNEL_ID = os.getenv("YOUTUBE_AI_CHANNEL_ID", "")
+YOUTUBE_DRAMA_TOKEN = os.getenv("YOUTUBE_DRAMA_TOKEN", "")
+YOUTUBE_DRAMA_CHANNEL_ID = os.getenv("YOUTUBE_DRAMA_CHANNEL_ID", "")
+TIKTOK_TOKEN = os.getenv("TIKTOK_TOKEN", "")
+TIKTOK_OPEN_ID = os.getenv("TIKTOK_OPEN_ID", "")
+
 # --- Video engine flags (Video Enhancement roadmap; default = legacy behaviour) ---
 # Each flag has a "legacy" default so the pipeline behaves exactly as before
 # unless explicitly opted in. See docs/current/video-enhancement/.

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -97,17 +97,31 @@ def article_exists(url: str) -> bool:
 
 def insert_article(source: str, title: str, url: str,
                    raw_content: Optional[str] = None,
-                   summary: Optional[str] = None) -> Optional[int]:
-    """Insert a new article. Returns the article id or None if duplicate."""
+                   summary: Optional[str] = None,
+                   track: str = "ai",
+                   destination: Optional[str] = None) -> Optional[int]:
+    """Insert a new article. Returns the article id or None if duplicate.
+
+    `track`/`destination` require migration 001_multi_track (see
+    storage/migrate.py); on a pre-migration DB the extra columns don't exist
+    and this call falls back to the legacy INSERT below.
+    """
     if article_exists(url):
         logger.debug("Article already exists: %s", url)
         return None
     conn = get_connection()
     try:
-        cursor = conn.execute(
-            "INSERT INTO articles (source, title, url, raw_content, summary) VALUES (?, ?, ?, ?, ?)",
-            (source, title, url, raw_content, summary),
-        )
+        try:
+            cursor = conn.execute(
+                "INSERT INTO articles (source, title, url, raw_content, summary, track, destination) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (source, title, url, raw_content, summary, track, destination),
+            )
+        except sqlite3.OperationalError:
+            cursor = conn.execute(
+                "INSERT INTO articles (source, title, url, raw_content, summary) VALUES (?, ?, ?, ?, ?)",
+                (source, title, url, raw_content, summary),
+            )
         conn.commit()
         logger.info("Inserted article: %s", title[:80])
         return cursor.lastrowid
@@ -301,17 +315,33 @@ def mark_article_used(article_id: int):
 def insert_video(video_type: str, script_text: str, youtube_title: str = "",
                  youtube_description: str = "", tiktok_caption: str = "",
                  tiktok_hashtags: str = "", scheduled_date: str = "",
-                 scheduled_platform: str = "") -> int:
-    """Insert a new video record. Returns the video id."""
+                 scheduled_platform: str = "", track: str = "ai",
+                 destination: Optional[str] = None) -> int:
+    """Insert a new video record. Returns the video id.
+
+    `track`/`destination` require migration 001_multi_track (see
+    storage/migrate.py); on a pre-migration DB the extra columns don't exist
+    and this call falls back to the legacy INSERT below.
+    """
     conn = get_connection()
     try:
-        cursor = conn.execute(
-            "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
-            "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (video_type, script_text, youtube_title, youtube_description,
-             tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform),
-        )
+        try:
+            cursor = conn.execute(
+                "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
+                "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform, track, destination) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (video_type, script_text, youtube_title, youtube_description,
+                 tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform,
+                 track, destination),
+            )
+        except sqlite3.OperationalError:
+            cursor = conn.execute(
+                "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
+                "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (video_type, script_text, youtube_title, youtube_description,
+                 tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform),
+            )
         conn.commit()
         logger.info("Inserted video id=%d type=%s", cursor.lastrowid, video_type)
         return cursor.lastrowid

--- a/content-pipeline/storage/migrate.py
+++ b/content-pipeline/storage/migrate.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import config
+import storage.database as database
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,12 @@ MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 
 def _connection() -> sqlite3.Connection:
-    os.makedirs(os.path.dirname(config.DB_PATH), exist_ok=True)
+    # Ensure the base schema (articles/videos) exists before any migration
+    # runs — on a clean checkout, `migrate up` is often the very first
+    # command run and there is no table for 001_multi_track to ALTER yet.
+    # Idempotent (CREATE TABLE IF NOT EXISTS) so this is a no-op on an
+    # already-initialized DB.
+    database.init_db()
     conn = sqlite3.connect(config.DB_PATH)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS _migrations ("
@@ -38,6 +44,11 @@ def _connection() -> sqlite3.Connection:
     )
     conn.commit()
     return conn
+
+
+def _quote_literal(value: str) -> str:
+    """Escape a value for inline use as a single-quoted SQL string literal."""
+    return value.replace("'", "''")
 
 
 def _discover_migrations() -> list[tuple[str, Path]]:
@@ -66,9 +77,17 @@ def migrate_up(conn: sqlite3.Connection | None = None) -> list[str]:
             if version in applied:
                 continue
             sql = path.read_text(encoding="utf-8")
-            conn.executescript(sql)
-            conn.execute("INSERT INTO _migrations (version) VALUES (?)", (version,))
-            conn.commit()
+            # Bookkeeping INSERT is folded into the same script as the DDL
+            # (single executescript call = single SQLite transaction) so a
+            # crash mid-migration can never leave the schema changed without
+            # the version recorded (which would break idempotency on retry).
+            script = (
+                "BEGIN TRANSACTION;\n"
+                f"{sql}\n"
+                f"INSERT INTO _migrations (version) VALUES ('{_quote_literal(version)}');\n"
+                "COMMIT;"
+            )
+            conn.executescript(script)
             newly_applied.append(version)
             logger.info("Applied migration: %s", version)
         return newly_applied
@@ -93,9 +112,15 @@ def migrate_down(conn: sqlite3.Connection | None = None) -> str | None:
         if not down_path.exists():
             raise FileNotFoundError(f"No down migration found for {version}: {down_path}")
         sql = down_path.read_text(encoding="utf-8")
-        conn.executescript(sql)
-        conn.execute("DELETE FROM _migrations WHERE version = ?", (version,))
-        conn.commit()
+        # Same atomicity fix as migrate_up(): fold the bookkeeping DELETE
+        # into the same script/transaction as the rollback DDL.
+        script = (
+            "BEGIN TRANSACTION;\n"
+            f"{sql}\n"
+            f"DELETE FROM _migrations WHERE version = '{_quote_literal(version)}';\n"
+            "COMMIT;"
+        )
+        conn.executescript(script)
         logger.info("Reverted migration: %s", version)
         return version
     finally:

--- a/content-pipeline/storage/migrate.py
+++ b/content-pipeline/storage/migrate.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+"""
+Migration runner — áp dụng các file SQL trong storage/migrations/ theo thứ tự,
+lưu version đã apply vào bảng `_migrations` để idempotent.
+
+Usage:
+    python -m storage.migrate up        # áp dụng mọi migration còn pending
+    python -m storage.migrate status    # in danh sách migration đã/chưa apply
+    python -m storage.migrate down      # rollback migration mới nhất
+
+Convention: mỗi migration là 1 file `<version>.sql` (vd `001_multi_track.sql`).
+File rollback tương ứng (tuỳ chọn) là `<version>_down.sql` và bị bỏ qua khi
+liệt kê migration "up".
+"""
+
+import argparse
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+
+logger = logging.getLogger(__name__)
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def _connection() -> sqlite3.Connection:
+    os.makedirs(os.path.dirname(config.DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _migrations ("
+        "version TEXT PRIMARY KEY, applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+    )
+    conn.commit()
+    return conn
+
+
+def _discover_migrations() -> list[tuple[str, Path]]:
+    """Return (version, up_sql_path) sorted by version, skipping *_down.sql files."""
+    result = []
+    for path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        if path.stem.endswith("_down"):
+            continue
+        result.append((path.stem, path))
+    return result
+
+
+def _applied_versions(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT version FROM _migrations").fetchall()
+    return {r[0] for r in rows}
+
+
+def migrate_up(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Apply all pending migrations in order. Returns the list of versions applied."""
+    owns_conn = conn is None
+    conn = conn or _connection()
+    try:
+        applied = _applied_versions(conn)
+        newly_applied = []
+        for version, path in _discover_migrations():
+            if version in applied:
+                continue
+            sql = path.read_text(encoding="utf-8")
+            conn.executescript(sql)
+            conn.execute("INSERT INTO _migrations (version) VALUES (?)", (version,))
+            conn.commit()
+            newly_applied.append(version)
+            logger.info("Applied migration: %s", version)
+        return newly_applied
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def migrate_down(conn: sqlite3.Connection | None = None) -> str | None:
+    """Revert the most recently applied migration. Returns its version, or None if none applied."""
+    owns_conn = conn is None
+    conn = conn or _connection()
+    try:
+        row = conn.execute(
+            "SELECT version FROM _migrations ORDER BY applied_at DESC, version DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            logger.info("No migrations to revert.")
+            return None
+        version = row[0]
+        down_path = MIGRATIONS_DIR / f"{version}_down.sql"
+        if not down_path.exists():
+            raise FileNotFoundError(f"No down migration found for {version}: {down_path}")
+        sql = down_path.read_text(encoding="utf-8")
+        conn.executescript(sql)
+        conn.execute("DELETE FROM _migrations WHERE version = ?", (version,))
+        conn.commit()
+        logger.info("Reverted migration: %s", version)
+        return version
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def status(conn: sqlite3.Connection | None = None) -> list[dict]:
+    """Return [{"version": ..., "applied": bool}, ...] for every discovered migration."""
+    owns_conn = conn is None
+    conn = conn or _connection()
+    try:
+        applied = _applied_versions(conn)
+        return [
+            {"version": version, "applied": version in applied}
+            for version, _ in _discover_migrations()
+        ]
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SQLite migration runner")
+    parser.add_argument("command", choices=["up", "down", "status"])
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if args.command == "up":
+        applied = migrate_up()
+        print(f"Applied {len(applied)} migration(s): {', '.join(applied)}" if applied
+              else "No pending migrations.")
+    elif args.command == "down":
+        reverted = migrate_down()
+        print(f"Reverted: {reverted}" if reverted else "Nothing to revert.")
+    elif args.command == "status":
+        for entry in status():
+            mark = "[x]" if entry["applied"] else "[ ]"
+            print(f"{mark} {entry['version']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/content-pipeline/storage/migrations/001_multi_track.sql
+++ b/content-pipeline/storage/migrations/001_multi_track.sql
@@ -6,8 +6,10 @@
 --
 -- Applied via: python -m storage.migrate up
 -- Rollback:    storage/migrations/001_multi_track_down.sql
-
-BEGIN TRANSACTION;
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction, so
+-- schema + version record are applied atomically.
 
 ALTER TABLE articles ADD COLUMN track TEXT NOT NULL DEFAULT 'ai';
 ALTER TABLE articles ADD COLUMN destination TEXT;
@@ -32,5 +34,3 @@ CREATE TABLE IF NOT EXISTS stories (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   produced_at TIMESTAMP
 );
-
-COMMIT;

--- a/content-pipeline/storage/migrations/001_multi_track.sql
+++ b/content-pipeline/storage/migrations/001_multi_track.sql
@@ -1,0 +1,36 @@
+-- Migration 001: multi-track foundation (Phase 1 — Multi-channel).
+--
+-- Adds `track` and `destination` to the existing `articles` and `videos`
+-- tables so every content item can be routed to the right channel, and
+-- creates the `stories` table used by the Drama track (Phase 2+).
+--
+-- Applied via: python -m storage.migrate up
+-- Rollback:    storage/migrations/001_multi_track_down.sql
+
+BEGIN TRANSACTION;
+
+ALTER TABLE articles ADD COLUMN track TEXT NOT NULL DEFAULT 'ai';
+ALTER TABLE articles ADD COLUMN destination TEXT;
+CREATE INDEX IF NOT EXISTS idx_articles_track ON articles(track);
+CREATE INDEX IF NOT EXISTS idx_articles_destination ON articles(destination);
+
+ALTER TABLE videos ADD COLUMN track TEXT NOT NULL DEFAULT 'ai';
+ALTER TABLE videos ADD COLUMN destination TEXT;
+CREATE INDEX IF NOT EXISTS idx_videos_track ON videos(track);
+CREATE INDEX IF NOT EXISTS idx_videos_destination ON videos(destination);
+
+CREATE TABLE IF NOT EXISTS stories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source TEXT NOT NULL,           -- 'reddit', 'vn_original', 'manual'
+  source_id TEXT,                 -- Reddit post_id, hoặc UUID cho VN
+  raw_content TEXT,
+  rewritten_content TEXT,
+  track TEXT NOT NULL,            -- 'drama' (sau này có thể mở rộng)
+  rubric_score INTEGER,
+  status TEXT DEFAULT 'pending',  -- pending, approved, rejected, produced
+  destination TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  produced_at TIMESTAMP
+);
+
+COMMIT;

--- a/content-pipeline/storage/migrations/001_multi_track_down.sql
+++ b/content-pipeline/storage/migrations/001_multi_track_down.sql
@@ -1,7 +1,8 @@
 -- Rollback for 001_multi_track.
 -- Requires SQLite >= 3.35.0 (2021-03-12) for ALTER TABLE ... DROP COLUMN.
-
-BEGIN TRANSACTION;
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping DELETE in one transaction.
 
 DROP TABLE IF EXISTS stories;
 
@@ -14,5 +15,3 @@ DROP INDEX IF EXISTS idx_articles_destination;
 DROP INDEX IF EXISTS idx_articles_track;
 ALTER TABLE articles DROP COLUMN destination;
 ALTER TABLE articles DROP COLUMN track;
-
-COMMIT;

--- a/content-pipeline/storage/migrations/001_multi_track_down.sql
+++ b/content-pipeline/storage/migrations/001_multi_track_down.sql
@@ -1,0 +1,18 @@
+-- Rollback for 001_multi_track.
+-- Requires SQLite >= 3.35.0 (2021-03-12) for ALTER TABLE ... DROP COLUMN.
+
+BEGIN TRANSACTION;
+
+DROP TABLE IF EXISTS stories;
+
+DROP INDEX IF EXISTS idx_videos_destination;
+DROP INDEX IF EXISTS idx_videos_track;
+ALTER TABLE videos DROP COLUMN destination;
+ALTER TABLE videos DROP COLUMN track;
+
+DROP INDEX IF EXISTS idx_articles_destination;
+DROP INDEX IF EXISTS idx_articles_track;
+ALTER TABLE articles DROP COLUMN destination;
+ALTER TABLE articles DROP COLUMN track;
+
+COMMIT;

--- a/content-pipeline/tests/test_channels.py
+++ b/content-pipeline/tests/test_channels.py
@@ -1,0 +1,69 @@
+"""Tests for the channel registry (Phase 1 — Multi-channel Foundation)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import channels
+
+
+class TestChannelRegistry(unittest.TestCase):
+    def test_has_at_least_three_channels(self):
+        self.assertGreaterEqual(len(channels.CHANNELS), 3)
+
+    def test_expected_channels_present(self):
+        for key in ("ai_youtube", "drama_youtube", "tiktok_main"):
+            self.assertIn(key, channels.CHANNELS)
+
+    def test_each_channel_has_required_fields(self):
+        required = {
+            "platform", "track", "name", "format_long",
+            "format_shorts", "oauth_token_env", "tts_voice_profile",
+        }
+        for key, channel in channels.CHANNELS.items():
+            missing = required - channel.keys()
+            self.assertFalse(missing, f"{key} missing fields: {missing}")
+
+    def test_default_track_is_ai_for_ai_youtube(self):
+        self.assertEqual(channels.get_channel("ai_youtube")["track"], "ai")
+
+
+class TestGetChannel(unittest.TestCase):
+    def test_get_channel_returns_dict(self):
+        channel = channels.get_channel("ai_youtube")
+        self.assertEqual(channel["platform"], "youtube")
+
+    def test_get_channel_raises_on_unknown_key(self):
+        with self.assertRaises(ValueError):
+            channels.get_channel("does_not_exist")
+
+
+class TestChannelsForTrack(unittest.TestCase):
+    def test_ai_track_includes_mixed_channel(self):
+        result = channels.channels_for_track("ai")
+        self.assertIn("ai_youtube", result)
+        self.assertIn("tiktok_main", result)
+        self.assertNotIn("drama_youtube", result)
+
+    def test_drama_track_includes_mixed_channel(self):
+        result = channels.channels_for_track("drama")
+        self.assertIn("drama_youtube", result)
+        self.assertIn("tiktok_main", result)
+        self.assertNotIn("ai_youtube", result)
+
+
+class TestChannelsForPlatform(unittest.TestCase):
+    def test_youtube_platform_has_two_channels(self):
+        result = channels.channels_for_platform("youtube")
+        self.assertEqual(set(result.keys()), {"ai_youtube", "drama_youtube"})
+
+    def test_tiktok_platform_has_one_channel(self):
+        result = channels.channels_for_platform("tiktok")
+        self.assertEqual(set(result.keys()), {"tiktok_main"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_migrate.py
+++ b/content-pipeline/tests/test_migrate.py
@@ -1,0 +1,168 @@
+"""Integration tests for the migration runner (Phase 1 — Multi-channel Foundation)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+
+
+class TestMigrateUp(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_up_applies_001(self):
+        applied = migrate.migrate_up()
+        self.assertIn("001_multi_track", applied)
+
+    def test_up_is_idempotent(self):
+        migrate.migrate_up()
+        second_run = migrate.migrate_up()
+        self.assertEqual(second_run, [])
+
+    def test_track_column_added_with_default_ai(self):
+        migrate.migrate_up()
+        video_id = db.insert_video("long", "Script thử nghiệm.")
+        conn = db.get_connection()
+        try:
+            row = conn.execute("SELECT track FROM videos WHERE id = ?", (video_id,)).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["track"], "ai")
+
+    def test_destination_column_added_nullable(self):
+        migrate.migrate_up()
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(videos)")}
+        finally:
+            conn.close()
+        self.assertIn("destination", cols)
+
+    def test_stories_table_created(self):
+        migrate.migrate_up()
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='stories'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+
+    def test_articles_track_column_added(self):
+        migrate.migrate_up()
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(articles)")}
+        finally:
+            conn.close()
+        self.assertIn("track", cols)
+        self.assertIn("destination", cols)
+
+
+class TestMigrateStatus(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_status_before_up_shows_pending(self):
+        entries = migrate.status()
+        self.assertTrue(any(e["version"] == "001_multi_track" and not e["applied"] for e in entries))
+
+    def test_status_after_up_shows_applied(self):
+        migrate.migrate_up()
+        entries = migrate.status()
+        self.assertTrue(any(e["version"] == "001_multi_track" and e["applied"] for e in entries))
+
+
+class TestTrackDestinationRoundtrip(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_insert_video_before_migration_falls_back_gracefully(self):
+        # No migration applied yet: track/destination columns don't exist,
+        # insert_video must still succeed via its legacy-INSERT fallback.
+        video_id = db.insert_video("short", "Kịch bản.")
+        self.assertIsInstance(video_id, int)
+
+    def test_insert_video_after_migration_stores_custom_track(self):
+        migrate.migrate_up()
+        video_id = db.insert_video("short", "Kịch bản.", track="drama",
+                                   destination="drama_youtube")
+        video = db.get_video(video_id)
+        self.assertEqual(video["track"], "drama")
+        self.assertEqual(video["destination"], "drama_youtube")
+
+    def test_insert_article_after_migration_stores_custom_track(self):
+        migrate.migrate_up()
+        article_id = db.insert_article("reddit", "Tiêu đề", "https://example.com/1",
+                                       track="drama", destination="tiktok_main")
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT track, destination FROM articles WHERE id = ?", (article_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["track"], "drama")
+        self.assertEqual(row["destination"], "tiktok_main")
+
+
+class TestMigrateDown(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_down_removes_stories_table(self):
+        migrate.migrate_down()
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='stories'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNone(row)
+
+    def test_down_then_up_again_is_clean(self):
+        migrate.migrate_down()
+        applied = migrate.migrate_up()
+        self.assertIn("001_multi_track", applied)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_migrate.py
+++ b/content-pipeline/tests/test_migrate.py
@@ -2,15 +2,46 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import storage.database as db
 import storage.migrate as migrate
+
+
+class TestMigrateUpOnCleanCheckout(unittest.TestCase):
+    """`migrate up` must work as the very first command on a brand-new DB
+    file — no prior `init_db()` call — since that's the documented flow for
+    a fresh checkout (README / CLAUDE.md just say `python -m storage.migrate up`).
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        # Deliberately do NOT call db.init_db() — simulates a clean checkout
+        # where only `python -m storage.migrate up` has ever been run.
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_up_creates_base_schema_then_applies_migration(self):
+        applied = migrate.migrate_up()
+        self.assertIn("001_multi_track", applied)
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(articles)")}
+        finally:
+            conn.close()
+        self.assertIn("track", cols)
+        self.assertIn("destination", cols)
 
 
 class TestMigrateUp(unittest.TestCase):
@@ -72,6 +103,58 @@ class TestMigrateUp(unittest.TestCase):
             conn.close()
         self.assertIn("track", cols)
         self.assertIn("destination", cols)
+
+
+class TestMigrateAtomicity(unittest.TestCase):
+    """A migration script that fails partway through must leave neither a
+    partial schema change nor a bookkeeping row — schema DDL and the
+    _migrations INSERT are one SQLite transaction (single executescript
+    call), so a mid-script failure rolls both back together.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+
+        self.migrations_dir = Path(tempfile.mkdtemp())
+        # Valid first statement, then a statement that references a
+        # nonexistent table to force a mid-script failure.
+        (self.migrations_dir / "001_broken.sql").write_text(
+            "ALTER TABLE articles ADD COLUMN partial_col TEXT;\n"
+            "ALTER TABLE table_that_does_not_exist ADD COLUMN x TEXT;\n",
+            encoding="utf-8",
+        )
+        self._dir_patch = patch.object(migrate, "MIGRATIONS_DIR", self.migrations_dir)
+        self._dir_patch.start()
+
+    def tearDown(self):
+        self._dir_patch.stop()
+        self._patch.stop()
+
+    def test_failed_migration_leaves_no_bookkeeping_row(self):
+        with self.assertRaises(sqlite3.OperationalError):
+            migrate.migrate_up()
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM _migrations WHERE version = '001_broken'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNone(row)
+
+    def test_failed_migration_rolls_back_partial_schema_change(self):
+        with self.assertRaises(sqlite3.OperationalError):
+            migrate.migrate_up()
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(articles)")}
+        finally:
+            conn.close()
+        self.assertNotIn("partial_col", cols)
 
 
 class TestMigrateStatus(unittest.TestCase):

--- a/docs/current/oauth-setup.md
+++ b/docs/current/oauth-setup.md
@@ -1,0 +1,90 @@
+# OAuth Setup — YouTube Brand Accounts + TikTok Developer Portal
+
+> Hướng dẫn thủ công để lấy OAuth credentials cho từng kênh trong
+> `content-pipeline/channels.py` (`ai_youtube`, `drama_youtube`, `tiktok_main`).
+> Đây là task thủ công (không code) — không có bước nào chạy được tự động.
+
+---
+
+## 1. YouTube Data API v3 — Brand Account cho từng kênh
+
+Mỗi kênh YouTube (`ai_youtube`, `drama_youtube`) nên là một **Brand Account**
+riêng (không phải channel cá nhân gắn trực tiếp vào Gmail chính), để:
+- Uỷ quyền OAuth độc lập, không lộ Gmail cá nhân làm owner trực tiếp.
+- Dễ chuyển quyền quản lý (thêm manager) sau này mà không đổi tài khoản gốc.
+
+### 1.1 Tạo Brand Account
+
+1. Đăng nhập Gmail riêng cho kênh (khuyến nghị: 1 Gmail/kênh, không dùng chung).
+2. Vào [youtube.com](https://youtube.com) → avatar góc phải → **Tạo kênh** →
+   chọn **Sử dụng tên tuỳ chỉnh** → đặt tên kênh (xem `branding/naming.md`).
+   Đây chính là Brand Account.
+3. YouTube Studio → **Tuỳ chỉnh** → upload avatar (800×800) + banner
+   (2560×1440) + mô tả kênh (xem `branding/<channel>/description.md`).
+
+### 1.2 Tạo OAuth2 Client (Google Cloud Console)
+
+1. Vào [console.cloud.google.com](https://console.cloud.google.com) → tạo
+   project mới (hoặc dùng chung 1 project cho cả 2 kênh, chỉ khác OAuth
+   client/token).
+2. **APIs & Services → Library** → bật **YouTube Data API v3**.
+3. **APIs & Services → OAuth consent screen** → loại **External** (hoặc
+   **Internal** nếu dùng Google Workspace) → điền tên app, scope
+   `youtube.upload` + `youtube.force-ssl` (dùng để upload caption track, xem
+   `publisher/youtube_uploader.py`).
+4. **APIs & Services → Credentials → Create Credentials → OAuth client ID**
+   → loại **Desktop app** → tải file `client_secret.json`.
+5. Chạy `publisher/youtube_uploader.py` (hoặc pipeline) lần đầu với
+   `YOUTUBE_CLIENT_SECRETS` trỏ tới file này → trình duyệt mở lên → **đăng
+   nhập đúng Gmail của Brand Account đó** (dễ nhầm sang tài khoản cá nhân) →
+   cấp quyền → token được lưu lại (`YOUTUBE_TOKEN_FILE`).
+
+> ⚠️ **Lưu ý quan trọng:** OAuth consent luôn hỏi "chọn kênh nào để uỷ
+> quyền" nếu Gmail quản lý nhiều Brand Account. Chọn nhầm kênh sẽ khiến video
+> bị upload lên sai kênh. Luôn kiểm tra lại tên kênh trước khi bấm "Cho phép".
+
+6. Vì mỗi kênh cần một token riêng, đặt tên file token theo kênh (ví dụ
+   `.youtube_token_ai.json`, `.youtube_token_drama.json`) và trỏ biến môi
+   trường tương ứng (`YOUTUBE_AI_TOKEN`, `YOUTUBE_DRAMA_TOKEN` trong
+   `.env.example`) tới đường dẫn token đó — logic đọc đúng biến theo kênh sẽ
+   được nối dây ở Phase 5, hiện tại các biến này chỉ cần tồn tại.
+
+### 1.3 Lấy Channel ID
+
+YouTube Studio → **Cài đặt → Kênh → Thông tin nâng cao** → copy
+**ID kênh** (`UC...`) → điền vào `YOUTUBE_AI_CHANNEL_ID` /
+`YOUTUBE_DRAMA_CHANNEL_ID`.
+
+---
+
+## 2. TikTok Developer Portal — Content Posting API
+
+1. Đăng ký tài khoản tại [developers.tiktok.com](https://developers.tiktok.com).
+2. **Manage apps → Create an app** → điền thông tin app.
+3. Ở phần **Products**, thêm **Content Posting API** → xin quyền
+   `video.publish` (cần TikTok review trước khi dùng production; sandbox mode
+   dùng được ngay để test).
+4. **Login Kit** → cấu hình OAuth redirect URI cho flow ủy quyền.
+5. Thực hiện OAuth authorization code flow (theo tài liệu TikTok) với tài
+   khoản TikTok chính (`tiktok_main` trong `channels.py`, dùng chung cho cả 2
+   track) → nhận `access_token` + `open_id`.
+6. Điền `TIKTOK_TOKEN` (access token) và `TIKTOK_OPEN_ID` vào `.env`.
+
+> TikTok access token hết hạn định kỳ (thường 24h cho access token, có
+> refresh token riêng) — cần script refresh token định kỳ trước khi dùng cho
+> cron tự động (nằm ngoài phạm vi Phase 1, sẽ xử lý ở Phase 5).
+
+---
+
+## 3. Checklist sau khi hoàn tất
+
+- [ ] `ai_youtube`: Brand Account tạo xong, branding tối thiểu, OAuth token lưu tại đường dẫn `YOUTUBE_AI_TOKEN`.
+- [ ] `drama_youtube`: tương tự.
+- [ ] `tiktok_main`: tài khoản tạo xong, bio có đủ 2 hashtag series, `TIKTOK_TOKEN`/`TIKTOK_OPEN_ID` đã điền.
+- [ ] `.env` (không commit) đã điền đủ; `.env.example` chỉ chứa placeholder.
+
+## Liên kết
+
+- Channel registry: `content-pipeline/channels.py`
+- Branding draft: `branding/naming.md`
+- Phase 1 design doc: `docs/current/phase-1-detailed.md`


### PR DESCRIPTION
## Summary

Implements the code-facing parts of Phase 1 (`docs/current/phase-1-detailed.md`, `docs/current/phase-1-issues.md`):

- **`content-pipeline/channels.py`** — channel registry, single source of truth for every destination. 3 entries (`ai_youtube`, `drama_youtube`, `tiktok_main`), `get_channel()` raises `ValueError` on an unknown key. Plus `channels_for_track()` / `channels_for_platform()` helpers.
- **DB migration system** — `storage/migrations/001_multi_track.sql` (+ `_down.sql`) adds `track`/`destination` to `articles` and `videos` (default `track='ai'`, preserving current behavior) and creates the `stories` table for the upcoming Drama track. `storage/migrate.py` is an idempotent CLI runner (`up` / `down` / `status`) tracked via a `_migrations` table, independent from `init_db()`.
- **`storage/database.py`** — `insert_article()` / `insert_video()` now accept optional `track`/`destination` kwargs (default `track="ai"`), with a legacy-INSERT fallback so pre-migration DBs keep working.
- **`config.py` / `.env.example`** — per-channel credential placeholders (`YOUTUBE_AI_TOKEN`, `YOUTUBE_AI_CHANNEL_ID`, `YOUTUBE_DRAMA_TOKEN`, `YOUTUBE_DRAMA_CHANNEL_ID`, `TIKTOK_TOKEN`, `TIKTOK_OPEN_ID`) referenced by `channels.py`'s `oauth_token_env` field. Actual multi-channel upload routing is explicitly out of scope for Phase 1 (lands in Phase 5).
- **Docs** — `CLAUDE.md` and `README.md` updated with the multi-channel architecture; new `docs/current/oauth-setup.md` walks through YouTube Brand Account + TikTok Developer Portal OAuth setup.
- **`branding/`** — EPIC #1.3 is manual by nature (real account creation, live name-availability checks, logo/banner design aren't things this session can do). Scaffolded the text deliverables instead: `naming.md` (5 candidate names per channel + rationale), channel description drafts, TikTok bio draft — each with a manual follow-up checklist.

## Out of scope (per phase-1-detailed.md)

- Drama content logic (Phase 2–3).
- Actual multi-channel upload routing in the uploaders/scheduler (Phase 5).
- Real YouTube/TikTok account creation, logo/banner design, live name checks (manual, see `branding/README.md`).

## Test plan

- [x] `python3 -m unittest discover -s content-pipeline/tests` — 265 tests pass (2 skipped, missing optional `Pillow`), including 23 new tests across `test_channels.py` and `test_migrate.py`.
- [x] Manually exercised `storage/migrate.py` CLI (`status` → `up` → `status`) against a scratch DB.
- [x] Verified `insert_article`/`insert_video` work both before and after migration (legacy-INSERT fallback covered by test).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
