### PR TITLE
Phase 1 follow-up: real channel names, TikTok bio guide, per-channel OAuth

### DIFF
--- a/branding/README.md
+++ b/branding/README.md
@@ -6,19 +6,17 @@ Thư mục này chứa asset branding cho 2 kênh YouTube (`ai_youtube`,
 
 ## Trạng thái
 
-EPIC #1.3 là task **thủ công** (không code) — phần này chỉ scaffold nội dung
-text (naming draft, description draft, bio draft) để người quyết định branding
-duyệt/chỉnh sửa. Các việc sau **cần làm thủ công ngoài phiên làm việc này**
-(không thể tự động hoá từ môi trường coding):
+EPIC #1.3 là task **thủ công** (không code). Tiến độ thực tế:
 
-- [ ] Chốt tên cuối cùng cho từng kênh (xem `naming.md` — 5 candidate/kênh,
-      cần kiểm tra tên trống trên YouTube/TikTok trước khi chốt).
-- [ ] Thiết kế avatar (800×800) + banner (2560×1440) — Midjourney/Ideogram +
-      Canva, hoặc thuê designer.
-- [ ] Đăng ký 2 kênh YouTube trên 2 Gmail riêng, tạo Brand Account (xem
-      `docs/current/oauth-setup.md`).
-- [ ] Đăng ký tài khoản TikTok, viết bio + link bio (Linktree/Beacons).
-- [ ] Upload avatar/banner/description lên từng kênh.
+- [x] Đăng ký 2 kênh YouTube trên 2 Gmail riêng:
+      `[2P] AI Hôm Nay` (`2p.broadcast@gmail.com`),
+      `[2P] Chuyện Đời` (`2p.drama@gmail.com`).
+- [x] Đăng ký 1 tài khoản TikTok (bằng `2p.broadcast@gmail.com`).
+- [x] Thiết kế avatar + banner + description cho 2 kênh YouTube, đã upload.
+- [ ] Đặt bio + link-in-bio cho TikTok (xem `tiktok/bio.md` — hướng dẫn từng
+      bước) và ghi lại handle thật vào `naming.md`.
+- [ ] Setup OAuth2 cho kênh `[2P] Chuyện Đời` (đã có OAuth2 cho `AI Hôm Nay`
+      từ trước) — xem `docs/current/oauth-setup.md` mục 1.4.
 
 ## Cấu trúc
 

--- a/branding/ai_youtube/description.md
+++ b/branding/ai_youtube/description.md
@@ -1,8 +1,8 @@
-# Channel description draft — AI Đi Làm (`ai_youtube`)
+# Channel description draft — [2P] AI Hôm Nay (`ai_youtube`)
 
-> Draft — chỉnh sửa tự do trước khi dán vào YouTube Studio → Tuỳ chỉnh → Mô tả.
-> Mục tiêu 200–400 ký tự, có keyword chính + lịch đăng + CTA (theo acceptance
-> criteria `phase-1-issues.md` EPIC #1.3).
+> Kênh đã được tạo và branding (avatar/banner/description) đã hoàn tất thủ
+> công. Giữ bản draft dưới đây làm tài liệu tham khảo/lịch sử — nội dung thật
+> trên kênh có thể đã khác.
 
 ## Bản tiếng Việt (chính)
 
@@ -26,7 +26,6 @@ tức AI mới nhất và cách áp dụng ngay vào công việc hàng ngày.
 
 ## Việc còn lại (thủ công)
 
-- [ ] Duyệt/chỉnh nội dung theo giọng văn thật của kênh.
-- [ ] Dán vào YouTube Studio sau khi kênh được tạo (xem
-      `docs/current/oauth-setup.md`).
-- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh.
+- [x] Duyệt/chỉnh nội dung theo giọng văn thật của kênh.
+- [x] Dán vào YouTube Studio (kênh đã tạo và branding đã hoàn tất).
+- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh (nếu chưa có).

--- a/branding/drama_youtube/description.md
+++ b/branding/drama_youtube/description.md
@@ -1,9 +1,9 @@
-# Channel description draft — Chuyện Đời (`drama_youtube`)
+# Channel description draft — [2P] Chuyện Đời (`drama_youtube`)
 
-> Draft — chỉnh sửa tự do trước khi dán vào YouTube Studio → Tuỳ chỉnh → Mô tả.
-> Mục tiêu 200–400 ký tự, có keyword chính + lịch đăng + CTA (theo acceptance
-> criteria `phase-1-issues.md` EPIC #1.3). Nội dung Drama chi tiết thuộc
-> Phase 2 — draft này chỉ mô tả định vị kênh ở mức tổng quát.
+> Kênh đã được tạo và branding (avatar/banner/description) đã hoàn tất thủ
+> công. Giữ bản draft dưới đây làm tài liệu tham khảo/lịch sử — nội dung thật
+> trên kênh có thể đã khác. Nội dung Drama chi tiết (rubric, nguồn chuyện,
+> giọng kể) vẫn thuộc Phase 2.
 
 ## Bản tiếng Việt (chính)
 
@@ -25,8 +25,7 @@ một khoảnh khắc khiến bạn phải suy nghĩ lại.
 
 ## Việc còn lại (thủ công)
 
-- [ ] Duyệt/chỉnh nội dung sau khi Phase 2 chốt định hướng nội dung Drama cụ
-      thể hơn (rubric, nguồn chuyện, giọng kể).
-- [ ] Dán vào YouTube Studio sau khi kênh được tạo (xem
-      `docs/current/oauth-setup.md`).
-- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh.
+- [x] Dán vào YouTube Studio (kênh đã tạo và branding đã hoàn tất).
+- [ ] Duyệt/chỉnh lại nội dung sau khi Phase 2 chốt định hướng nội dung Drama
+      cụ thể hơn (rubric, nguồn chuyện, giọng kể).
+- [ ] Thêm link bio (Linktree/Beacons) vào phần "Liên kết" của kênh (nếu chưa có).

--- a/branding/naming.md
+++ b/branding/naming.md
@@ -1,62 +1,70 @@
-# Naming — Draft (chưa chốt)
+# Naming
 
-> **Trạng thái: DRAFT.** Đây là bản brainstorm để người quyết định branding
-> chọn/chỉnh. Chưa kiểm tra tên nào còn trống trên YouTube/TikTok — bắt buộc
-> kiểm tra thủ công trước khi đăng ký kênh thật (search trực tiếp trên
-> youtube.com và tiktok.com, và domain nếu định mua link-in-bio riêng).
+> **Trạng thái: ĐÃ CHỐT cho 2 kênh YouTube.** TikTok còn thiếu handle thật —
+> xem mục cuối.
 
 ## Kênh YouTube AI (`ai_youtube` trong `channels.py`)
 
 Định vị: AI cho dân văn phòng Việt Nam 22–35 tuổi, không rành kỹ thuật, "hiểu
 và dùng AI trong 5 phút".
 
+**ĐÃ CHỐT: `[2P] AI Hôm Nay`** — kênh đã tạo, quản lý bởi `2p.broadcast@gmail.com`.
+
+<details>
+<summary>Candidate list ban đầu (tham khảo)</summary>
+
 | # | Tên đề xuất | Lý do |
 |---|-------------|-------|
-| 1 | **AI Đi Làm** *(working title hiện tại)* | Ngắn, đúng định vị "AI cho người đi làm", dễ nhớ, dễ SEO tiếng Việt |
+| 1 | AI Đi Làm | Ngắn, đúng định vị "AI cho người đi làm", dễ nhớ, dễ SEO tiếng Việt |
 | 2 | 5 Phút AI | Nhấn mạnh format ngắn gọn — lời hứa cốt lõi của kênh |
 | 3 | AI Văn Phòng | Rõ đối tượng, dễ tìm trên search |
 | 4 | AI Cho Người Bận Rộn | Nhấn insight "không có thời gian học AI" |
 | 5 | Sếp AI | Thân thiện, gợi tò mò, dễ tạo thumbnail/branding vui |
 
-**Đề xuất chốt:** giữ **AI Đi Làm** trừ khi kiểm tra trùng tên/nhãn hiệu.
+</details>
 
 ## Kênh YouTube Drama (`drama_youtube` trong `channels.py`)
 
 Định vị: nội dung Drama/Twist (kể chuyện, plot twist) — xem Phase 2 để biết
 chi tiết nội dung.
 
+**ĐÃ CHỐT: `[2P] Chuyện Đời`** — kênh đã tạo, quản lý bởi `2p.drama@gmail.com`.
+
+<details>
+<summary>Candidate list ban đầu (tham khảo)</summary>
+
 | # | Tên đề xuất | Lý do |
 |---|-------------|-------|
-| 1 | **Chuyện Đời** *(working title hiện tại)* | Ngắn, trung tính, dễ mở rộng nhiều thể loại chuyện |
+| 1 | Chuyện Đời | Ngắn, trung tính, dễ mở rộng nhiều thể loại chuyện |
 | 2 | Góc Khuất | Gợi drama/bí mật, đúng tinh thần "twist" |
 | 3 | Chuyện Kể Đêm Khuya | Gợi hình ảnh storytelling, phù hợp video dài |
 | 4 | Twist Đời Thường | Nói thẳng chất "twist" của nội dung |
 | 5 | Drama Đời Thực | Rõ thể loại, dễ tìm kiếm |
 
-**Đề xuất chốt:** giữ **Chuyện Đời** trừ khi kiểm tra trùng tên/nhãn hiệu.
+</details>
 
 ## Tài khoản TikTok (`tiktok_main` trong `channels.py`)
 
 1 tài khoản mix cả 2 track, phân biệt bằng 2 hashtag series (xem
-`tiktok/bio.md`).
+`tiktok/bio.md`). Tài khoản đã tạo bằng `2p.broadcast@gmail.com`, **nhưng
+handle thật (@...) chưa được ghi lại ở đây.**
 
 | # | Handle đề xuất | Lý do |
 |---|-----------------|-------|
-| 1 | **@phuong.contentlab** *(working title hiện tại)* | Gắn với tên người sáng lập, dễ nhớ |
+| 1 | @phuong.contentlab *(placeholder cũ)* | Gắn với tên người sáng lập, dễ nhớ |
 | 2 | @aivadrama | Nói rõ 2 track (AI và Drama) trong 1 handle |
 | 3 | @contentlab.vn | Trung tính, dễ mở rộng track mới sau này |
-| 4 | @2phutmoingay | Nhấn format ngắn gọn, giống AI Đi Làm |
+| 4 | @2phutmoingay | Nhấn format ngắn gọn |
 | 5 | @phuong.aidrama | Kết hợp tên cá nhân + 2 track |
 
-**Đề xuất chốt:** giữ **@phuong.contentlab** trừ khi đã bị trùng trên TikTok.
+**TODO:** điền handle TikTok thật vào đây và vào
+`content-pipeline/channels.py` (field `"name"` của `tiktok_main`).
 
 ---
 
-## Việc còn lại (thủ công)
+## Checklist còn lại
 
-- [ ] Search trực tiếp trên youtube.com/tiktok.com để xác nhận tên/handle
-      còn trống.
-- [ ] Chốt 1 tên/kênh, ghi quyết định cuối + lý do vào file này (thay phần
-      "Đề xuất chốt" ở trên bằng "ĐÃ CHỐT").
-- [ ] Cập nhật `content-pipeline/channels.py` field `"name"` nếu tên cuối
-      khác placeholder hiện tại.
+- [x] Chốt tên 2 kênh YouTube, cập nhật `channels.py`.
+- [ ] Điền handle TikTok thật (xem TODO ở trên).
+- [ ] (Tuỳ chọn) Kiểm tra trùng nhãn hiệu/tên nếu định mở rộng thương hiệu
+      sau này (domain riêng, sản phẩm phụ, ...).

--- a/branding/tiktok/bio.md
+++ b/branding/tiktok/bio.md
@@ -1,8 +1,9 @@
-# TikTok bio draft — `tiktok_main`
+# TikTok bio — `tiktok_main`
 
-> Draft — 1 tài khoản TikTok đăng cả 2 track (AI + Drama), phân biệt bằng 2
-> hashtag series riêng (theo acceptance criteria `phase-1-issues.md` EPIC
-> #1.3: "Bio chứa 2 hashtag series + link bio").
+> 1 tài khoản TikTok đăng cả 2 track (AI + Drama), phân biệt bằng 2 hashtag
+> series riêng (theo acceptance criteria `phase-1-issues.md` EPIC #1.3: "Bio
+> chứa 2 hashtag series + link bio"). Tài khoản đã tạo bằng
+> `2p.broadcast@gmail.com` — còn thiếu: đặt bio + link-in-bio (hướng dẫn dưới).
 
 ## Bio draft (giới hạn ~80 ký tự của TikTok)
 
@@ -16,16 +17,61 @@
 - Track AI: `#AIDiLam` (gắn vào caption mọi video track `ai`)
 - Track Drama: `#ChuyenDoiTwist` (gắn vào caption mọi video track `drama`)
 
-## Link bio
+*(Đổi tên hashtag nếu muốn khớp tên kênh thật `[2P] AI Hôm Nay` /
+`[2P] Chuyện Đời`, ví dụ `#AIHomNay` / `#ChuyenDoi2P` — chỉ cần nhớ dùng
+đúng 1 cặp hashtag xuyên suốt để dễ theo dõi hiệu quả.)*
 
-Dùng Linktree/Beacons trỏ tới:
-- Kênh YouTube AI (`ai_youtube`)
-- Kênh YouTube Drama (`drama_youtube`)
+---
+
+## Hướng dẫn đặt bio + link-in-bio (từng bước)
+
+### 1. Đặt bio text
+
+1. Mở app TikTok → tab **Hồ sơ (Profile)** → **Chỉnh sửa hồ sơ (Edit profile)**.
+2. Ở ô **Tiểu sử (Bio)** (giới hạn 80 ký tự), dán nội dung ở phần "Bio draft"
+   phía trên (hoặc bản bạn tự viết).
+3. Lưu lại.
+
+> Lưu ý: bio text ở TikTok **không tự động biến URL thành link bấm được**
+> trừ khi đặt vào đúng ô "Website" (bước 2 dưới) — dán link thô vào bio text
+> chỉ hiện dạng chữ, không bấm được.
+
+### 2. Bật link ngoài (Website) trong bio
+
+TikTok chỉ hiện ô "Website"/"Trang web" có thể bấm được khi tài khoản là
+**Business Account** (miễn phí, không cần điều kiện follower):
+
+1. **Cài đặt (Settings) → Quản lý tài khoản (Manage account) → Chuyển sang
+   tài khoản doanh nghiệp (Switch to Business Account)** → chọn danh mục phù
+   hợp (ví dụ "Media/News Company" hoặc "Personal blog").
+2. Quay lại **Chỉnh sửa hồ sơ (Edit profile)** → sẽ xuất hiện thêm ô
+   **Website**.
+3. Dán link Linktree/Beacons vào ô này (xem bước 3) → lưu lại.
+
+### 3. Tạo link-in-bio (Linktree hoặc Beacons — miễn phí)
+
+1. Vào [linktr.ee](https://linktr.ee) (hoặc [beacons.ai](https://beacons.ai))
+   → đăng ký tài khoản miễn phí.
+2. Tạo các nút link, tối thiểu:
+   - "🤖 AI Hôm Nay — YouTube" → URL kênh `[2P] AI Hôm Nay`
+   - "🎭 Chuyện Đời — YouTube" → URL kênh `[2P] Chuyện Đời`
+   - (tuỳ chọn) link Telegram/kênh khác nếu có.
+3. Đặt tên trang ngắn (vd `linktr.ee/2pcontent`) → copy link.
+4. Dán link đó vào ô **Website** ở bước 2.
+
+### 4. Kiểm tra lại
+
+- [ ] Mở trang cá nhân TikTok bằng tài khoản khác (hoặc trình duyệt ẩn danh)
+      để xác nhận: bio hiển thị đúng, nút Website hiện ra và bấm vào mở đúng
+      trang Linktree/Beacons.
+- [ ] Bấm thử từng nút trên Linktree/Beacons để chắc chắn dẫn đúng kênh
+      YouTube.
+
+---
 
 ## Việc còn lại (thủ công)
 
-- [ ] Đăng ký tài khoản TikTok thật, xác nhận handle còn trống (xem
-      `../naming.md`).
-- [ ] Tạo Linktree/Beacons, dán link vào phần bio TikTok.
+- [ ] Ghi lại handle TikTok thật vào `../naming.md` sau khi đặt xong.
+- [ ] Thực hiện 4 bước ở trên.
 - [ ] Xác nhận 2 hashtag series không trùng hashtag đang được dùng phổ biến
       cho nội dung khác (search trên TikTok trước khi chốt).

--- a/content-pipeline/channels.py
+++ b/content-pipeline/channels.py
@@ -29,7 +29,7 @@ CHANNELS: dict[str, Channel] = {
     "ai_youtube": {
         "platform": "youtube",
         "track": "ai",
-        "name": "AI Đi Làm",                   # placeholder, user chốt
+        "name": "[2P] AI Hôm Nay",             # Gmail owner: 2p.broadcast@gmail.com
         "format_long": True,
         "format_shorts": True,
         "oauth_token_env": "YOUTUBE_AI_TOKEN",
@@ -38,7 +38,7 @@ CHANNELS: dict[str, Channel] = {
     "drama_youtube": {
         "platform": "youtube",
         "track": "drama",
-        "name": "Chuyện Đời",                  # placeholder
+        "name": "[2P] Chuyện Đời",              # Gmail owner: 2p.drama@gmail.com
         "format_long": True,
         "format_shorts": True,
         "oauth_token_env": "YOUTUBE_DRAMA_TOKEN",
@@ -47,7 +47,7 @@ CHANNELS: dict[str, Channel] = {
     "tiktok_main": {
         "platform": "tiktok",
         "track": "mixed",                      # cả 2 track đăng cùng tài khoản
-        "name": "@phuong.contentlab",          # placeholder
+        "name": "@phuong.contentlab",          # TODO: cập nhật đúng handle thật (account 2p.broadcast@gmail.com)
         "format_long": False,
         "format_shorts": True,
         "oauth_token_env": "TIKTOK_TOKEN",

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -83,7 +83,10 @@ def _get_authenticated_service(token_file: str | None = None):
             flow = InstalledAppFlow.from_client_secrets_file(config.YOUTUBE_CLIENT_SECRETS, SCOPES)
             creds = flow.run_local_server(port=0)
 
-        os.makedirs(os.path.dirname(token_file), exist_ok=True)
+        # os.path.dirname("") for a bare filename (e.g. --token-file
+        # .youtube_token_drama.json) — makedirs("") raises FileNotFoundError,
+        # so fall back to the current directory.
+        os.makedirs(os.path.dirname(token_file) or ".", exist_ok=True)
         with open(token_file, "w") as f:
             f.write(creds.to_json())
 

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -43,14 +43,22 @@ def _has_required_scopes(granted) -> bool:
     return set(SCOPES).issubset(set(granted or []))
 
 
-def _get_authenticated_service():
-    """Build authenticated YouTube API service."""
+def _get_authenticated_service(token_file: str | None = None):
+    """Build authenticated YouTube API service.
+
+    `token_file` defaults to config.YOUTUBE_TOKEN_FILE (the single-channel
+    behaviour used by upload_video/upload_caption today). Pass an explicit
+    path to authenticate a *different* channel using the same OAuth2 client
+    — one Google Cloud OAuth client can authorize multiple Google accounts;
+    what differs is which token file the resulting credentials are saved to.
+    See docs/current/oauth-setup.md and this module's __main__ CLI below.
+    """
     from google.oauth2.credentials import Credentials
     from google_auth_oauthlib.flow import InstalledAppFlow
     from googleapiclient.discovery import build
 
     creds = None
-    token_file = config.YOUTUBE_TOKEN_FILE
+    token_file = token_file or config.YOUTUBE_TOKEN_FILE
 
     if os.path.exists(token_file):
         creds = Credentials.from_authorized_user_file(token_file, SCOPES)
@@ -191,8 +199,48 @@ def upload_caption(video_url_or_id: str, srt_path: str,
         return False
 
 
+def _authenticate_and_print(token_file: str | None):
+    """Run the OAuth flow (if needed) and print which channel it authenticated
+    as — the key check when authorizing a second channel/account so you catch
+    a wrong-account mistake before it ever reaches an upload.
+    """
+    resolved_path = token_file or config.YOUTUBE_TOKEN_FILE
+    service = _get_authenticated_service(token_file)
+    if not service:
+        print("Authentication failed — check YOUTUBE_CLIENT_SECRETS in .env.")
+        return
+    try:
+        resp = service.channels().list(part="snippet", mine=True).execute()
+    except Exception as e:
+        print(f"Authenticated, but failed to fetch channel info: {e}")
+        return
+    items = resp.get("items", [])
+    if not items:
+        print("Authenticated, but no channel found for this account.")
+        return
+    for item in items:
+        print(f"Authenticated as channel: {item['snippet']['title']}")
+    print(f"Token saved to: {resolved_path}")
+
+
 if __name__ == "__main__":
+    import argparse
+
     logging.basicConfig(level=logging.INFO)
-    print("YouTube uploader ready.")
-    print("Configure YOUTUBE_CLIENT_SECRETS in .env")
-    print("Run this module to test OAuth flow.")
+    parser = argparse.ArgumentParser(
+        description=(
+            "YouTube uploader. Run directly to (re)authenticate a channel and "
+            "save its OAuth token — use --token-file to set up a SECOND channel "
+            "(e.g. drama_youtube) with the same OAuth2 client from Google Cloud "
+            "Console without overwriting the first channel's token. See "
+            "docs/current/oauth-setup.md."
+        )
+    )
+    parser.add_argument(
+        "--token-file",
+        help="Where to save the OAuth token (default: config.YOUTUBE_TOKEN_FILE). "
+             "Use a distinct path per channel, e.g. "
+             "publisher/.youtube_token_drama.json for the Drama channel.",
+    )
+    args = parser.parse_args()
+    _authenticate_and_print(args.token_file)

--- a/docs/current/oauth-setup.md
+++ b/docs/current/oauth-setup.md
@@ -34,26 +34,63 @@ riêng (không phải channel cá nhân gắn trực tiếp vào Gmail chính), 
    `publisher/youtube_uploader.py`).
 4. **APIs & Services → Credentials → Create Credentials → OAuth client ID**
    → loại **Desktop app** → tải file `client_secret.json`.
-5. Chạy `publisher/youtube_uploader.py` (hoặc pipeline) lần đầu với
-   `YOUTUBE_CLIENT_SECRETS` trỏ tới file này → trình duyệt mở lên → **đăng
-   nhập đúng Gmail của Brand Account đó** (dễ nhầm sang tài khoản cá nhân) →
-   cấp quyền → token được lưu lại (`YOUTUBE_TOKEN_FILE`).
+5. Đặt `YOUTUBE_CLIENT_SECRETS` trong `.env` trỏ tới file này, rồi chạy:
+
+   ```bash
+   cd content-pipeline
+   python publisher/youtube_uploader.py
+   ```
+
+   → trình duyệt mở lên → **đăng nhập đúng Gmail của Brand Account đó** (dễ
+   nhầm sang tài khoản cá nhân) → cấp quyền → token được lưu tại
+   `YOUTUBE_TOKEN_FILE` (mặc định `publisher/.youtube_token.json`). Lệnh này
+   in ra tên kênh vừa xác thực (`Authenticated as channel: ...`) — **luôn
+   kiểm tra tên kênh in ra khớp với kênh bạn định dùng** trước khi chạy upload
+   thật.
 
 > ⚠️ **Lưu ý quan trọng:** OAuth consent luôn hỏi "chọn kênh nào để uỷ
 > quyền" nếu Gmail quản lý nhiều Brand Account. Chọn nhầm kênh sẽ khiến video
 > bị upload lên sai kênh. Luôn kiểm tra lại tên kênh trước khi bấm "Cho phép".
-
-6. Vì mỗi kênh cần một token riêng, đặt tên file token theo kênh (ví dụ
-   `.youtube_token_ai.json`, `.youtube_token_drama.json`) và trỏ biến môi
-   trường tương ứng (`YOUTUBE_AI_TOKEN`, `YOUTUBE_DRAMA_TOKEN` trong
-   `.env.example`) tới đường dẫn token đó — logic đọc đúng biến theo kênh sẽ
-   được nối dây ở Phase 5, hiện tại các biến này chỉ cần tồn tại.
 
 ### 1.3 Lấy Channel ID
 
 YouTube Studio → **Cài đặt → Kênh → Thông tin nâng cao** → copy
 **ID kênh** (`UC...`) → điền vào `YOUTUBE_AI_CHANNEL_ID` /
 `YOUTUBE_DRAMA_CHANNEL_ID`.
+
+### 1.4 Setup OAuth2 cho kênh thứ 2 (cùng project Google Cloud)
+
+Không cần tạo project/OAuth client mới cho kênh thứ 2 — **1 OAuth2 Client ID
+(Desktop app) dùng chung được cho nhiều Google Account/Brand Account khác
+nhau**; điểm khác nhau là *token nào được sinh ra khi bạn đăng nhập tài khoản
+nào* lúc chạy flow. Vì vậy nếu đã setup OAuth2 xong cho kênh 1 (`AI Hôm Nay`,
+`2p.broadcast@gmail.com`), để setup cho kênh 2 (`Chuyện Đời`,
+`2p.drama@gmail.com`) trong cùng project:
+
+1. **Nếu OAuth consent screen đang ở chế độ Testing** (chưa submit Google
+   verify — thường đúng ở giai đoạn này): vào **APIs & Services → OAuth
+   consent screen → Audience/Test users** → **Add users** → thêm
+   `2p.drama@gmail.com` vào danh sách test user. Thiếu bước này, Google sẽ
+   chặn tài khoản `2p.drama@gmail.com` ngay ở màn hình consent với lỗi
+   "app has not completed verification"/"access blocked".
+2. Chạy lại uploader nhưng chỉ định **token file riêng** cho kênh 2 (không
+   dùng chung path với kênh 1, kẻo bị ghi đè):
+
+   ```bash
+   cd content-pipeline
+   python publisher/youtube_uploader.py \
+       --token-file publisher/.youtube_token_drama.json
+   ```
+
+3. Trình duyệt mở lên → **đăng xuất Google trước nếu trình duyệt đang đăng
+   nhập sẵn `2p.broadcast@gmail.com`**, rồi đăng nhập bằng `2p.drama@gmail.com`
+   → cấp quyền cho kênh `[2P] Chuyện Đời`.
+4. Kiểm tra dòng in ra `Authenticated as channel: ...` đúng là
+   `[2P] Chuyện Đời` (không phải `[2P] AI Hôm Nay`) trước khi coi như xong.
+5. Điền `YOUTUBE_DRAMA_TOKEN=publisher/.youtube_token_drama.json` vào `.env`
+   (đường dẫn tới file token vừa tạo). Việc đọc đúng biến này theo từng kênh
+   khi upload thật sẽ được nối dây ở Phase 5 — Phase 1 chỉ cần token đã sẵn
+   sàng.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #66 (already merged) based on real progress on the manual Phase 1 tasks: 2 YouTube channels created + branded, 1 TikTok account created, OAuth2 already set up for the first YouTube channel.

- **`channels.py` / `branding/naming.md`** — lock in the real channel names: `[2P] AI Hôm Nay` (`2p.broadcast@gmail.com`) and `[2P] Chuyện Đời` (`2p.drama@gmail.com`). TikTok handle still pending (flagged as TODO — not yet provided).
- **`branding/tiktok/bio.md`** — added a concrete step-by-step guide for setting the TikTok bio + link-in-bio: switching to a Business Account (needed to unlock a clickable "Website" field), and wiring up Linktree/Beacons. Bio text alone doesn't render a clickable link on TikTok, which is the gap the user ran into.
- **`publisher/youtube_uploader.py`** — `_get_authenticated_service()` now accepts an optional `token_file` param, and the module's `__main__` CLI actually runs the OAuth flow now (previously it only printed static instructions) and prints which channel it authenticated as. This is what unblocks setting up OAuth2 for the *second* YouTube channel (`Chuyện Đời`) using the same Google Cloud OAuth2 client as the first, without overwriting the first channel's saved token.
- **`docs/current/oauth-setup.md`** — new §1.4 walks through setting up OAuth2 for a second channel in the same project: adding the second Gmail as an OAuth consent-screen test user (the actual blocker most people hit), running the uploader with `--token-file`, and verifying the printed channel name before trusting the token.
- **`branding/*/description.md`** — marked the manual branding steps as done (avatars/banners/descriptions already designed and uploaded).

## Out of scope (unchanged from #66)

- Drama content logic (Phase 2–3).
- Actual multi-channel upload routing in the uploaders/scheduler (Phase 5) — the new `token_file` param only unblocks *generating* the second token now; wiring the uploader to pick the right token per channel at publish time is still Phase 5.
- TikTok Developer Portal OAuth (unchanged, see `docs/current/oauth-setup.md` §2).

## Test plan

- [x] `python3 -m unittest discover -s content-pipeline/tests` — 268 tests pass (2 skipped, missing optional `Pillow`).
- [x] `python3 -m py_compile publisher/youtube_uploader.py channels.py`.
- [x] `python3 publisher/youtube_uploader.py --help` — confirms the new `--token-file` CLI flag works.
- Note: did not add a unit test directly exercising `_get_authenticated_service()`'s new `token_file` branch — the google-auth import chain isn't safely mockable in this sandbox (unrelated environment issue with a system `cryptography` build), and the existing test file's stated philosophy is to never invoke the real google-auth code path in tests.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
