### PR TITLE
Phase 2 + 3: Drama Source & Generation Layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,19 +24,23 @@ Chi phí mục tiêu: ~$4/tháng
 ```
 content-pipeline/
 ├── collectors/
-│   ├── rss_collector.py        # Thu thập RSS feeds (The Rundown, Ben's Bites, VnExpress)
-│   ├── twitter_collector.py    # Twitter API v2
-│   └── reddit_collector.py     # Reddit API (r/ChatGPT, r/artificial)
+│   ├── rss_collector.py         # Thu thập RSS feeds (The Rundown, Ben's Bites, VnExpress)
+│   ├── twitter_collector.py     # Twitter API v2
+│   ├── reddit_collector.py      # Reddit API (r/ChatGPT, r/artificial) — track AI
+│   └── reddit_drama_collector.py # Reddit RSS+JSON (AITA, ProRevenge, ...) — track Drama (Phase 2)
 ├── processors/
 │   ├── rule_filter.py          # Lọc keyword, không dùng AI
 │   ├── ai_scorer.py            # Chấm điểm 1-10 bằng Claude Haiku (rẻ)
 │   └── ai_analyzer.py          # Phân tích sâu bằng Claude Sonnet (bài tốt)
 ├── storage/
-│   ├── database.py             # SQLite — CRUD cho articles/videos/stories
+│   ├── database.py             # SQLite — CRUD cho articles/videos
+│   ├── stories.py              # CRUD cho bảng stories (track Drama, Phase 2)
+│   ├── collector_health.py     # Theo dõi last_success/alert nếu collector im lặng (Phase 2)
 │   ├── migrate.py              # Migration runner (up/down/status)
 │   └── migrations/             # File SQL versioned, vd 001_multi_track.sql
 ├── notifier/
-│   └── telegram_bot.py         # Gửi báo cáo sáng qua Telegram Bot API
+│   ├── telegram_bot.py         # Bot chính: báo cáo sáng + approve/reject + dispatch seed bot
+│   └── seed_bot.py             # Command handlers /seed_vn, /seed_url, /list_pending (Phase 2)
 ├── channels.py                 # Channel registry — nguồn sự thật cho mọi destination
 ├── config.py                   # API keys, keywords, thresholds
 ├── main.py                     # Orchestrator — chạy toàn bộ pipeline
@@ -65,6 +69,47 @@ Từ Phase 1, pipeline hỗ trợ nhiều kênh/nhiều track thay vì 1 kênh A
 - Migration được áp dụng qua `python -m storage.migrate up` (chạy từ thư mục
   `content-pipeline/`), không phải qua `init_db()` — xem
   `storage/migrations/001_multi_track.sql`.
+
+---
+
+## Drama Source Layer (Phase 2)
+
+Xem `docs/current/phase-2-detailed.md`. Xây tầng thu thập nguồn cho track
+Drama — chưa có logic chấm điểm/rewrite (Phase 3).
+
+- **`collectors/reddit_drama_collector.py`** — cào top post từ 5 subreddit
+  (`AmItheAsshole`, `AskReddit`, `relationship_advice`, `MaliciousCompliance`,
+  `ProRevenge`) qua RSS (`/top/.rss?t=day`), sau đó gọi JSON API
+  (`/comments/{id}.json`) để lấy `score`/`selftext`/`over_18` — RSS không có
+  các trường này. **Khác với tài liệu thiết kế:** lọc NSFW dùng cờ `over_18`
+  chính thức từ JSON detail (không đoán từ RSS, vì Reddit không document rõ
+  field NSFW trong RSS) — đằng nào cũng phải gọi JSON API nên dùng luôn nguồn
+  đáng tin cậy hơn. Rate limit 1 req/2s, retry 3 lần backoff cho JSON call.
+  Chạy: `python -m collectors.reddit_drama_collector` (06:06 sáng, xem
+  `launchd/com.ai5phut.reddit-drama.plist`).
+- **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
+  `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
+  002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
+  nhận field trong allowlist, tránh dựng UPDATE động từ tên cột tuỳ ý).
+- **`notifier/seed_bot.py`** — xử lý lệnh `/seed_vn`, `/seed_url`,
+  `/list_pending` cho việc feed "tình huống lõi" VN-original thủ công.
+  **Khác với tài liệu thiết kế:** tài liệu đề xuất chạy 1 process
+  `python-telegram-bot` độc lập song song với bot approve/reject hiện có.
+  Thực tế `seed_bot.py` chỉ export các hàm xử lý THUẦN, được
+  `notifier/telegram_bot.py._handle_update()` gọi vào TRONG CÙNG vòng
+  long-polling đang chạy — vì Telegram chỉ cho phép 1 `getUpdates` connection
+  tại 1 thời điểm/bot token; 2 process độc lập cùng token sẽ liên tục bị lỗi
+  409 Conflict. State hội thoại (chờ nội dung sau `/seed_vn`) lưu trong
+  `notifier/.seed_state.json` (persisted qua restart).
+- **`storage/collector_health.py`** — `record_success(name)` sau mỗi lần
+  `reddit_drama_collector` chạy xong (không raise, kể cả 0 story mới — đó là
+  bình thường, không phải lỗi). Job riêng `python -m storage.collector_health`
+  (chạy 06:30 + 18:30, xem `launchd/com.ai5phut.drama-health.plist`) alert
+  Telegram (`notifier.telegram_bot.send_alert`) nếu 1 collector chưa thành
+  công quá 2 ngày — bắt lỗi cron dừng chạy hoặc crash không bắt được, không
+  phải để phát hiện "0 bài hôm nay".
+- Migration 002 (`stories.title`/`metadata` + unique `source_id`) và 003
+  (`collector_health`) — chạy `python -m storage.migrate up` sau khi pull.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,21 @@ content-pipeline/
 │   └── reddit_drama_collector.py # Reddit RSS+JSON (AITA, ProRevenge, ...) — track Drama (Phase 2)
 ├── processors/
 │   ├── rule_filter.py          # Lọc keyword, không dùng AI
-│   ├── ai_scorer.py            # Chấm điểm 1-10 bằng Claude Haiku (rẻ)
-│   └── ai_analyzer.py          # Phân tích sâu bằng Claude Sonnet (bài tốt)
+│   ├── ai_scorer.py            # Chấm điểm 1-10 bằng Claude Haiku (rẻ) — track AI
+│   ├── ai_analyzer.py          # Phân tích sâu bằng Claude Sonnet (bài tốt) — track AI
+│   ├── prompt_loader.py        # load_prompt()/render() — đọc prompts/{module}/{name}.{version}.txt (Phase 3)
+│   ├── ai_usage.py             # Log token usage mỗi call Anthropic (Phase 3)
+│   ├── ab_harness.py           # A/B test prompt version (deterministic theo story_id, Phase 3)
+│   ├── drama_scorer.py         # Rubric 6 tiêu chí bằng Haiku — track Drama (Phase 3)
+│   ├── drama_rewriter.py       # Việt hoá story bằng Sonnet + validate_rewrite() — track Drama (Phase 3)
+│   └── drama_compiler.py       # Gom 3-5 story cùng theme thành video long-form (Phase 3)
+├── prompts/
+│   └── drama/                  # scorer.v1.txt, rewriter.v1.txt, theme_detect.v1.txt, longform.v1.txt
 ├── storage/
 │   ├── database.py             # SQLite — CRUD cho articles/videos
-│   ├── stories.py              # CRUD cho bảng stories (track Drama, Phase 2)
+│   ├── stories.py              # CRUD cho bảng stories (track Drama, Phase 2/3)
+│   ├── compiled_videos.py      # CRUD cho bảng compiled_videos (Phase 3)
+│   ├── ab_runs.py              # CRUD cho bảng ab_runs (Phase 3)
 │   ├── collector_health.py     # Theo dõi last_success/alert nếu collector im lặng (Phase 2)
 │   ├── migrate.py              # Migration runner (up/down/status)
 │   └── migrations/             # File SQL versioned, vd 001_multi_track.sql
@@ -110,6 +120,52 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   phải để phát hiện "0 bài hôm nay".
 - Migration 002 (`stories.title`/`metadata` + unique `source_id`) và 003
   (`collector_health`) — chạy `python -m storage.migrate up` sau khi pull.
+
+---
+
+## Drama Generation Layer (Phase 3)
+
+Xem `docs/current/phase-3-detailed.md`. Biến story `stories.status='pending'`
+(đã qua Phase 2 + đã chấm điểm) thành script tiếng Việt sẵn-render. Ngoài
+phạm vi: TTS/render video thật (Phase 4).
+
+- **`processors/prompt_loader.py`** — `load_prompt(module, name, version=None)`
+  đọc `prompts/{module}/{name}.{version}.txt`; `version` mặc định lấy từ
+  `config.PROMPT_VERSION` (đổi env var để rollback, không cần sửa code).
+  `render(template, **values)` điền placeholder `{{KEY}}` bằng `str.replace`
+  (không phải `.format()`) — tránh phải escape dấu `{`/`}` thật trong các
+  ví dụ JSON schema nằm ngay trong prompt.
+- **`processors/drama_scorer.py`** — chấm 6 tiêu chí (HOOK_3S, STAKES, TWIST,
+  LOCALIZABLE, COMMENT_BAIT, SAFE) bằng Haiku. `total` LUÔN được tính lại từ
+  6 field boolean phía server — không tin số `total` model tự báo cáo (LLM
+  occasionally tính sai tổng). `safe=0` luôn bị loại (`status='rejected'`) dù
+  `total` cao. Story đạt ngưỡng (`config.DRAMA_SCORE_THRESHOLD`, mặc định 5/6)
+  giữ nguyên `status='pending'`, sẵn sàng cho rewriter.
+- **`processors/drama_rewriter.py`** — module quan trọng nhất: Việt hoá story
+  bằng Sonnet (đổi tên/địa điểm sang VN, thêm `vn_commentary` ≥20% thời
+  lượng). `validate_rewrite()` là heuristic gate độc lập với prompt (word
+  count 800-1200, `vn_commentary` ≥200 từ, hook ngắn — proxy cho cấu trúc
+  "Hook 3s", chặn tên/từ văn hoá Mỹ lọt qua). Rewrite hợp lệ →
+  `status='approved'`; không hợp lệ → `status='needs_review'` + alert
+  Telegram (nhưng output vẫn được lưu để người xem lại, không bị huỷ).
+  **Cải tiến so với tài liệu gốc:** 2 rule phòng rủi ro mà tài liệu liệt kê
+  ở mục "Rủi ro" (tên thuần Việt 2-3 từ, không nhắc văn hoá Mỹ) được đưa
+  thẳng vào prompt v1 luôn, không đợi tune sang v2 — xem
+  `docs/current/prompts-decisions.md`.
+- **`processors/drama_compiler.py`** — gom 3-5 story cùng theme (`status=
+  'produced'`, đã qua Phase 4) thành 1 script long-form 8-15 phút + chapter
+  markers. `detect_theme()` (Sonnet, weekly) tìm theme xuất hiện ≥3 story;
+  `compile_long_form()` sinh intro/bridge/outro + validate format chapter
+  marker + word count (1100-2100 từ, suy ra từ tốc độ đọc ~140 từ/phút mà
+  chính codebase này dùng cho video AI dài — xem `video/script_generator.py`).
+- **`processors/ab_harness.py`** — A/B test prompt version. **Thiết kế rút
+  gọn so với tài liệu:** `choose_version(experiment, story_id)` là hash
+  ổn định (không phải random thật) để cùng 1 story luôn ra cùng 1 version
+  dù gọi lại nhiều lần hay retry. `compare_ab_results()` so mean
+  heuristic_score mỗi version sau khi đủ mẫu (`ab_runs` — migration 005).
+- Migration 004 (`compiled_videos`) và 005 (`ab_runs`) — chạy
+  `python -m storage.migrate up` sau khi pull.
+- Prompt versioning + quyết định v1: `docs/current/prompts-decisions.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,18 +27,22 @@ content-pipeline/
 ├── collectors/
 │   ├── rss_collector.py           # RSS feeds (The Rundown, Ben's Bites, VnExpress, Reddit)
 │   ├── twitter_collector.py       # Twitter API v2 (OpenAI, Anthropic, Google, ...)
-│   ├── reddit_collector.py        # Reddit JSON API (r/ChatGPT, r/artificial)
+│   ├── reddit_collector.py        # Reddit JSON API (r/ChatGPT, r/artificial) — track AI
+│   ├── reddit_drama_collector.py  # Reddit RSS+JSON (AITA, ProRevenge, ...) — track Drama
 │   └── producthunt_collector.py   # Product Hunt GraphQL API
 ├── processors/
 │   ├── rule_filter.py             # Lọc keyword, không tốn AI
 │   ├── ai_scorer.py               # Chấm điểm 1-10 bằng Claude Haiku
 │   └── ai_analyzer.py             # Phân tích sâu bằng Claude Sonnet
 ├── storage/
-│   ├── database.py                # SQLite CRUD
+│   ├── database.py                # SQLite CRUD (articles/videos)
+│   ├── stories.py                 # CRUD cho bảng stories (track Drama)
+│   ├── collector_health.py        # Alert Telegram nếu collector im lặng >2 ngày
 │   ├── migrate.py                 # Migration runner (up/down/status)
 │   └── migrations/                # File SQL versioned
 ├── notifier/
-│   └── telegram_bot.py            # Gửi báo cáo qua Telegram Bot API
+│   ├── telegram_bot.py            # Bot chính: báo cáo + approve/reject + dispatch seed bot
+│   └── seed_bot.py                # /seed_vn, /seed_url, /list_pending (feed Drama seed)
 ├── channels.py                    # Channel registry (multi-channel, xem bên dưới)
 ├── config.py                      # Cấu hình tập trung
 ├── main.py                        # Pipeline orchestrator
@@ -65,6 +69,26 @@ Từ Phase 1, pipeline hỗ trợ nhiều kênh thay vì 1 kênh AI duy nhất:
 - Chi tiết thiết kế: [`docs/current/phase-1-detailed.md`](docs/current/phase-1-detailed.md).
 - Logic routing nội dung sang đúng channel để upload sẽ được nối dây ở Phase 5;
   Phase 1 chỉ đặt khung schema + registry.
+
+## Drama Source Layer (Phase 2)
+
+Tầng thu thập nguồn cho track Drama — chưa có logic chấm điểm/rewrite (Phase 3):
+
+- **`collectors/reddit_drama_collector.py`** — cào 5 subreddit drama (AITA,
+  AskReddit, relationship_advice, MaliciousCompliance, ProRevenge) qua RSS +
+  JSON detail (score, NSFW, selftext), lọc theo ngưỡng upvote riêng từng sub.
+  ```bash
+  cd content-pipeline
+  python -m collectors.reddit_drama_collector
+  ```
+- **`notifier/seed_bot.py`** — lệnh Telegram `/seed_vn` (feed tình huống lõi
+  VN-original), `/seed_url` (paste link FB/TikTok), `/list_pending` (xem
+  story đang chờ duyệt). Chạy trong CÙNG bot approve/reject hiện có
+  (`python main.py --bot`) — không phải process riêng, để tránh 2 poller
+  tranh nhau 1 bot token (409 Conflict).
+- **`storage/collector_health.py`** — alert Telegram nếu 1 collector chưa
+  chạy thành công quá 2 ngày: `python -m storage.collector_health`.
+- Chi tiết thiết kế: [`docs/current/phase-2-detailed.md`](docs/current/phase-2-detailed.md).
 
 ## Cài đặt
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ content-pipeline/
 │   └── producthunt_collector.py   # Product Hunt GraphQL API
 ├── processors/
 │   ├── rule_filter.py             # Lọc keyword, không tốn AI
-│   ├── ai_scorer.py               # Chấm điểm 1-10 bằng Claude Haiku
-│   └── ai_analyzer.py             # Phân tích sâu bằng Claude Sonnet
+│   ├── ai_scorer.py               # Chấm điểm 1-10 bằng Claude Haiku — track AI
+│   ├── ai_analyzer.py             # Phân tích sâu bằng Claude Sonnet — track AI
+│   ├── prompt_loader.py           # load_prompt()/render() theo version (Phase 3)
+│   ├── drama_scorer.py            # Rubric 6 tiêu chí bằng Haiku — track Drama
+│   ├── drama_rewriter.py          # Việt hoá story bằng Sonnet + validate_rewrite()
+│   ├── drama_compiler.py          # Gom 3-5 story cùng theme → video long-form
+│   └── ab_harness.py              # A/B test prompt version
+├── prompts/drama/                 # scorer.v1.txt, rewriter.v1.txt, ...
 ├── storage/
 │   ├── database.py                # SQLite CRUD (articles/videos)
 │   ├── stories.py                 # CRUD cho bảng stories (track Drama)
+│   ├── compiled_videos.py         # CRUD cho bảng compiled_videos
+│   ├── ab_runs.py                 # CRUD cho bảng ab_runs
 │   ├── collector_health.py        # Alert Telegram nếu collector im lặng >2 ngày
 │   ├── migrate.py                 # Migration runner (up/down/status)
 │   └── migrations/                # File SQL versioned
@@ -89,6 +97,32 @@ Tầng thu thập nguồn cho track Drama — chưa có logic chấm điểm/rew
 - **`storage/collector_health.py`** — alert Telegram nếu 1 collector chưa
   chạy thành công quá 2 ngày: `python -m storage.collector_health`.
 - Chi tiết thiết kế: [`docs/current/phase-2-detailed.md`](docs/current/phase-2-detailed.md).
+
+## Drama Generation Layer (Phase 3)
+
+Biến story đã chấm điểm (Phase 2) thành script tiếng Việt sẵn-render. Video
+production thật (TTS/render) vẫn thuộc Phase 4:
+
+- **`processors/drama_scorer.py`** — chấm rubric 6 tiêu chí bằng Haiku, loại
+  ngay nếu không an toàn (`safe=0`) dù điểm tổng cao.
+  ```bash
+  cd content-pipeline
+  python -m processors.drama_scorer
+  ```
+- **`processors/drama_rewriter.py`** — Việt hoá story bằng Sonnet (đổi tên/
+  địa điểm sang VN, thêm bình luận góc nhìn Việt ≥20% thời lượng), validate
+  lại bằng heuristic độc lập (word count, tên VN, không lẫn văn hoá Mỹ).
+  ```bash
+  python -m processors.drama_rewriter
+  ```
+- **`processors/drama_compiler.py`** — gộp 3-5 story cùng theme thành video
+  long-form 8-15 phút (chạy weekly).
+- **`processors/ab_harness.py`** — A/B test prompt version, gán version theo
+  hash ổn định của story_id (không phải random) để nhất quán giữa các lần gọi.
+- Prompt versioning: `PROMPT_VERSION` trong `.env` (mặc định `v1`), file
+  prompt tại `prompts/drama/`. Quyết định version + lý do:
+  [`docs/current/prompts-decisions.md`](docs/current/prompts-decisions.md).
+- Chi tiết thiết kế: [`docs/current/phase-3-detailed.md`](docs/current/phase-3-detailed.md).
 
 ## Cài đặt
 

--- a/content-pipeline/.gitignore
+++ b/content-pipeline/.gitignore
@@ -8,7 +8,8 @@ logs/*.log
 .DS_Store
 output/long/
 output/short/
-publisher/.youtube_token.json
+publisher/.youtube_token*.json
 notifier/.telegram_offset
+notifier/.seed_state.json
 video/assets/backgrounds/*.mp4
 video/assets/fonts/*.ttf

--- a/content-pipeline/collectors/reddit_drama_collector.py
+++ b/content-pipeline/collectors/reddit_drama_collector.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+"""
+Reddit Drama Collector — cào top post từ các subreddit "drama" (Phase 2).
+
+Khác với collectors/reddit_collector.py (dùng cho track AI, JSON API 'hot'),
+collector này:
+1. Dùng RSS (`/top/.rss?t=day`) để lấy danh sách post — nhẹ, không cần auth.
+2. Gọi thêm JSON API (`/comments/{id}.json`) cho từng post để lấy `score`
+   (upvotes) và `selftext` đầy đủ — RSS không có 2 trường này.
+3. Lọc theo `min_upvotes` (khác nhau mỗi subreddit) và bỏ NSFW (`over_18`).
+4. Lưu vào bảng `stories` (track='drama') qua storage/stories.py, dedupe theo
+   `source_id`.
+
+Lưu ý thiết kế (khác với phase-2-detailed.md mục 3.1): NSFW được lọc bằng
+cờ `over_18` chính thức từ JSON detail response — không cố đoán từ RSS, vì
+định dạng RSS của Reddit không có trường NSFW được document rõ ràng. Đằng
+nào cũng phải gọi JSON API để lấy score/selftext, nên dùng luôn `over_18`
+từ đó là nguồn duy nhất, đáng tin cậy hơn.
+"""
+
+import json
+import logging
+import re
+import time
+from urllib.request import Request, urlopen
+
+import feedparser
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.stories import insert_story, dedupe_check
+
+logger = logging.getLogger(__name__)
+
+REDDIT_USER_AGENT = "ContentPipeline/1.0 (drama story collector; contact: admin@example.com)"
+
+DRAMA_SUBREDDITS = [
+    {"name": "AmItheAsshole", "min_upvotes": 5000, "weight": 1.5},
+    {"name": "AskReddit", "min_upvotes": 10000, "weight": 1.0},
+    {"name": "relationship_advice", "min_upvotes": 3000, "weight": 1.3},
+    {"name": "MaliciousCompliance", "min_upvotes": 5000, "weight": 1.4},
+    {"name": "ProRevenge", "min_upvotes": 3000, "weight": 1.4},
+]
+
+# Reddit JSON API detail fetch: rate limit + retry tuning.
+DETAIL_MIN_INTERVAL_SECONDS = 2.0
+DETAIL_MAX_RETRIES = 3
+DETAIL_RETRY_BACKOFF_BASE = 2  # seconds: 2, 4, 8...
+
+_POST_ID_FROM_LINK_RE = re.compile(r"/comments/([a-z0-9]+)/", re.IGNORECASE)
+_POST_ID_FROM_FULLNAME_RE = re.compile(r"t3_([a-z0-9]+)", re.IGNORECASE)
+
+
+class _RateLimiter:
+    """Sleeps as needed so consecutive calls are >= min_interval apart."""
+
+    def __init__(self, min_interval: float = DETAIL_MIN_INTERVAL_SECONDS):
+        self.min_interval = min_interval
+        self._last_call = 0.0
+
+    def wait(self):
+        now = time.monotonic()
+        elapsed = now - self._last_call
+        if elapsed < self.min_interval:
+            time.sleep(self.min_interval - elapsed)
+        self._last_call = time.monotonic()
+
+
+_rate_limiter = _RateLimiter()
+
+
+def _extract_post_id(entry: dict) -> str | None:
+    """Extract the bare Reddit post id (e.g. 'abc123') from a feedparser entry."""
+    link = entry.get("link", "") or ""
+    m = _POST_ID_FROM_LINK_RE.search(link)
+    if m:
+        return m.group(1)
+    entry_id = entry.get("id", "") or ""
+    m = _POST_ID_FROM_FULLNAME_RE.search(entry_id)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _fetch_rss_content(url: str) -> str:
+    """Fetch RSS content with a proper User-Agent (network call)."""
+    req = Request(url)
+    req.add_header("User-Agent", REDDIT_USER_AGENT)
+    with urlopen(req, timeout=15) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def parse_rss_entries(rss_content: str) -> list[dict]:
+    """Parse RSS/Atom content into a list of {post_id, title, link, summary}.
+
+    Pure function (no network) — entries with no resolvable post id are
+    skipped since we can't dedupe/detail-fetch them.
+    """
+    feed = feedparser.parse(rss_content)
+    result = []
+    for entry in feed.entries:
+        post_id = _extract_post_id(entry)
+        if not post_id:
+            continue
+        result.append({
+            "post_id": post_id,
+            "title": (entry.get("title", "") or "").strip(),
+            "link": entry.get("link", "") or "",
+            "summary": entry.get("summary", "") or "",
+        })
+    return result
+
+
+def fetch_subreddit_rss(subreddit: str, sort: str = "top", period: str = "day") -> list[dict]:
+    """Fetch + parse the RSS feed for a subreddit. Returns [] on any error."""
+    url = f"https://www.reddit.com/r/{subreddit}/{sort}/.rss?t={period}"
+    try:
+        content = _fetch_rss_content(url)
+    except Exception as e:
+        logger.warning("Failed to fetch RSS for r/%s: %s", subreddit, e)
+        return []
+    entries = parse_rss_entries(content)
+    logger.info("r/%s RSS returned %d entries", subreddit, len(entries))
+    return entries
+
+
+def _fetch_post_json(subreddit: str, post_id: str) -> dict | None:
+    """Fetch raw JSON for a post's detail (network call), rate-limited + retried."""
+    url = f"https://www.reddit.com/r/{subreddit}/comments/{post_id}.json"
+    last_error = None
+    for attempt in range(DETAIL_MAX_RETRIES):
+        _rate_limiter.wait()
+        req = Request(url)
+        req.add_header("User-Agent", REDDIT_USER_AGENT)
+        try:
+            with urlopen(req, timeout=15) as resp:
+                return json.loads(resp.read().decode("utf-8", errors="replace"))
+        except Exception as e:
+            last_error = e
+            wait = DETAIL_RETRY_BACKOFF_BASE ** (attempt + 1)
+            logger.warning(
+                "Attempt %d/%d fetching detail for %s/%s failed: %s",
+                attempt + 1, DETAIL_MAX_RETRIES, subreddit, post_id, e,
+            )
+            if attempt < DETAIL_MAX_RETRIES - 1:
+                time.sleep(wait)
+    logger.error("Giving up on %s/%s after %d attempts: %s",
+                 subreddit, post_id, DETAIL_MAX_RETRIES, last_error)
+    return None
+
+
+def parse_post_detail(raw_json) -> dict | None:
+    """Extract {selftext, ups, over_18} from a /comments/{id}.json response.
+
+    Pure function (no network). Returns None if the shape is unexpected.
+    """
+    try:
+        post_data = raw_json[0]["data"]["children"][0]["data"]
+    except (KeyError, IndexError, TypeError):
+        return None
+    return {
+        "selftext": post_data.get("selftext", "") or "",
+        "ups": post_data.get("score", post_data.get("ups", 0)) or 0,
+        "over_18": bool(post_data.get("over_18", False)),
+    }
+
+
+def collect_subreddit(sub_config: dict) -> int:
+    """Collect eligible posts from one subreddit into `stories`. Returns new-story count."""
+    name = sub_config["name"]
+    min_upvotes = sub_config["min_upvotes"]
+    weight = sub_config.get("weight", 1.0)
+
+    entries = fetch_subreddit_rss(name)
+    count = 0
+    skipped_dup = 0
+    skipped_nsfw = 0
+    skipped_low_score = 0
+    skipped_no_detail = 0
+
+    for entry in entries:
+        source_id = f"reddit_{entry['post_id']}"
+        if dedupe_check(source_id):
+            skipped_dup += 1
+            continue
+
+        detail = _fetch_post_json(name, entry["post_id"])
+        if detail is None:
+            skipped_no_detail += 1
+            continue
+
+        if detail["over_18"]:
+            skipped_nsfw += 1
+            continue
+        if detail["ups"] < min_upvotes:
+            skipped_low_score += 1
+            continue
+
+        raw_content = detail["selftext"] or entry["title"]
+        insert_story(
+            source="reddit",
+            source_id=source_id,
+            raw_content=raw_content,
+            track="drama",
+            title=entry["title"],
+            metadata={
+                "subreddit": name,
+                "upvotes": detail["ups"],
+                "url": entry["link"],
+                "weight": weight,
+            },
+        )
+        count += 1
+
+    if skipped_dup or skipped_nsfw or skipped_low_score or skipped_no_detail:
+        logger.info(
+            "r/%s skipped: %d duplicates, %d nsfw, %d below %d upvotes, %d detail-fetch failed",
+            name, skipped_dup, skipped_nsfw, skipped_low_score, min_upvotes, skipped_no_detail,
+        )
+    logger.info("Collected %d new drama stories from r/%s", count, name)
+    return count
+
+
+def collect_all_drama() -> int:
+    """Collect from every configured drama subreddit. Returns total new stories."""
+    total = 0
+    for sub_config in DRAMA_SUBREDDITS:
+        try:
+            total += collect_subreddit(sub_config)
+        except Exception as e:
+            logger.error("Error collecting r/%s: %s", sub_config["name"], e)
+            continue
+    logger.info("Total new drama stories: %d", total)
+    return total
+
+
+if __name__ == "__main__":
+    import logging.handlers
+
+    logs_dir = os.path.join(os.path.dirname(__file__), "..", "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.StreamHandler(),
+            logging.handlers.TimedRotatingFileHandler(
+                os.path.join(logs_dir, "reddit_drama.log"),
+                when="midnight", backupCount=14, encoding="utf-8",
+            ),
+        ],
+    )
+    from storage.database import init_db
+    from storage.migrate import migrate_up
+    from storage.collector_health import record_success
+    init_db()
+    migrate_up()  # idempotent — ensures stories.title/metadata + track columns exist
+    collect_all_drama()
+    # Completing without an uncaught exception IS the "success" the 2-day
+    # staleness alert (storage/collector_health.py) checks for — 0 new
+    # stories on a given day is normal, not a failure.
+    record_success("reddit_drama")

--- a/content-pipeline/collectors/reddit_drama_collector.py
+++ b/content-pipeline/collectors/reddit_drama_collector.py
@@ -186,7 +186,11 @@ def collect_subreddit(sub_config: dict) -> int:
             skipped_dup += 1
             continue
 
-        detail = _fetch_post_json(name, entry["post_id"])
+        raw_json = _fetch_post_json(name, entry["post_id"])
+        if raw_json is None:
+            skipped_no_detail += 1
+            continue
+        detail = parse_post_detail(raw_json)
         if detail is None:
             skipped_no_detail += 1
             continue
@@ -196,6 +200,12 @@ def collect_subreddit(sub_config: dict) -> int:
             continue
         if detail["ups"] < min_upvotes:
             skipped_low_score += 1
+            continue
+        if detail["selftext"].strip() in ("[removed]", "[deleted]"):
+            # Moderator/user-removed posts return this literal sentinel as
+            # selftext — truthy, so it would otherwise be stored as if it
+            # were real story content.
+            skipped_no_detail += 1
             continue
 
         raw_content = detail["selftext"] or entry["title"]
@@ -224,14 +234,30 @@ def collect_subreddit(sub_config: dict) -> int:
 
 
 def collect_all_drama() -> int:
-    """Collect from every configured drama subreddit. Returns total new stories."""
+    """Collect from every configured drama subreddit. Returns total new stories.
+
+    A single failing subreddit doesn't fail the run (logged and skipped —
+    same resilience philosophy as the rest of this codebase). But if EVERY
+    subreddit call raises — a systemic failure like a total network outage,
+    not "just found nothing new today" — this raises RuntimeError instead of
+    silently returning 0. That distinction matters to the caller: __main__
+    only calls collector_health.record_success() after this returns
+    normally, so a fully-failed run correctly stays unrecorded and the 2-day
+    staleness alert can eventually catch it.
+    """
     total = 0
+    failures = 0
     for sub_config in DRAMA_SUBREDDITS:
         try:
             total += collect_subreddit(sub_config)
         except Exception as e:
             logger.error("Error collecting r/%s: %s", sub_config["name"], e)
+            failures += 1
             continue
+    if DRAMA_SUBREDDITS and failures == len(DRAMA_SUBREDDITS):
+        raise RuntimeError(
+            f"All {failures} configured drama subreddit(s) failed to collect"
+        )
     logger.info("Total new drama stories: %d", total)
     return total
 

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -183,5 +183,14 @@ def validate_flags(logger=None):
     return issues
 
 
+# --- Drama prompt versioning (Phase 3) ---
+# Selects prompts/{module}/{name}.{version}.txt via processors/prompt_loader.py.
+# Rollback = change this env var, no code change needed.
+PROMPT_VERSION = os.getenv("PROMPT_VERSION", "v1")
+
+# Drama rubric scoring threshold (out of 6 criteria) — story must score
+# >= this AND safe=1 to proceed to the rewriter.
+DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "5"))
+
 # Logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -13,6 +13,8 @@ sed -i '' 's|/Users/YOU|/Users/your-username|g' com.ai5phut.*.plist
 ```bash
 cp com.ai5phut.pipeline.plist ~/Library/LaunchAgents/
 cp com.ai5phut.bot.plist ~/Library/LaunchAgents/
+cp com.ai5phut.reddit-drama.plist ~/Library/LaunchAgents/
+cp com.ai5phut.drama-health.plist ~/Library/LaunchAgents/
 ```
 
 ## Bước 3: Load services
@@ -21,8 +23,15 @@ cp com.ai5phut.bot.plist ~/Library/LaunchAgents/
 # Load pipeline (chạy mỗi sáng 7:00)
 launchctl load ~/Library/LaunchAgents/com.ai5phut.pipeline.plist
 
-# Load bot (chạy liên tục, approve → publish ngay)
+# Load bot (chạy liên tục, approve/reject + Drama seed commands)
 launchctl load ~/Library/LaunchAgents/com.ai5phut.bot.plist
+
+# Load Reddit Drama collector (chạy mỗi sáng 6:06 — Phase 2)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.reddit-drama.plist
+
+# Load Drama collector health check (chạy 06:30 + 18:30 — alert Telegram nếu
+# reddit_drama chưa chạy thành công quá 2 ngày)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.drama-health.plist
 ```
 
 ## Bước 4: Kiểm tra
@@ -34,6 +43,8 @@ launchctl list | grep ai5phut
 # Xem log
 tail -f ~/ContentCreator/content-pipeline/logs/bot_stdout.log
 tail -f ~/ContentCreator/content-pipeline/logs/pipeline_stdout.log
+tail -f ~/ContentCreator/content-pipeline/logs/reddit_drama.log       # rotating app log (14 ngày)
+tail -f ~/ContentCreator/content-pipeline/logs/reddit_drama_stdout.log
 ```
 
 ## Quản lý
@@ -47,4 +58,10 @@ cd ~/ContentCreator/content-pipeline && python3 main.py
 
 # Chạy bot thủ công (foreground)
 cd ~/ContentCreator/content-pipeline && python3 main.py --bot
+
+# Chạy Reddit Drama collector thủ công
+cd ~/ContentCreator/content-pipeline && python3 -m collectors.reddit_drama_collector
+
+# Chạy health check thủ công
+cd ~/ContentCreator/content-pipeline && python3 -m storage.collector_health
 ```

--- a/content-pipeline/launchd/com.ai5phut.drama-health.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-health.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.drama-health</string>
+
+    <!-- Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>-m</string>
+        <string>storage.collector_health</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- Chạy mỗi 12h (06:30 và 18:30) — alert Telegram nếu reddit_drama
+         collector chưa chạy thành công quá 2 ngày (EPIC #2.4). -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>6</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>18</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+    </array>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_health_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_health_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
+++ b/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.reddit-drama</string>
+
+    <!-- Use the venv Python directly (this job isn't the main pipeline
+         entrypoint, so run_pipeline.sh's wrapper doesn't apply).
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>-m</string>
+        <string>collectors.reddit_drama_collector</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- Chạy 06:06 sáng mỗi ngày (Phase 2 — Drama Source Layer) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>6</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/reddit_drama_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/reddit_drama_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/notifier/seed_bot.py
+++ b/content-pipeline/notifier/seed_bot.py
@@ -21,6 +21,7 @@ Nếu sau này có bot token riêng cho seed bot, có thể tách thành process
 lập thật sự mà không cần đổi các hàm xử lý lệnh bên dưới.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -29,7 +30,7 @@ import uuid
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from storage.stories import insert_story, get_pending
+from storage.stories import insert_story, get_pending, dedupe_check
 
 logger = logging.getLogger(__name__)
 
@@ -132,14 +133,29 @@ def _save_vn_seed(text: str) -> str:
     return f"✅ Đã lưu seed VN-original #{story_id}."
 
 
+def _seed_url_source_id(url: str) -> str:
+    """Deterministic source_id for a seeded URL, derived from the URL itself
+    (not a random UUID) — so submitting the same link twice always maps to
+    the same source_id and the unique-index/dedupe_check() actually catches
+    the repeat instead of silently creating a duplicate row every time.
+    """
+    normalized = url.strip().rstrip("/")
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    return f"url_{digest}"
+
+
 def _save_seed_url(url: str) -> str:
     url = url.strip()
     if not url.startswith("http"):
         return "⚠️ Không phải link hợp lệ. Gõ /seed_url để thử lại."
+
+    source_id = _seed_url_source_id(url)
+    if dedupe_check(source_id):
+        return "⚠️ Link này đã được lưu trước đó rồi."
+
     og = _fetch_og_metadata(url)
     title = og.get("title", "")
     raw_content = og.get("description", "") or title or url
-    source_id = f"url_{uuid.uuid4().hex[:12]}"
     story_id = insert_story(
         source="url_seed", source_id=source_id, raw_content=raw_content, track="drama",
         title=title or None,

--- a/content-pipeline/notifier/seed_bot.py
+++ b/content-pipeline/notifier/seed_bot.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+"""
+Seed Bot — nhận lệnh Telegram để feed nội dung nguồn cho track Drama (Phase 2).
+
+Thiết kế khác với phase-2-detailed.md mục 3.2: tài liệu đề xuất chạy 2 process
+Telegram bot độc lập (`python-telegram-bot`, FSM riêng). Thực tế module này
+được gọi trực tiếp từ `notifier/telegram_bot.py._handle_update()` — CÙNG một
+vòng long-polling/1 bot token đang chạy sẵn cho approve/reject, thay vì một
+poller thứ hai.
+
+Lý do: Telegram's `getUpdates` chỉ cho phép MỘT long-poll connection tại một
+thời điểm cho mỗi bot token — chạy 2 process độc lập cùng gọi `getUpdates`
+trên cùng 1 token sẽ gây lỗi 409 Conflict liên tục (đúng cơ chế mà
+`_acquire_bot_lock()` trong telegram_bot.py đã cố tránh cho CHÍNH bot đó, nói
+gì đến 2 bot khác nhau tranh nhau cùng token). Module này export các hàm xử
+lý lệnh THUẦN (không tự polling), để telegram_bot.py dispatch vào cùng vòng
+lặp hiện có — tránh bug 409 mà vẫn đạt được mục tiêu chức năng của Phase 2.
+
+Nếu sau này có bot token riêng cho seed bot, có thể tách thành process độc
+lập thật sự mà không cần đổi các hàm xử lý lệnh bên dưới.
+"""
+
+import json
+import logging
+import os
+import re
+import uuid
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.stories import insert_story, get_pending
+
+logger = logging.getLogger(__name__)
+
+# Persisted so a bot restart mid-conversation (rare, but possible) doesn't
+# leave /seed_vn or /seed_url silently swallowing the next unrelated message.
+_STATE_FILE = os.path.join(os.path.dirname(__file__), ".seed_state.json")
+
+_META_TAG_RE = re.compile(r"<meta\b[^>]*>", re.IGNORECASE)
+_OG_PROPERTY_RE = re.compile(r'property=["\']og:([a-zA-Z]+)["\']', re.IGNORECASE)
+_CONTENT_RE = re.compile(r'content=["\']([^"\']*)["\']', re.IGNORECASE)
+
+
+# --- Conversation state (single-user bot: one awaiting state at a time) ---
+
+def _get_awaiting() -> str | None:
+    if not os.path.exists(_STATE_FILE):
+        return None
+    try:
+        with open(_STATE_FILE) as f:
+            return json.load(f).get("awaiting")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _set_awaiting(value: str | None):
+    try:
+        with open(_STATE_FILE, "w") as f:
+            json.dump({"awaiting": value}, f)
+    except OSError as e:
+        logger.warning("Could not persist seed bot state: %s", e)
+
+
+# --- Public command handlers (called from telegram_bot._handle_update) ---
+
+def start_seed_vn() -> str:
+    """Handle /seed_vn — prompt for the next message to be saved as a seed."""
+    _set_awaiting("vn_seed")
+    return (
+        "📝 Hãy gửi tình huống lõi (1-3 câu). "
+        "Tin nhắn tiếp theo của bạn sẽ được lưu làm seed VN-original."
+    )
+
+
+def start_seed_url() -> str:
+    """Handle /seed_url — prompt for the next message to be a FB/TikTok link."""
+    _set_awaiting("seed_url")
+    return "🔗 Hãy paste link Facebook/TikTok. Bot sẽ lưu link kèm metadata."
+
+
+def handle_awaiting_message(text: str) -> str | None:
+    """If /seed_vn or /seed_url is awaiting input, consume `text` as that input.
+
+    Returns the reply text, or None if nothing was awaiting (caller should
+    treat `text` as an ordinary/unrecognized message instead).
+    """
+    awaiting = _get_awaiting()
+    if awaiting is None:
+        return None
+    _set_awaiting(None)
+    if awaiting == "vn_seed":
+        return _save_vn_seed(text)
+    if awaiting == "seed_url":
+        return _save_seed_url(text)
+    return None
+
+
+def list_pending_text(limit: int = 5) -> str:
+    """Handle /list_pending — top N pending Drama stories, short markdown-ish list."""
+    pending = get_pending(limit=limit, track="drama")
+    if not pending:
+        return "✨ Không có story Drama nào đang chờ duyệt."
+    lines = [f"📋 {len(pending)} story đang chờ duyệt:"]
+    for s in pending:
+        title = s.get("title") or (s["raw_content"][:60] + "...")
+        lines.append(f"  • #{s['id']} [{s['source']}] {title}")
+    return "\n".join(lines)
+
+
+def help_text() -> str:
+    """Handle /help contribution for the seed bot commands."""
+    return (
+        "🎭 Drama seed bot:\n"
+        "/seed_vn — Gửi tình huống lõi VN-original\n"
+        "/seed_url — Gửi link FB/TikTok làm seed\n"
+        "/list_pending — Xem story Drama đang chờ duyệt"
+    )
+
+
+# --- Internal ---
+
+def _save_vn_seed(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return "⚠️ Nội dung trống, không lưu. Gõ /seed_vn để thử lại."
+    source_id = f"vn_{uuid.uuid4().hex[:12]}"
+    story_id = insert_story(
+        source="vn_original", source_id=source_id, raw_content=text, track="drama",
+    )
+    logger.info("Saved VN-original seed as story %d", story_id)
+    return f"✅ Đã lưu seed VN-original #{story_id}."
+
+
+def _save_seed_url(url: str) -> str:
+    url = url.strip()
+    if not url.startswith("http"):
+        return "⚠️ Không phải link hợp lệ. Gõ /seed_url để thử lại."
+    og = _fetch_og_metadata(url)
+    title = og.get("title", "")
+    raw_content = og.get("description", "") or title or url
+    source_id = f"url_{uuid.uuid4().hex[:12]}"
+    story_id = insert_story(
+        source="url_seed", source_id=source_id, raw_content=raw_content, track="drama",
+        title=title or None,
+        metadata={"url": url, "og_image": og.get("image")},
+    )
+    logger.info("Saved URL seed as story %d (%s)", story_id, url)
+    reply = f"✅ Đã lưu seed từ link #{story_id}."
+    if title:
+        reply += f"\n📝 {title}"
+    return reply
+
+
+def _fetch_og_metadata(url: str) -> dict:
+    """Best-effort Open Graph tag scrape (title/description/image).
+
+    Uses `requests` (already a project dependency) + a tolerant regex parse
+    instead of pulling in a new HTML-parsing dependency for 3 meta tags.
+    Returns {} on any network/parse failure — a failed fetch must not block
+    saving the seed URL itself.
+    """
+    import requests
+
+    try:
+        resp = requests.get(
+            url, timeout=10,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; ContentPipelineBot/1.0)"},
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.warning("Failed to fetch OG metadata for %s: %s", url, e)
+        return {}
+
+    result = {}
+    for tag in _META_TAG_RE.findall(resp.text):
+        prop_match = _OG_PROPERTY_RE.search(tag)
+        content_match = _CONTENT_RE.search(tag)
+        if prop_match and content_match:
+            result.setdefault(prop_match.group(1), content_match.group(1))
+    return result

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -154,6 +154,17 @@ def send_publish_notification(video_id: int, platform: str, url: str):
     _send_text(f"🚀 Video {video_id} đã đăng lên {platform}!\n🔗 {url}")
 
 
+def send_alert(text: str) -> bool:
+    """Send an arbitrary alert/notification message.
+
+    Public wrapper around the internal `_send_text` for callers outside this
+    module (e.g. storage/collector_health.py's stale-collector check) that
+    just need to push a plain text message, without reaching into a
+    leading-underscore "private" helper.
+    """
+    return _send_text(text)
+
+
 def send_narrative_report(narrative: str, article_count: int) -> bool:
     """Send the narrative summary as a text message before video generation.
 
@@ -324,6 +335,16 @@ def _handle_update(update: dict, publish_callback):
     if chat_id != config.TELEGRAM_CHAT_ID:
         return
 
+    # Drama seed bot (Phase 2): a plain (non-command) message answers a
+    # pending /seed_vn or /seed_url prompt. Checked first so every command
+    # below still takes priority even in the middle of a seed conversation.
+    if not text.startswith("/"):
+        from notifier import seed_bot
+        reply = seed_bot.handle_awaiting_message(text)
+        if reply is not None:
+            _send_text(reply)
+        return
+
     if text.startswith("/approve_"):
         try:
             video_id = int(text.split("_", 1)[1])
@@ -381,13 +402,27 @@ def _handle_update(update: dict, publish_callback):
         else:
             _send_text("✨ Không có video nào đang chờ duyệt.")
 
+    elif text == "/seed_vn":
+        from notifier import seed_bot
+        _send_text(seed_bot.start_seed_vn())
+
+    elif text == "/seed_url":
+        from notifier import seed_bot
+        _send_text(seed_bot.start_seed_url())
+
+    elif text == "/list_pending":
+        from notifier import seed_bot
+        _send_text(seed_bot.list_pending_text())
+
     elif text == "/help":
+        from notifier import seed_bot
         _send_text(
             "📖 Lệnh bot:\n"
             "/approve_<id> — Duyệt và đăng video\n"
             "/reject_<id> — Từ chối video\n"
             "/script_<id> — Xem lại script video\n"
-            "/status — Xem video đang chờ duyệt"
+            "/status — Xem video đang chờ duyệt\n\n"
+            + seed_bot.help_text()
         )
 
 

--- a/content-pipeline/processors/ab_harness.py
+++ b/content-pipeline/processors/ab_harness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""
+A/B harness — chọn version prompt theo split ổn định (deterministic) theo
+story_id, ghi kết quả heuristic để so sánh sau khi đủ mẫu (Phase 3 EPIC #3.4).
+
+**Thiết kế rút gọn so với phase-3-issues.md**: bản gốc đề xuất hạ tầng chia
+traffic 50/50 đầy đủ. `choose_version()` ở đây chỉ hash `(experiment,
+story_id)` — không cần state lưu trữ riêng cho việc chia traffic, và quan
+trọng hơn: CÙNG 1 story luôn ra CÙNG 1 version dù gọi lại nhiều lần (scorer
+và rewriter của cùng 1 story nên dùng nhất quán 1 version; retry sau lỗi
+không được đổi version giữa chừng — random thuần túy sẽ vi phạm cả 2 điều
+này).
+"""
+
+import hashlib
+import logging
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.ab_runs import record_run, get_runs
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VERSIONS = ("v1", "v2")
+MIN_SAMPLES_TO_COMPARE = 10
+
+
+def choose_version(experiment: str, story_id: int,
+                   versions: tuple[str, ...] = DEFAULT_VERSIONS) -> str:
+    """Deterministically assign one of `versions` to (experiment, story_id).
+
+    Same inputs always produce the same output — this is a hash lookup, not
+    a random draw — so repeated/retried calls for one story stay consistent.
+    """
+    key = f"{experiment}:{story_id}".encode("utf-8")
+    digest = hashlib.sha256(key).hexdigest()
+    index = int(digest, 16) % len(versions)
+    return versions[index]
+
+
+def record_ab_result(experiment: str, version: str, story_id: int,
+                     heuristic_score: float) -> None:
+    """Record one experiment outcome for later comparison via compare_ab_results()."""
+    record_run(experiment, version, story_id, heuristic_score)
+    logger.info(
+        "Recorded A/B result: experiment=%s version=%s story=%s score=%s",
+        experiment, version, story_id, heuristic_score,
+    )
+
+
+def compare_ab_results(experiment: str,
+                       min_samples: int = MIN_SAMPLES_TO_COMPARE) -> dict | None:
+    """Compare mean heuristic_score per version recorded for `experiment`.
+
+    Returns None if there are no runs yet, or any version present has fewer
+    than `min_samples` runs (too early to conclude anything). Otherwise:
+        {"<version>": {"n": int, "mean": float}, ..., "better": "<version>"|"tie"}
+    """
+    runs = get_runs(experiment)
+    if not runs:
+        return None
+
+    by_version: dict[str, list[float]] = {}
+    for run in runs:
+        score = run.get("heuristic_score")
+        if score is None:
+            continue
+        by_version.setdefault(run["version"], []).append(score)
+
+    if not by_version or any(len(scores) < min_samples for scores in by_version.values()):
+        return None
+
+    summary: dict = {
+        version: {"n": len(scores), "mean": sum(scores) / len(scores)}
+        for version, scores in by_version.items()
+    }
+
+    means = {version: stats["mean"] for version, stats in summary.items()}
+    if len(set(means.values())) == 1:
+        summary["better"] = "tie"
+    else:
+        summary["better"] = max(means, key=means.get)
+
+    return summary

--- a/content-pipeline/processors/ai_usage.py
+++ b/content-pipeline/processors/ai_usage.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""
+Shared token-usage logging for Drama processors (Phase 3 EPIC #3.2).
+
+Logs raw input/output token counts per call — not a $ estimate, since
+hardcoding per-model pricing here would silently go stale as prices change.
+Check the current Anthropic pricing page if you want a cost figure; token
+counts alone are enough to spot a run that's unexpectedly expensive.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_token_usage(label: str, story_id: int, message) -> None:
+    """Log input/output token counts from an Anthropic Message response."""
+    usage = getattr(message, "usage", None)
+    if usage is None:
+        return
+    # %s (not %d): tolerates a non-int usage object (e.g. a test double)
+    # without crashing logging's lazy message formatting.
+    logger.info(
+        "%s story=%s tokens: input=%s output=%s",
+        label, story_id,
+        getattr(usage, "input_tokens", 0), getattr(usage, "output_tokens", 0),
+    )

--- a/content-pipeline/processors/drama_compiler.py
+++ b/content-pipeline/processors/drama_compiler.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+"""
+Drama Compiler — gom 3-5 story cùng theme thành 1 script video long-form
+(Phase 3 EPIC #3.3). Chạy weekly (thứ 6) trên story `status='produced'`
+(đã qua Phase 4 — sản xuất thành video riêng lẻ).
+"""
+
+import json
+import logging
+import re
+import time
+
+import anthropic
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from processors.prompt_loader import load_prompt, render
+from processors.ai_usage import log_token_usage
+from storage.stories import get_by_status
+from storage.compiled_videos import insert_compiled_video
+
+logger = logging.getLogger(__name__)
+
+MIN_STORIES_FOR_THEME = 3
+MAX_STORIES_PER_COMPILATION = 5
+
+# Derived from this codebase's own established narration rate (see
+# video/script_generator.py: "long" AI videos target 800-1200 words for a
+# 5-10 min video, i.e. ~120-160 words/minute). Using ~140 wpm:
+#   8 min ≈ 1120 words, 15 min ≈ 2100 words.
+TARGET_MIN_WORDS = 1100
+TARGET_MAX_WORDS = 2100
+
+_CHAPTER_MARKER_RE = re.compile(r"^\d{1,2}:\d{2}(:\d{2})?\s+\S")
+
+
+def detect_theme(candidate_stories: list[dict]) -> dict | None:
+    """Find a theme shared by >= MIN_STORIES_FOR_THEME stories (Claude Sonnet).
+
+    Returns {"theme": str, "story_ids": [...], "reason": str}, or None if no
+    theme reaches the threshold or the call/parse fails after retries.
+    """
+    if len(candidate_stories) < MIN_STORIES_FOR_THEME:
+        logger.info(
+            "Only %d candidate stories (< %d) — skipping theme detection",
+            len(candidate_stories), MIN_STORIES_FOR_THEME,
+        )
+        return None
+
+    story_list = "\n".join(
+        f"{s['id']}: {(s.get('title') or s['raw_content'] or '')[:100]}"
+        for s in candidate_stories
+    )
+    prompt = render(load_prompt("drama", "theme_detect"), STORY_LIST=story_list)
+
+    client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+    for attempt in range(3):
+        try:
+            message = client.messages.create(
+                model="claude-sonnet-4-5", max_tokens=500,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            log_token_usage("drama_theme_detect", f"{len(candidate_stories)}_stories", message)
+            response_text = message.content[0].text.strip()
+            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = json.loads(json_match.group())
+            if not result.get("theme") or len(result.get("story_ids") or []) < MIN_STORIES_FOR_THEME:
+                logger.info("No qualifying theme found: %s", result.get("reason", ""))
+                return None
+            return result
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning(
+                "Attempt %d/3: failed to parse theme detection response: %s", attempt + 1, e,
+            )
+            continue
+        except anthropic.RateLimitError:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Rate limited detecting theme, waiting %ds", wait)
+            time.sleep(wait)
+            continue
+        except anthropic.APIError as e:
+            logger.error("API error detecting theme: %s", e)
+            return None
+    logger.error("Failed to detect theme after 3 attempts")
+    return None
+
+
+def _story_script_block(story: dict) -> str:
+    """Best-effort script text for a story: prefer the Vietnamese rewrite."""
+    rewritten = story.get("rewritten_content")
+    if isinstance(rewritten, str):
+        try:
+            rewritten = json.loads(rewritten)
+        except json.JSONDecodeError:
+            rewritten = None
+    title = (rewritten or {}).get("title") or story.get("title") or f"Story {story['id']}"
+    script = (rewritten or {}).get("script") or story.get("raw_content") or ""
+    return f"--- Story #{story['id']}: {title} ---\n{script}"
+
+
+def compile_long_form(selected_stories: list[dict], theme: str) -> dict | None:
+    """Generate the long-form compiled script (intro/bridges/outro/chapters).
+
+    Returns the parsed result dict, or None on failure after retries.
+    """
+    selected = selected_stories[:MAX_STORIES_PER_COMPILATION]
+    stories_block = "\n\n".join(_story_script_block(s) for s in selected)
+
+    prompt = render(
+        load_prompt("drama", "longform"),
+        STORY_COUNT=str(len(selected)), THEME=theme, STORIES_BLOCK=stories_block,
+    )
+
+    client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+    for attempt in range(3):
+        try:
+            message = client.messages.create(
+                model="claude-sonnet-4-5", max_tokens=4000,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            log_token_usage("drama_compiler", theme, message)
+            response_text = message.content[0].text.strip()
+            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = json.loads(json_match.group())
+            _validate_compiled_script(result)
+            return result
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            logger.warning(
+                "Attempt %d/3: failed to parse/validate compiled script: %s", attempt + 1, e,
+            )
+            continue
+        except anthropic.RateLimitError:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Rate limited compiling long-form, waiting %ds", wait)
+            time.sleep(wait)
+            continue
+        except anthropic.APIError as e:
+            logger.error("API error compiling long-form script: %s", e)
+            return None
+    logger.error("Failed to compile long-form script after 3 attempts")
+    return None
+
+
+def _validate_compiled_script(result: dict) -> None:
+    """Raise ValueError if `result` doesn't look like a usable compiled script."""
+    required = ("intro", "outro", "chapters", "full_script")
+    missing = [k for k in required if not result.get(k)]
+    if missing:
+        raise ValueError(f"missing/empty field(s): {missing}")
+
+    if not isinstance(result["chapters"], list) or not result["chapters"]:
+        raise ValueError("chapters must be a non-empty list")
+    for chapter in result["chapters"]:
+        if not _CHAPTER_MARKER_RE.match(chapter):
+            raise ValueError(f"chapter marker not in 'MM:SS Title' format: {chapter!r}")
+
+    word_count = len(result["full_script"].split())
+    if not (TARGET_MIN_WORDS <= word_count <= TARGET_MAX_WORDS):
+        raise ValueError(
+            f"full_script word count {word_count} outside "
+            f"{TARGET_MIN_WORDS}-{TARGET_MAX_WORDS} (~8-15 min)"
+        )
+
+
+def run_weekly_compilation() -> int | None:
+    """Weekly job (Friday): detect a theme among produced Drama stories and
+    compile a long-form script. Returns the new compiled_videos id, or None
+    if no theme reached the threshold or compilation failed.
+    """
+    produced = get_by_status("produced", limit=50, track="drama")
+    theme_result = detect_theme(produced)
+    if theme_result is None:
+        return None
+
+    selected_ids = set(theme_result["story_ids"])
+    selected = [s for s in produced if s["id"] in selected_ids]
+    if len(selected) < MIN_STORIES_FOR_THEME:
+        logger.warning(
+            "Theme detection returned story_ids not present in the produced set — skipping"
+        )
+        return None
+
+    compiled = compile_long_form(selected, theme_result["theme"])
+    if compiled is None:
+        return None
+
+    video_id = insert_compiled_video(
+        theme=theme_result["theme"],
+        story_ids=[s["id"] for s in selected],
+        script=compiled["full_script"],
+        chapter_markers=compiled["chapters"],
+    )
+    logger.info(
+        "Compiled long-form video %d for theme %r (%d stories)",
+        video_id, theme_result["theme"], len(selected),
+    )
+    return video_id
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_weekly_compilation()

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+"""
+Drama Rewriter — Việt hoá story Reddit/VN-seed bằng Claude Sonnet (Phase 3
+EPIC #3.2). Module quan trọng nhất của Drama track: mỗi story được kể lại
+ngôi thứ nhất, nhân vật/bối cảnh chuyển hẳn sang Việt Nam, và thêm đoạn
+"bình luận góc nhìn Việt" (≥20% thời lượng) — giá trị chuyển đổi (transformative)
+không có trong bản gốc.
+"""
+
+import json
+import logging
+import re
+import time
+
+import anthropic
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from processors.prompt_loader import load_prompt, render
+from processors.ai_usage import log_token_usage
+from storage.stories import get_pending, update_status, get_story
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
+_SCRIPT_MIN_WORDS = 800
+_SCRIPT_MAX_WORDS = 1200
+_VN_COMMENTARY_MIN_WORDS = 200
+# Structure heuristic ("Hook 3s → Setup → Escalation → Twist → Reflection"):
+# a real 3-second hook is one short punchy line, not a paragraph. Can't
+# heuristically verify the other 4 structure beats without real NLP, but a
+# hook that's suspiciously long is a good, cheap signal something went wrong.
+_HOOK_MAX_WORDS = 25
+
+# Heuristic guard against the 2 failure modes called out in
+# phase-3-detailed.md's risk section: half-Western character names (e.g.
+# "Linh Smith") and US-culture details leaking into a story meant to be set
+# entirely in Vietnam.
+_FOREIGN_CULTURE_TERMS = ("mall", "prom", "thanksgiving", "dollar", "dollars", "usd")
+_FOREIGN_CULTURE_SYMBOLS = ("$",)
+_WESTERN_NAME_FRAGMENTS = (
+    "smith", "johnson", "williams", "brown", "jones", "miller", "davis",
+    "john", "mike", "michael", "sarah", "jessica", "james", "robert",
+    "david", "mary", "jennifer", "linda", "susan", "karen",
+)
+
+
+def validate_rewrite(result: dict) -> list[str]:
+    """Heuristic quality gate for a rewriter JSON result.
+
+    Pure function, no network — returns a list of human-readable issues;
+    an empty list means the rewrite passes. Checked (per phase-3-detailed.md
+    EPIC #3.2 "Validation post-rewrite"):
+    - all required fields present and non-empty
+    - `script` word count in [800, 1200]
+    - `vn_commentary` >= 200 words
+    - `hook` is a short punchy line, not a paragraph (structure heuristic)
+    - no common Western name fragments / US-culture terms leaking through
+    - `tags` is a non-empty list
+    """
+    issues = []
+    missing = [k for k in _REQUIRED_FIELDS if not result.get(k)]
+    if missing:
+        issues.append(f"missing/empty field(s): {missing}")
+        return issues  # other checks need these fields to make sense
+
+    script = result["script"]
+    word_count = len(script.split())
+    if not (_SCRIPT_MIN_WORDS <= word_count <= _SCRIPT_MAX_WORDS):
+        issues.append(
+            f"script word count {word_count} outside "
+            f"{_SCRIPT_MIN_WORDS}-{_SCRIPT_MAX_WORDS}"
+        )
+
+    hook_word_count = len(result["hook"].split())
+    if hook_word_count > _HOOK_MAX_WORDS:
+        issues.append(
+            f"hook has {hook_word_count} words — expected a short ~3s line "
+            f"(<= {_HOOK_MAX_WORDS})"
+        )
+
+    commentary_count = len(result["vn_commentary"].split())
+    if commentary_count < _VN_COMMENTARY_MIN_WORDS:
+        issues.append(
+            f"vn_commentary only {commentary_count} words "
+            f"(need >= {_VN_COMMENTARY_MIN_WORDS})"
+        )
+
+    combined = f"{result['title']} {script} {result['vn_commentary']}".lower()
+
+    for term in _FOREIGN_CULTURE_TERMS + _WESTERN_NAME_FRAGMENTS:
+        if re.search(rf"\b{re.escape(term)}\b", combined):
+            issues.append(f"contains disallowed term: {term!r}")
+
+    for sym in _FOREIGN_CULTURE_SYMBOLS:
+        if sym in combined:
+            issues.append(f"contains disallowed symbol: {sym!r}")
+
+    if not isinstance(result.get("tags"), list) or not result["tags"]:
+        issues.append("tags must be a non-empty list")
+
+    return issues
+
+
+def rewrite_story(story_id: int) -> dict | None:
+    """Rewrite one story into a Vietnamese script via Claude Sonnet.
+
+    On success, stores the JSON result in `stories.rewritten_content` and
+    sets status:
+    - 'approved' — passed validate_rewrite(), ready for production (Phase 4).
+    - 'needs_review' — failed validate_rewrite(); the (still-saved) output
+      needs a human look. A Telegram alert is sent with the specific issues.
+
+    Returns the parsed rewrite dict, or None on failure (story left
+    untouched so a later run can retry).
+    """
+    story = get_story(story_id)
+    if not story:
+        logger.error("Story %d not found", story_id)
+        return None
+
+    prompt_template = load_prompt("drama", "rewriter")
+    prompt = render(prompt_template, RAW_CONTENT=(story["raw_content"] or "")[:4000])
+
+    client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+    result = None
+
+    for attempt in range(3):
+        try:
+            message = client.messages.create(
+                model="claude-sonnet-4-5",
+                max_tokens=2000,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            log_token_usage("drama_rewriter", story_id, message)
+            response_text = message.content[0].text.strip()
+            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = json.loads(json_match.group())
+            break
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning(
+                "Attempt %d/3: failed to parse rewrite for story %d: %s",
+                attempt + 1, story_id, e,
+            )
+            continue
+        except anthropic.RateLimitError:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Rate limited rewriting story %d, waiting %ds", story_id, wait)
+            time.sleep(wait)
+            continue
+        except anthropic.APIError as e:
+            logger.error("API error rewriting story %d: %s", story_id, e)
+            return None
+
+    if result is None:
+        logger.error("Failed to rewrite story %d after 3 attempts", story_id)
+        return None
+
+    issues = validate_rewrite(result)
+    rewritten_json = json.dumps(result, ensure_ascii=False)
+
+    if issues:
+        update_status(story_id, "needs_review", rewritten_content=rewritten_json)
+        logger.warning("Story %d rewrite failed validation: %s", story_id, issues)
+        _alert_validation_failure(story_id, issues)
+    else:
+        update_status(story_id, "approved", rewritten_content=rewritten_json)
+        logger.info("Story %d rewritten and validated OK", story_id)
+
+    return result
+
+
+def _alert_validation_failure(story_id: int, issues: list[str]) -> None:
+    from notifier.telegram_bot import send_alert
+    lines = "\n".join(f"  • {i}" for i in issues)
+    send_alert(f"⚠️ Story #{story_id} rewrite cần review thủ công:\n{lines}")
+
+
+def rewrite_all_scored(limit: int = 10) -> int:
+    """Rewrite every scored-and-passing drama story not yet rewritten.
+
+    Returns the count successfully processed (a rewrite that fails
+    validation and lands in 'needs_review' still counts as processed).
+    """
+    candidates = [
+        s for s in get_pending(limit=limit, track="drama")
+        if s.get("rubric_score") is not None and not s.get("rewritten_content")
+    ]
+    done = 0
+    for story in candidates:
+        if rewrite_story(story["id"]) is not None:
+            done += 1
+    logger.info("Rewrote %d/%d scored drama stories", done, len(candidates))
+    return done
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    rewrite_all_scored()

--- a/content-pipeline/processors/drama_scorer.py
+++ b/content-pipeline/processors/drama_scorer.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+"""
+Drama Rubric Scorer — chấm story Drama theo 6 tiêu chí bằng Claude Haiku
+(Phase 3 EPIC #3.1).
+
+Tiêu chí: HOOK_3S, STAKES, TWIST, LOCALIZABLE, COMMENT_BAIT, SAFE (mỗi cái
+0 hoặc 1). `total` LUÔN được tính lại từ 6 trường boolean phía server —
+không tin vào con số "total" model tự báo cáo, vì LLM occasionally tính
+sai tổng đơn giản trong JSON output; validate + tự cộng loại bỏ cả lớp lỗi
+đó. Story `safe=0` luôn bị loại dù `total` cao (xem `phase-3-detailed.md`).
+"""
+
+import json
+import logging
+import re
+import time
+
+import anthropic
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from processors.prompt_loader import load_prompt, render
+from processors.ai_usage import log_token_usage
+from storage.stories import get_pending, update_status, get_story
+
+logger = logging.getLogger(__name__)
+
+_RUBRIC_KEYS = ("hook_3s", "stakes", "twist", "localizable", "comment_bait", "safe")
+
+
+def _validate_and_normalize_rubric(result: dict) -> dict:
+    """Validate the 6 rubric fields and recompute `total` deterministically.
+
+    Raises:
+        ValueError: nếu thiếu field hoặc field không phải 0/1.
+    """
+    missing = [k for k in _RUBRIC_KEYS if k not in result]
+    if missing:
+        raise ValueError(f"Missing rubric keys: {missing}")
+    for k in _RUBRIC_KEYS:
+        if result[k] not in (0, 1):
+            raise ValueError(f"Rubric field {k!r} must be 0 or 1, got {result[k]!r}")
+    result["total"] = sum(result[k] for k in _RUBRIC_KEYS)
+    result.setdefault("reason", "")
+    return result
+
+
+def score_story(story_id: int) -> dict | None:
+    """Score one story via Claude Haiku's 6-criteria rubric.
+
+    Updates the story's status: 'rejected' if it fails (safe=0 or total
+    below config.DRAMA_SCORE_THRESHOLD), otherwise stays 'pending' — ready
+    for the rewriter (Phase 3 EPIC #3.2) — with `rubric_score` recorded.
+
+    Returns the parsed+normalized rubric dict, or None on failure (story
+    left untouched so a later run can retry).
+    """
+    story = get_story(story_id)
+    if not story:
+        logger.error("Story %d not found", story_id)
+        return None
+
+    prompt_template = load_prompt("drama", "scorer")
+    # Truncate like ai_scorer.py/ai_analyzer.py do — keeps token cost bounded
+    # for the (rare) unusually long Reddit post.
+    prompt = render(prompt_template, RAW_CONTENT=(story["raw_content"] or "")[:4000])
+
+    client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
+    result = None
+
+    for attempt in range(3):
+        try:
+            message = client.messages.create(
+                model="claude-haiku-4-5",
+                max_tokens=300,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            log_token_usage("drama_scorer", story_id, message)
+            response_text = message.content[0].text.strip()
+            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+            if not json_match:
+                raise json.JSONDecodeError("No JSON object found", response_text, 0)
+            result = _validate_and_normalize_rubric(json.loads(json_match.group()))
+            break
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            logger.warning(
+                "Attempt %d/3: failed to parse rubric for story %d: %s",
+                attempt + 1, story_id, e,
+            )
+            continue
+        except anthropic.RateLimitError:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Rate limited scoring story %d, waiting %ds", story_id, wait)
+            time.sleep(wait)
+            continue
+        except anthropic.APIError as e:
+            logger.error("API error scoring story %d: %s", story_id, e)
+            return None
+
+    if result is None:
+        logger.error("Failed to score story %d after 3 attempts", story_id)
+        return None
+
+    total = result["total"]
+    passes = result["safe"] == 1 and total >= config.DRAMA_SCORE_THRESHOLD
+    if passes:
+        update_status(story_id, "pending", rubric_score=total)
+        logger.info("Story %d scored %d/6 — passes, ready for rewrite", story_id, total)
+    else:
+        update_status(story_id, "rejected", rubric_score=total)
+        logger.info(
+            "Story %d scored %d/6 (safe=%s) — rejected", story_id, total, result["safe"],
+        )
+
+    return result
+
+
+def score_all_pending(limit: int = 20) -> int:
+    """Score every pending drama story that hasn't been scored yet.
+
+    Returns the count of stories successfully scored (a story that gets
+    scored and then rejected still counts — it was successfully processed).
+    """
+    candidates = [
+        s for s in get_pending(limit=limit, track="drama")
+        if s.get("rubric_score") is None
+    ]
+    scored = 0
+    for story in candidates:
+        if score_story(story["id"]) is not None:
+            scored += 1
+    logger.info("Scored %d/%d pending drama stories", scored, len(candidates))
+    return scored
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    score_all_pending()

--- a/content-pipeline/processors/prompt_loader.py
+++ b/content-pipeline/processors/prompt_loader.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""
+Prompt loader — đọc prompt template theo version, cho phép rollback/A-B test
+mà không cần sửa code (Phase 3 EPIC #3.4).
+
+Convention: `content-pipeline/prompts/{module}/{name}.{version}.txt`.
+Placeholder trong prompt dùng dạng `{{TEN_BIEN}}` (không phải `{ten_bien}` của
+`str.format`) vì các prompt JSON-output chứa dấu ngoặc `{`/`}` thật trong ví
+dụ schema — dùng `str.format` sẽ phải escape toàn bộ, dễ sai sót. Điền giá
+trị bằng `render()` (str.replace đơn giản) thay vì `.format()`.
+"""
+
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "prompts")
+
+
+def load_prompt(module: str, name: str, version: str | None = None) -> str:
+    """Đọc nội dung prompt từ `prompts/{module}/{name}.{version}.txt`.
+
+    Args:
+        module: thư mục con, vd 'drama'.
+        name: tên prompt, vd 'scorer', 'rewriter'.
+        version: mặc định lấy từ `config.PROMPT_VERSION` — đổi env var
+            `PROMPT_VERSION` để rollback mà không cần sửa code.
+
+    Raises:
+        FileNotFoundError: nếu không tìm thấy file prompt.
+    """
+    version = version or config.PROMPT_VERSION
+    path = os.path.join(PROMPTS_DIR, module, f"{name}.{version}.txt")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Prompt not found: {path}")
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def render(template: str, **values: str) -> str:
+    """Thay các placeholder `{{KEY}}` trong `template` bằng `values[KEY]`."""
+    result = template
+    for key, value in values.items():
+        result = result.replace(f"{{{{{key}}}}}", str(value))
+    return result

--- a/content-pipeline/prompts/drama/longform.v1.txt
+++ b/content-pipeline/prompts/drama/longform.v1.txt
@@ -1,0 +1,22 @@
+Bạn là biên tập viên video YouTube kênh Drama tiếng Việt.
+Nhiệm vụ: gộp {{STORY_COUNT}} câu chuyện dưới đây (cùng theme "{{THEME}}")
+thành 1 kịch bản video dài 8-15 phút.
+
+CÁC STORY (đã Việt hoá, mỗi story gồm title + script):
+{{STORIES_BLOCK}}
+
+Tạo:
+1. Intro ~15 giây: giới thiệu chủ đề chung + teaser cả {{STORY_COUNT}} câu
+   chuyện sắp kể.
+2. Đoạn chuyển (bridge) ngắn giữa mỗi story.
+3. Outro có CTA (đăng ký kênh, bình luận ai đúng ai sai).
+4. Chapter markers đúng định dạng YouTube: mỗi dòng "MM:SS Tên chương".
+
+Trả lời CHỈ bằng JSON, không giải thích thêm:
+{
+  "intro": "<script intro>",
+  "bridges": ["<bridge 1>", "<bridge 2>"],
+  "outro": "<script outro>",
+  "chapters": ["00:00 Intro", "01:30 Story 1: ..."],
+  "full_script": "<toàn bộ kịch bản ghép lại theo thứ tự intro/story/bridge/outro, sẵn để đưa vào TTS>"
+}

--- a/content-pipeline/prompts/drama/rewriter.v1.txt
+++ b/content-pipeline/prompts/drama/rewriter.v1.txt
@@ -1,0 +1,27 @@
+Bạn là người kể chuyện cho kênh YouTube/TikTok drama tiếng Việt.
+Phong cách: kể chuyện ngôi thứ nhất, ngôn ngữ đời thường, có cảm xúc.
+Đối tượng: phụ nữ Việt 22-50 tuổi, nghe khi nấu cơm/đi xe.
+
+Quy tắc bắt buộc:
+1. Đổi tên nhân vật sang tên Việt (Linh, Tuấn, Mai, Hùng, Thu...)
+2. Đổi địa điểm sang Việt Nam (Quận 1, Hà Đông, chung cư X, công ty Y)
+3. Đổi văn hoá đặc thù: mâm cơm Việt, lì xì Tết, sếp người Việt, mẹ chồng nàng dâu, hội bạn nhậu
+4. THÊM 1-2 đoạn "bình luận góc nhìn Việt" chiếm tối thiểu 20% tổng thời lượng - đây là điểm tạo unique value (không có trong Reddit gốc)
+5. Cấu trúc: Hook 3s → Setup 12s → Escalation 30s → Twist 25s → Reflection + CTA 15s
+6. Tổng độ dài: 800-1200 từ (tương đương 60-90 giây TTS)
+7. KHÔNG dùng ngôn từ 18+, không nhắc tên người thật, không vu khống
+8. Đặt câu chuyện HOÀN TOÀN ở Việt Nam - KHÔNG nhắc tới đô la Mỹ, mall, prom, Thanksgiving, hay bất kỳ chi tiết văn hoá Mỹ nào khác
+9. Tên nhân vật phải THUẦN VIỆT (họ + tên đệm + tên, 2-3 từ, vd "Nguyễn Thị Mai") - KHÔNG đặt tên nửa Tây nửa Việt (vd "Linh Smith")
+
+STORY GỐC (tiếng Anh từ Reddit, hoặc seed VN-original):
+{{RAW_CONTENT}}
+
+Trả lời CHỈ bằng JSON, không giải thích thêm:
+{
+  "title": "<tiêu đề câu hook 1 dòng>",
+  "hook": "<3 giây đầu>",
+  "script": "<full script>",
+  "vn_commentary": "<đoạn bình luận góc nhìn Việt, riêng, tối thiểu 200 từ>",
+  "thumbnail_prompt": "<mô tả ảnh AI cho thumbnail>",
+  "tags": ["<tag1>", "<tag2>"]
+}

--- a/content-pipeline/prompts/drama/scorer.v1.txt
+++ b/content-pipeline/prompts/drama/scorer.v1.txt
@@ -1,0 +1,15 @@
+Bạn là content editor cho kênh YouTube Drama tiếng Việt.
+Chấm story sau theo 6 tiêu chí (mỗi tiêu chí 0 hoặc 1):
+
+1. HOOK_3S: Có thể tóm tắt mâu thuẫn trong 1 câu khiến người xem khựng lại không?
+2. STAKES: Nhân vật đang mất gì rõ ràng? (tiền, danh dự, mối quan hệ, công việc)
+3. TWIST: Có khoảnh khắc 'À HÓA RA' hoặc cú lật ngược không?
+4. LOCALIZABLE: Có thể chuyển sang bối cảnh Việt Nam tự nhiên không?
+5. COMMENT_BAIT: Khán giả có lý do để bình luận phân định ai sai/đúng không?
+6. SAFE: Không có sex/tự sát/bạo lực cụ thể/hate speech?
+
+STORY:
+{{RAW_CONTENT}}
+
+Trả lời CHỈ bằng JSON, không giải thích thêm:
+{"hook_3s": 0|1, "stakes": 0|1, "twist": 0|1, "localizable": 0|1, "comment_bait": 0|1, "safe": 0|1, "total": <tổng>, "reason": "<1 câu>"}

--- a/content-pipeline/prompts/drama/theme_detect.v1.txt
+++ b/content-pipeline/prompts/drama/theme_detect.v1.txt
@@ -1,0 +1,15 @@
+Bạn là content strategist cho kênh YouTube Drama tiếng Việt.
+Dưới đây là danh sách tóm tắt các story đã sản xuất trong tuần (mỗi dòng
+định dạng "ID: tóm tắt ngắn"):
+
+{{STORY_LIST}}
+
+Tìm 1 theme/chủ đề xuất hiện ở ÍT NHẤT 3 story (vd "ngoại tình", "mẹ chồng
+nàng dâu", "đồng nghiệp xấu tính"). Nếu có nhiều theme đạt ngưỡng, chọn theme
+có story hay nhất/liên quan nhất.
+
+Trả lời CHỈ bằng JSON, không giải thích thêm:
+{"theme": "<tên theme>", "story_ids": [<id1>, <id2>], "reason": "<1 câu>"}
+
+Nếu KHÔNG có theme nào đạt ngưỡng 3 story, trả về:
+{"theme": null, "story_ids": [], "reason": "<lý do>"}

--- a/content-pipeline/storage/ab_runs.py
+++ b/content-pipeline/storage/ab_runs.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `ab_runs` (Phase 3 EPIC #3.4 — A/B harness).
+
+Yêu cầu migration 005_ab_runs (xem storage/migrate.py).
+"""
+
+import logging
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def record_run(experiment: str, version: str, story_id: Optional[int],
+               heuristic_score: Optional[float]) -> int:
+    """Record one A/B run. Returns the new row id."""
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            "INSERT INTO ab_runs (experiment, version, story_id, heuristic_score) "
+            "VALUES (?, ?, ?, ?)",
+            (experiment, version, story_id, heuristic_score),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def get_runs(experiment: str) -> list[dict]:
+    """All recorded runs for `experiment`, oldest first."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM ab_runs WHERE experiment = ? ORDER BY id", (experiment,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [dict(r) for r in rows]

--- a/content-pipeline/storage/collector_health.py
+++ b/content-pipeline/storage/collector_health.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""
+Collector health tracking — Phase 2 EPIC #2.4 (Operational hardening).
+
+Records the last successful run per collector (`record_success`) and lets a
+separate cron job (this module's __main__) alert via Telegram if a collector
+hasn't succeeded in N days — catching a stopped cron/launchd job or a
+persistent uncaught crash, not day-to-day content variance (a collector that
+runs and finds 0 eligible posts is still a "success": it did its job, there
+just wasn't anything to collect that day).
+
+Requires migration 003_collector_health (see storage/migrate.py).
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_AGE_DAYS = 2.0
+
+
+def record_success(name: str) -> None:
+    """Mark `name` (e.g. 'reddit_drama') as having just succeeded."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO collector_health (name, last_success) VALUES (?, CURRENT_TIMESTAMP) "
+            "ON CONFLICT(name) DO UPDATE SET last_success = CURRENT_TIMESTAMP",
+            (name,),
+        )
+        conn.commit()
+        logger.info("Recorded successful run for collector %r", name)
+    finally:
+        conn.close()
+
+
+def get_last_success(name: str) -> Optional[datetime]:
+    """UTC datetime of the last recorded success, or None if never recorded."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT last_success FROM collector_health WHERE name = ?", (name,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None or row["last_success"] is None:
+        return None
+    raw = row["last_success"]
+    fmt = "%Y-%m-%d %H:%M:%S.%f" if "." in raw else "%Y-%m-%d %H:%M:%S"
+    try:
+        return datetime.strptime(raw, fmt).replace(tzinfo=timezone.utc)
+    except ValueError:
+        logger.warning("Unparseable last_success timestamp for %r: %r", name, raw)
+        return None
+
+
+def is_stale(name: str, max_age_days: float = DEFAULT_MAX_AGE_DAYS) -> bool:
+    """True if `name` has never succeeded, or its last success is older than max_age_days."""
+    last = get_last_success(name)
+    if last is None:
+        return True
+    age_days = (datetime.now(timezone.utc) - last).total_seconds() / 86400
+    return age_days > max_age_days
+
+
+def check_and_alert(names: list[str], max_age_days: float = DEFAULT_MAX_AGE_DAYS) -> list[str]:
+    """Alert via Telegram for every stale collector in `names`. Returns the stale ones.
+
+    Meant to run on its own cron (~every 12h), separate from the collectors
+    themselves, so a collector that stops running entirely still gets caught.
+    """
+    from notifier.telegram_bot import send_alert
+
+    stale = []
+    for name in names:
+        if is_stale(name, max_age_days):
+            stale.append(name)
+            logger.warning("Collector %r has not succeeded in > %.1f day(s)", name, max_age_days)
+            send_alert(
+                f"⚠️ Collector '{name}' chưa chạy thành công trong hơn "
+                f"{max_age_days:.0f} ngày — kiểm tra log/cron!"
+            )
+    return stale
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    check_and_alert(["reddit_drama"])

--- a/content-pipeline/storage/compiled_videos.py
+++ b/content-pipeline/storage/compiled_videos.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `compiled_videos` (Phase 3 EPIC #3.3 — Drama Compiler).
+
+Yêu cầu migration 004_compiled_videos (xem storage/migrate.py).
+"""
+
+import json
+import logging
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def insert_compiled_video(theme: str, story_ids: list[int], script: str,
+                          chapter_markers: list[str]) -> int:
+    """Insert a new compiled long-form video record. Returns its id."""
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            "INSERT INTO compiled_videos (theme, story_ids, script, chapter_markers) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                theme,
+                json.dumps(story_ids),
+                script,
+                json.dumps(chapter_markers, ensure_ascii=False),
+            ),
+        )
+        conn.commit()
+        logger.info(
+            "Inserted compiled video id=%d theme=%r (%d stories)",
+            cursor.lastrowid, theme, len(story_ids),
+        )
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def get_compiled_video(video_id: int) -> Optional[dict]:
+    """Fetch a compiled video by id, with story_ids/chapter_markers parsed back to lists."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM compiled_videos WHERE id = ?", (video_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return _row_to_dict(row)
+
+
+def get_recent_compiled_videos(limit: int = 10) -> list[dict]:
+    """Most recent compiled videos, newest first."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM compiled_videos ORDER BY created_at DESC, id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [_row_to_dict(r) for r in rows]
+
+
+def _row_to_dict(row) -> Optional[dict]:
+    if row is None:
+        return None
+    d = dict(row)
+    d["story_ids"] = json.loads(d["story_ids"]) if d.get("story_ids") else []
+    d["chapter_markers"] = json.loads(d["chapter_markers"]) if d.get("chapter_markers") else []
+    return d

--- a/content-pipeline/storage/migrations/002_stories_metadata.sql
+++ b/content-pipeline/storage/migrations/002_stories_metadata.sql
@@ -1,0 +1,14 @@
+-- Migration 002: stories title/metadata + unique source_id (Phase 2 — Drama
+-- Source Layer).
+--
+-- Adds fields the Drama collectors/seed bot need: a display `title` (used by
+-- /list_pending and Reddit post titles) and a JSON `metadata` blob (subreddit,
+-- upvotes, url, ...). `source_id` gets a UNIQUE index so insert_story can rely
+-- on sqlite3.IntegrityError for dedupe instead of a separate existence check.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+ALTER TABLE stories ADD COLUMN title TEXT;
+ALTER TABLE stories ADD COLUMN metadata TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_stories_source_id ON stories(source_id);

--- a/content-pipeline/storage/migrations/002_stories_metadata_down.sql
+++ b/content-pipeline/storage/migrations/002_stories_metadata_down.sql
@@ -1,0 +1,9 @@
+-- Rollback for 002_stories_metadata.
+-- Requires SQLite >= 3.35.0 (2021-03-12) for ALTER TABLE ... DROP COLUMN.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping DELETE in one transaction.
+
+DROP INDEX IF EXISTS idx_stories_source_id;
+ALTER TABLE stories DROP COLUMN metadata;
+ALTER TABLE stories DROP COLUMN title;

--- a/content-pipeline/storage/migrations/003_collector_health.sql
+++ b/content-pipeline/storage/migrations/003_collector_health.sql
@@ -1,0 +1,14 @@
+-- Migration 003: collector_health table (Phase 2 — Operational hardening).
+--
+-- Tracks the last successful run per collector (keyed by a short name, e.g.
+-- 'reddit_drama') so a separate health-check job can alert via Telegram if a
+-- collector hasn't succeeded in N days (cron/launchd stopped firing, an
+-- uncaught crash, etc.) — see storage/collector_health.py.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS collector_health (
+  name TEXT PRIMARY KEY,
+  last_success TIMESTAMP
+);

--- a/content-pipeline/storage/migrations/003_collector_health_down.sql
+++ b/content-pipeline/storage/migrations/003_collector_health_down.sql
@@ -1,0 +1,6 @@
+-- Rollback for 003_collector_health.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping DELETE in one transaction.
+
+DROP TABLE IF EXISTS collector_health;

--- a/content-pipeline/storage/migrations/004_compiled_videos.sql
+++ b/content-pipeline/storage/migrations/004_compiled_videos.sql
@@ -1,0 +1,18 @@
+-- Migration 004: compiled_videos table (Phase 3 EPIC #3.3 — Drama Compiler).
+--
+-- Stores the long-form script produced by processors/drama_compiler.py,
+-- which gathers 3-5 same-theme `stories` (status='produced', i.e. already
+-- turned into an individual video by Phase 4) into one 8-15 minute video.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS compiled_videos (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  theme TEXT NOT NULL,
+  story_ids TEXT NOT NULL,        -- JSON list of stories.id
+  script TEXT,                    -- full_script, ready for TTS
+  chapter_markers TEXT,           -- JSON list of "MM:SS Title" strings
+  status TEXT DEFAULT 'draft',    -- draft, ready, produced
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/content-pipeline/storage/migrations/004_compiled_videos_down.sql
+++ b/content-pipeline/storage/migrations/004_compiled_videos_down.sql
@@ -1,0 +1,6 @@
+-- Rollback for 004_compiled_videos.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping DELETE in one transaction.
+
+DROP TABLE IF EXISTS compiled_videos;

--- a/content-pipeline/storage/migrations/005_ab_runs.sql
+++ b/content-pipeline/storage/migrations/005_ab_runs.sql
@@ -1,0 +1,18 @@
+-- Migration 005: ab_runs table (Phase 3 EPIC #3.4 — Prompt versioning & A/B harness).
+--
+-- Records which prompt version was used for a given story + experiment, and
+-- a heuristic quality score for it, so processors/ab_harness.py can compare
+-- versions after enough samples accumulate.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS ab_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment TEXT NOT NULL,
+  version TEXT NOT NULL,
+  story_id INTEGER,
+  heuristic_score REAL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_ab_runs_experiment ON ab_runs(experiment);

--- a/content-pipeline/storage/migrations/005_ab_runs_down.sql
+++ b/content-pipeline/storage/migrations/005_ab_runs_down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 005_ab_runs.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping DELETE in one transaction.
+
+DROP INDEX IF EXISTS idx_ab_runs_experiment;
+DROP TABLE IF EXISTS ab_runs;

--- a/content-pipeline/storage/stories.py
+++ b/content-pipeline/storage/stories.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `stories` — CRUD cho Drama track (Phase 2).
+
+Bảng `stories` được tạo ở migration 001_multi_track; cột `title`/`metadata`
+và unique index trên `source_id` được thêm ở migration 002_stories_metadata
+(xem storage/migrate.py). Chạy `python -m storage.migrate up` trước khi dùng
+module này.
+"""
+
+import json
+import logging
+import sqlite3
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Columns update_status() is allowed to touch besides `status`, to avoid
+# building a dynamic UPDATE from caller-controlled column names.
+_UPDATABLE_FIELDS = {
+    "rubric_score", "rewritten_content", "destination", "produced_at", "title",
+}
+
+
+def insert_story(source: str, source_id: Optional[str], raw_content: str,
+                 track: str = "drama", title: Optional[str] = None,
+                 metadata: Optional[dict] = None) -> int:
+    """Insert a new story with status='pending'. Returns the story id.
+
+    Raises:
+        sqlite3.IntegrityError: nếu `source_id` đã tồn tại (unique index từ
+            migration 002). Gọi `dedupe_check()` trước nếu muốn tránh raise.
+    """
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            "INSERT INTO stories (source, source_id, raw_content, track, title, metadata, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'pending')",
+            (
+                source, source_id, raw_content, track, title,
+                json.dumps(metadata, ensure_ascii=False) if metadata is not None else None,
+            ),
+        )
+        conn.commit()
+        logger.info("Inserted story id=%d source=%s source_id=%s", cursor.lastrowid, source, source_id)
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def dedupe_check(source_id: str) -> bool:
+    """True nếu đã có story với `source_id` này."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM stories WHERE source_id = ?", (source_id,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def get_story(story_id: int) -> Optional[dict]:
+    """Lấy 1 story theo id."""
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT * FROM stories WHERE id = ?", (story_id,)).fetchone()
+        return _row_to_dict(row)
+    finally:
+        conn.close()
+
+
+def get_pending(limit: int = 10, track: Optional[str] = None) -> list[dict]:
+    """Lấy story status='pending', sort theo created_at DESC.
+
+    Tie-broken bằng `id DESC`: SQLite's CURRENT_TIMESTAMP chỉ có độ chính xác
+    tới giây, nên nhiều story insert trong cùng 1 giây (bình thường với 1 lần
+    chạy collector) sẽ có `created_at` giống hệt nhau — dùng `id` (tăng dần
+    theo thứ tự insert) làm tie-breaker để thứ tự luôn ổn định/đúng insert order.
+
+    Args:
+        track: lọc theo track ('drama', 'ai', ...) nếu truyền vào, mặc định
+            lấy mọi track.
+    """
+    conn = get_connection()
+    try:
+        if track:
+            rows = conn.execute(
+                "SELECT * FROM stories WHERE status = 'pending' AND track = ? "
+                "ORDER BY created_at DESC, id DESC LIMIT ?",
+                (track, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM stories WHERE status = 'pending' "
+                "ORDER BY created_at DESC, id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def update_status(story_id: int, status: str, **fields) -> None:
+    """Cập nhật status + các field khác (rubric_score, rewritten_content, ...).
+
+    Raises:
+        ValueError: nếu `fields` chứa tên cột không nằm trong allowlist
+            (`_UPDATABLE_FIELDS`) — tránh dựng UPDATE động từ tên cột tuỳ ý.
+    """
+    unknown = set(fields) - _UPDATABLE_FIELDS
+    if unknown:
+        raise ValueError(f"update_status: unknown field(s) {sorted(unknown)}")
+
+    set_clauses = ["status = ?"]
+    params: list = [status]
+    for key, value in fields.items():
+        set_clauses.append(f"{key} = ?")
+        params.append(value)
+    params.append(story_id)
+
+    conn = get_connection()
+    try:
+        conn.execute(
+            f"UPDATE stories SET {', '.join(set_clauses)} WHERE id = ?", params
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _row_to_dict(row: Optional[sqlite3.Row]) -> Optional[dict]:
+    if row is None:
+        return None
+    d = dict(row)
+    if d.get("metadata"):
+        try:
+            d["metadata"] = json.loads(d["metadata"])
+        except (json.JSONDecodeError, TypeError):
+            pass  # leave as raw string — malformed metadata shouldn't break callers
+    return d
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print("Pending stories:", len(get_pending()))

--- a/content-pipeline/storage/stories.py
+++ b/content-pipeline/storage/stories.py
@@ -79,12 +79,22 @@ def get_story(story_id: int) -> Optional[dict]:
 def get_pending(limit: int = 10, track: Optional[str] = None) -> list[dict]:
     """Lấy story status='pending', sort theo created_at DESC.
 
+    Xem `get_by_status()` — đây chỉ là shortcut cho status='pending' (dùng
+    nhiều nhất: seed bot, scorer, rewriter).
+    """
+    return get_by_status("pending", limit=limit, track=track)
+
+
+def get_by_status(status: str, limit: int = 10, track: Optional[str] = None) -> list[dict]:
+    """Lấy story theo `status` bất kỳ, sort theo created_at DESC.
+
     Tie-broken bằng `id DESC`: SQLite's CURRENT_TIMESTAMP chỉ có độ chính xác
     tới giây, nên nhiều story insert trong cùng 1 giây (bình thường với 1 lần
     chạy collector) sẽ có `created_at` giống hệt nhau — dùng `id` (tăng dần
     theo thứ tự insert) làm tie-breaker để thứ tự luôn ổn định/đúng insert order.
 
     Args:
+        status: 'pending', 'approved', 'rejected', 'needs_review', 'produced', ...
         track: lọc theo track ('drama', 'ai', ...) nếu truyền vào, mặc định
             lấy mọi track.
     """
@@ -92,15 +102,15 @@ def get_pending(limit: int = 10, track: Optional[str] = None) -> list[dict]:
     try:
         if track:
             rows = conn.execute(
-                "SELECT * FROM stories WHERE status = 'pending' AND track = ? "
+                "SELECT * FROM stories WHERE status = ? AND track = ? "
                 "ORDER BY created_at DESC, id DESC LIMIT ?",
-                (track, limit),
+                (status, track, limit),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT * FROM stories WHERE status = 'pending' "
+                "SELECT * FROM stories WHERE status = ? "
                 "ORDER BY created_at DESC, id DESC LIMIT ?",
-                (limit,),
+                (status, limit),
             ).fetchall()
         return [_row_to_dict(r) for r in rows]
     finally:

--- a/content-pipeline/tests/test_ab_harness.py
+++ b/content-pipeline/tests/test_ab_harness.py
@@ -1,0 +1,100 @@
+"""Tests for processors/ab_harness.py (Phase 3 EPIC #3.4 — A/B harness)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import processors.ab_harness as ab_harness
+
+
+class TestChooseVersion(unittest.TestCase):
+    def test_deterministic_for_same_inputs(self):
+        v1 = ab_harness.choose_version("rewriter", 42)
+        v2 = ab_harness.choose_version("rewriter", 42)
+        self.assertEqual(v1, v2)
+
+    def test_returns_one_of_the_given_versions(self):
+        result = ab_harness.choose_version("rewriter", 1, versions=("a", "b", "c"))
+        self.assertIn(result, ("a", "b", "c"))
+
+    def test_different_story_ids_can_get_different_versions(self):
+        # Not a strict requirement, but with a big enough sample the 2
+        # versions should both show up (sanity check the hash isn't constant).
+        assigned = {ab_harness.choose_version("rewriter", i) for i in range(50)}
+        self.assertEqual(assigned, {"v1", "v2"})
+
+    def test_roughly_balanced_split(self):
+        counts = {"v1": 0, "v2": 0}
+        for i in range(500):
+            counts[ab_harness.choose_version("exp", i)] += 1
+        # Not asserting exact 50/50, just that neither side is wildly skewed.
+        self.assertGreater(counts["v1"], 150)
+        self.assertGreater(counts["v2"], 150)
+
+    def test_different_experiments_can_assign_differently(self):
+        # Same story_id, different experiment namespace -> not required to
+        # match; just confirms the experiment name participates in the hash.
+        results = {ab_harness.choose_version(f"exp{i}", 7) for i in range(10)}
+        self.assertTrue(len(results) >= 1)  # sanity: doesn't error, returns valid values
+        for r in results:
+            self.assertIn(r, ("v1", "v2"))
+
+
+class ABHarnessDBTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestRecordAndCompare(ABHarnessDBTestBase):
+    def test_compare_returns_none_with_no_runs(self):
+        self.assertIsNone(ab_harness.compare_ab_results("rewriter"))
+
+    def test_compare_returns_none_below_min_samples(self):
+        for i in range(5):
+            ab_harness.record_ab_result("rewriter", "v1", i, 0.8)
+        self.assertIsNone(ab_harness.compare_ab_results("rewriter", min_samples=10))
+
+    def test_compare_after_enough_samples(self):
+        for i in range(10):
+            ab_harness.record_ab_result("rewriter", "v1", i, 0.7)
+        for i in range(10, 20):
+            ab_harness.record_ab_result("rewriter", "v2", i, 0.9)
+        result = ab_harness.compare_ab_results("rewriter", min_samples=10)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["v1"]["n"], 10)
+        self.assertEqual(result["v2"]["n"], 10)
+        self.assertAlmostEqual(result["v1"]["mean"], 0.7)
+        self.assertAlmostEqual(result["v2"]["mean"], 0.9)
+        self.assertEqual(result["better"], "v2")
+
+    def test_tie_when_means_equal(self):
+        for i in range(10):
+            ab_harness.record_ab_result("rewriter", "v1", i, 0.8)
+        for i in range(10, 20):
+            ab_harness.record_ab_result("rewriter", "v2", i, 0.8)
+        result = ab_harness.compare_ab_results("rewriter", min_samples=10)
+        self.assertEqual(result["better"], "tie")
+
+    def test_experiments_are_independent(self):
+        for i in range(10):
+            ab_harness.record_ab_result("expA", "v1", i, 0.5)
+        self.assertIsNone(ab_harness.compare_ab_results("expB", min_samples=10))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_ai_usage.py
+++ b/content-pipeline/tests/test_ai_usage.py
@@ -1,0 +1,60 @@
+"""Tests for processors/ai_usage.py (Phase 3 — token usage logging).
+
+Uses a real logging handler at INFO level (not the test suite's default
+WARNING root logger) — a %d-vs-%s formatting bug here would otherwise be
+masked by INFO messages simply never being formatted/emitted.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import processors.ai_usage as ai_usage
+
+
+class TestLogTokenUsage(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger("processors.ai_usage")
+        self._original_level = self.logger.level
+        self.logger.setLevel(logging.INFO)
+
+    def tearDown(self):
+        self.logger.setLevel(self._original_level)
+
+    def test_logs_with_real_int_usage_at_info_level(self):
+        message = MagicMock()
+        message.usage.input_tokens = 1234
+        message.usage.output_tokens = 567
+        with self.assertLogs("processors.ai_usage", level="INFO") as cm:
+            ai_usage.log_token_usage("drama_scorer", 42, message)
+        self.assertTrue(any("1234" in line and "567" in line for line in cm.output))
+
+    def test_no_usage_attribute_does_not_raise(self):
+        message = MagicMock()
+        message.usage = None
+        # Must not raise even with real INFO-level logging enabled.
+        ai_usage.log_token_usage("drama_scorer", 42, message)
+
+    def test_missing_token_fields_does_not_raise(self):
+        message = MagicMock(spec=["usage"])
+        message.usage = MagicMock(spec=[])  # no input_tokens/output_tokens attrs
+        with self.assertLogs("processors.ai_usage", level="INFO"):
+            ai_usage.log_token_usage("drama_scorer", 42, message)
+
+    def test_unconfigured_mock_usage_does_not_raise(self):
+        # A bare MagicMock() (as used by test fixtures elsewhere in this repo
+        # for fake Anthropic responses) auto-vivifies `.usage.input_tokens`
+        # as ANOTHER MagicMock, not an int — %d formatting would raise here;
+        # %s must not.
+        message = MagicMock()
+        with self.assertLogs("processors.ai_usage", level="INFO"):
+            ai_usage.log_token_usage("drama_scorer", 42, message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_collector_health.py
+++ b/content-pipeline/tests/test_collector_health.py
@@ -1,0 +1,118 @@
+"""Tests for storage/collector_health.py (Phase 2 — Operational hardening)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.collector_health as health
+
+
+class HealthTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestRecordAndGetSuccess(HealthTestBase):
+    def test_never_recorded_returns_none(self):
+        self.assertIsNone(health.get_last_success("reddit_drama"))
+
+    def test_record_then_get_returns_recent_time(self):
+        health.record_success("reddit_drama")
+        last = health.get_last_success("reddit_drama")
+        self.assertIsNotNone(last)
+        age = datetime.now(timezone.utc) - last
+        self.assertLess(age.total_seconds(), 10)
+
+    def test_record_twice_updates_timestamp(self):
+        # Insert an old row directly, then record_success should upsert it
+        # to "now" rather than erroring on the existing primary key.
+        conn = db.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO collector_health (name, last_success) VALUES (?, ?)",
+                ("reddit_drama", "2020-01-01 00:00:00"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        health.record_success("reddit_drama")
+        last = health.get_last_success("reddit_drama")
+        self.assertGreater(last.year, 2020)
+
+    def test_independent_per_collector_name(self):
+        health.record_success("reddit_drama")
+        self.assertIsNone(health.get_last_success("other_collector"))
+
+
+class TestIsStale(HealthTestBase):
+    def test_never_run_is_stale(self):
+        self.assertTrue(health.is_stale("reddit_drama"))
+
+    def test_just_ran_is_not_stale(self):
+        health.record_success("reddit_drama")
+        self.assertFalse(health.is_stale("reddit_drama", max_age_days=2.0))
+
+    def test_old_run_is_stale(self):
+        conn = db.get_connection()
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            conn.execute(
+                "INSERT INTO collector_health (name, last_success) VALUES (?, ?)",
+                ("reddit_drama", old_ts),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self.assertTrue(health.is_stale("reddit_drama", max_age_days=2.0))
+
+    def test_boundary_just_under_threshold_not_stale(self):
+        conn = db.get_connection()
+        recent_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            conn.execute(
+                "INSERT INTO collector_health (name, last_success) VALUES (?, ?)",
+                ("reddit_drama", recent_ts),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self.assertFalse(health.is_stale("reddit_drama", max_age_days=2.0))
+
+
+class TestCheckAndAlert(HealthTestBase):
+    def test_alerts_for_stale_collectors_only(self):
+        health.record_success("healthy_one")
+        with patch("notifier.telegram_bot.send_alert") as alert:
+            stale = health.check_and_alert(["healthy_one", "never_ran"], max_age_days=2.0)
+        self.assertEqual(stale, ["never_ran"])
+        alert.assert_called_once()
+        self.assertIn("never_ran", alert.call_args[0][0])
+
+    def test_no_alert_when_all_healthy(self):
+        health.record_success("a")
+        health.record_success("b")
+        with patch("notifier.telegram_bot.send_alert") as alert:
+            stale = health.check_and_alert(["a", "b"], max_age_days=2.0)
+        self.assertEqual(stale, [])
+        alert.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_drama_compiler.py
+++ b/content-pipeline/tests/test_drama_compiler.py
@@ -1,0 +1,209 @@
+"""Tests for processors/drama_compiler.py (Phase 3 EPIC #3.3 — Drama Compiler)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+import storage.compiled_videos as compiled_videos
+import processors.drama_compiler as drama_compiler
+
+
+def _fake_message(json_dict: dict):
+    msg = MagicMock()
+    msg.usage = None
+    msg.content = [MagicMock(text=json.dumps(json_dict, ensure_ascii=False))]
+    return msg
+
+
+def _mock_anthropic(json_dict: dict):
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_message(json_dict)
+    return patch.object(drama_compiler.anthropic, "Anthropic", return_value=fake_client)
+
+
+def _good_compiled_script(word_count: int = 1500) -> dict:
+    return {
+        "intro": "Hôm nay kể 3 câu chuyện về đồng nghiệp xấu tính.",
+        "bridges": ["Tiếp theo là...", "Và cuối cùng..."],
+        "outro": "Cảm ơn đã xem, đăng ký kênh nhé!",
+        "chapters": ["00:00 Intro", "01:30 Story 1", "05:00 Story 2", "08:30 Story 3"],
+        "full_script": " ".join(["từ"] * word_count),
+    }
+
+
+class DramaCompilerTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _make_produced_story(self, source_id: str, title: str) -> int:
+        story_id = stories.insert_story(
+            "reddit", source_id, "raw content", track="drama", title=title,
+        )
+        stories.update_status(
+            story_id, "produced",
+            rewritten_content=json.dumps({
+                "title": title,
+                "script": f"Script cho {title}. " * 50,
+            }, ensure_ascii=False),
+        )
+        return story_id
+
+
+class TestDetectTheme(DramaCompilerTestBase):
+    def test_too_few_stories_returns_none_without_calling_api(self):
+        s1 = {"id": 1, "title": "A", "raw_content": "a"}
+        s2 = {"id": 2, "title": "B", "raw_content": "b"}
+        with patch.object(drama_compiler.anthropic, "Anthropic") as mocked_anthropic:
+            result = drama_compiler.detect_theme([s1, s2])
+        self.assertIsNone(result)
+        mocked_anthropic.assert_not_called()
+
+    def test_qualifying_theme_returned(self):
+        candidates = [
+            {"id": i, "title": f"Story {i}", "raw_content": "x"} for i in range(1, 4)
+        ]
+        json_dict = {"theme": "đồng nghiệp xấu tính", "story_ids": [1, 2, 3], "reason": "ok"}
+        with _mock_anthropic(json_dict):
+            result = drama_compiler.detect_theme(candidates)
+        self.assertEqual(result["theme"], "đồng nghiệp xấu tính")
+        self.assertEqual(result["story_ids"], [1, 2, 3])
+
+    def test_below_threshold_theme_returns_none(self):
+        candidates = [
+            {"id": i, "title": f"Story {i}", "raw_content": "x"} for i in range(1, 4)
+        ]
+        json_dict = {"theme": "hiếm gặp", "story_ids": [1, 2], "reason": "not enough"}
+        with _mock_anthropic(json_dict):
+            result = drama_compiler.detect_theme(candidates)
+        self.assertIsNone(result)
+
+    def test_null_theme_returns_none(self):
+        candidates = [
+            {"id": i, "title": f"Story {i}", "raw_content": "x"} for i in range(1, 4)
+        ]
+        json_dict = {"theme": None, "story_ids": [], "reason": "no common theme"}
+        with _mock_anthropic(json_dict):
+            result = drama_compiler.detect_theme(candidates)
+        self.assertIsNone(result)
+
+    def test_malformed_response_returns_none(self):
+        candidates = [
+            {"id": i, "title": f"Story {i}", "raw_content": "x"} for i in range(1, 4)
+        ]
+        fake_client = MagicMock()
+        not_json_message = MagicMock()
+        not_json_message.usage = None
+        not_json_message.content = [MagicMock(text="not json at all")]
+        fake_client.messages.create.return_value = not_json_message
+        with patch.object(drama_compiler.anthropic, "Anthropic", return_value=fake_client):
+            result = drama_compiler.detect_theme(candidates)
+        self.assertIsNone(result)
+
+
+class TestCompileLongForm(DramaCompilerTestBase):
+    def test_valid_script_returned(self):
+        story_ids = [self._make_produced_story(f"s{i}", f"Story {i}") for i in range(3)]
+        selected = [stories.get_story(sid) for sid in story_ids]
+        with _mock_anthropic(_good_compiled_script()):
+            result = drama_compiler.compile_long_form(selected, "test theme")
+        self.assertIsNotNone(result)
+        self.assertIn("full_script", result)
+
+    def test_invalid_chapter_format_retries_then_fails(self):
+        story_ids = [self._make_produced_story(f"t{i}", f"Story {i}") for i in range(3)]
+        selected = [stories.get_story(sid) for sid in story_ids]
+        bad = _good_compiled_script()
+        bad["chapters"] = ["not a valid chapter marker"]
+        with _mock_anthropic(bad):
+            result = drama_compiler.compile_long_form(selected, "test theme")
+        self.assertIsNone(result)
+
+    def test_word_count_out_of_range_fails(self):
+        story_ids = [self._make_produced_story(f"u{i}", f"Story {i}") for i in range(3)]
+        selected = [stories.get_story(sid) for sid in story_ids]
+        bad = _good_compiled_script(word_count=100)
+        with _mock_anthropic(bad):
+            result = drama_compiler.compile_long_form(selected, "test theme")
+        self.assertIsNone(result)
+
+    def test_missing_field_fails(self):
+        story_ids = [self._make_produced_story(f"v{i}", f"Story {i}") for i in range(3)]
+        selected = [stories.get_story(sid) for sid in story_ids]
+        bad = _good_compiled_script()
+        del bad["outro"]
+        with _mock_anthropic(bad):
+            result = drama_compiler.compile_long_form(selected, "test theme")
+        self.assertIsNone(result)
+
+    def test_caps_at_max_stories_per_compilation(self):
+        story_ids = [self._make_produced_story(f"w{i}", f"Story {i}") for i in range(7)]
+        selected = [stories.get_story(sid) for sid in story_ids]
+        fake_client = MagicMock()
+        fake_client.messages.create.return_value = _fake_message(_good_compiled_script())
+        with patch.object(drama_compiler.anthropic, "Anthropic", return_value=fake_client):
+            drama_compiler.compile_long_form(selected, "test theme")
+        sent_prompt = fake_client.messages.create.call_args.kwargs["messages"][0]["content"]
+        # Only MAX_STORIES_PER_COMPILATION (5) of the 7 should appear in the prompt.
+        included = sum(1 for sid in story_ids if f"Story #{sid}" in sent_prompt)
+        self.assertEqual(included, drama_compiler.MAX_STORIES_PER_COMPILATION)
+
+
+class TestRunWeeklyCompilation(DramaCompilerTestBase):
+    def test_no_produced_stories_returns_none(self):
+        result = drama_compiler.run_weekly_compilation()
+        self.assertIsNone(result)
+
+    def test_full_flow_creates_compiled_video(self):
+        story_ids = [self._make_produced_story(f"p{i}", f"Story {i}") for i in range(3)]
+        theme_json = {"theme": "test theme", "story_ids": story_ids, "reason": "ok"}
+        compile_json = _good_compiled_script()
+
+        call_count = {"n": 0}
+
+        def fake_create(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _fake_message(theme_json)
+            return _fake_message(compile_json)
+
+        fake_client = MagicMock()
+        fake_client.messages.create.side_effect = fake_create
+        with patch.object(drama_compiler.anthropic, "Anthropic", return_value=fake_client):
+            video_id = drama_compiler.run_weekly_compilation()
+
+        self.assertIsNotNone(video_id)
+        video = compiled_videos.get_compiled_video(video_id)
+        self.assertEqual(video["theme"], "test theme")
+        self.assertEqual(set(video["story_ids"]), set(story_ids))
+
+    def test_theme_detection_failure_returns_none_without_compiling(self):
+        self._make_produced_story("q0", "Story 0")
+        self._make_produced_story("q1", "Story 1")
+        self._make_produced_story("q2", "Story 2")
+        json_dict = {"theme": None, "story_ids": [], "reason": "none found"}
+        with _mock_anthropic(json_dict) as _, \
+             patch.object(drama_compiler, "compile_long_form") as mocked_compile:
+            result = drama_compiler.run_weekly_compilation()
+        self.assertIsNone(result)
+        mocked_compile.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_drama_quality.py
+++ b/content-pipeline/tests/test_drama_quality.py
@@ -1,0 +1,147 @@
+"""Drama rewrite quality test harness (Phase 3 acceptance criteria,
+phase-3-detailed.md: "Test harness tests/test_drama_quality.py chấm output
+bằng heuristics (số từ, tên VN, structure)").
+
+Unlike tests/test_drama_rewriter.py's TestValidateRewrite (which isolates
+one failure mode per test case), this module runs whole realistic-looking
+rewrite outputs — the kind processors/drama_rewriter.py actually produces —
+through validate_rewrite() and checks the aggregate verdict. It's the
+fixture set a human would use to sanity-check a new prompt version against
+(see docs/current/prompts-decisions.md "Cách tune sang v2").
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from processors.drama_rewriter import validate_rewrite
+
+
+def _script(paragraphs: list[str], target_words: int) -> str:
+    """Pad/repeat `paragraphs` with filler Vietnamese-ish words to hit
+    `target_words`, keeping the paragraph breaks (rough structure proxy)."""
+    text = "\n\n".join(paragraphs)
+    words = text.split()
+    if len(words) >= target_words:
+        return " ".join(words[:target_words])
+    filler_needed = target_words - len(words)
+    words.extend(["rồi"] * filler_needed)
+    return " ".join(words)
+
+
+GOOD_REWRITE_1 = {
+    "title": "Chị dâu tôi đòi chia tài sản ông bà để lại",
+    "hook": "Chưa đầy một tuần sau đám tang, chị dâu đã đòi chia nhà.",
+    "script": _script([
+        "Tôi tên Nguyễn Thị Lan, năm nay ba mươi hai tuổi, sống ở Hà Đông.",
+        "Ông bà tôi mất, để lại căn nhà cho cả gia đình.",
+        "Chị dâu tôi, tên Trần Thị Hoa, bắt đầu đòi chia tài sản ngay lập tức.",
+        "Cả nhà tôi sốc, không ai nghĩ chị lại làm vậy giữa lúc tang gia bối rối.",
+        "Cuối cùng, sự thật về khoản nợ chị giấu kín mới lộ ra.",
+    ], target_words=900),
+    "vn_commentary": " ".join(
+        ["Góc nhìn của tôi là chuyện tài sản trong gia đình Việt luôn nhạy cảm."] * 40
+    ),
+    "thumbnail_prompt": "shocked Vietnamese woman standing in front of family house, dramatic lighting",
+    "tags": ["#giadinh", "#drama", "#chiadau"],
+}
+
+GOOD_REWRITE_2 = {
+    "title": "Sếp bắt tôi làm việc cuối tuần không trả lương",
+    "hook": "Ba tháng liền, tôi làm việc không công vào mỗi cuối tuần.",
+    "script": _script([
+        "Tôi là Phạm Văn Đức, nhân viên văn phòng tại một công ty ở Quận 1.",
+        "Sếp tôi, anh Hùng, liên tục giao thêm việc vào cuối tuần mà không trả thêm lương.",
+        "Tôi cắn răng chịu đựng vì sợ mất việc trong lúc kinh tế khó khăn.",
+        "Đến khi phát hiện đồng nghiệp khác cũng bị vậy, tôi quyết định lên tiếng.",
+        "Kết quả bất ngờ hơn tôi nghĩ rất nhiều.",
+    ], target_words=1000),
+    "vn_commentary": " ".join(
+        ["Văn hoá làm thêm giờ không lương ở nhiều công ty Việt Nam vẫn còn phổ biến."] * 45
+    ),
+    "thumbnail_prompt": "tired Vietnamese office worker at desk late at night, dramatic office lighting",
+    "tags": ["#congso", "#drama", "#luong"],
+}
+
+
+BAD_REWRITE_TOO_SHORT = {**GOOD_REWRITE_1, "script": "Một câu chuyện ngắn."}
+
+BAD_REWRITE_WESTERN_NAME = {
+    **GOOD_REWRITE_1,
+    "title": "Linh Smith và câu chuyện chia tài sản",
+}
+
+BAD_REWRITE_US_CULTURE = {
+    **GOOD_REWRITE_2,
+    "script": GOOD_REWRITE_2["script"] + " chúng tôi gặp nhau ở mall cuối tuần",
+}
+
+BAD_REWRITE_SHORT_COMMENTARY = {
+    **GOOD_REWRITE_1,
+    "vn_commentary": "Quá ngắn.",
+}
+
+BAD_REWRITE_MISSING_FIELD = {k: v for k, v in GOOD_REWRITE_1.items() if k != "thumbnail_prompt"}
+
+
+class TestGoodRewritesPassQualityGate(unittest.TestCase):
+    """Realistic, well-formed rewrites must produce zero heuristic issues."""
+
+    def test_good_rewrite_1_passes(self):
+        self.assertEqual(validate_rewrite(GOOD_REWRITE_1), [])
+
+    def test_good_rewrite_2_passes(self):
+        self.assertEqual(validate_rewrite(GOOD_REWRITE_2), [])
+
+
+class TestBadRewritesFailQualityGate(unittest.TestCase):
+    """Each fixture violates exactly one rule — confirms the harness catches
+    every category the doc calls out (số từ, tên VN, structure/culture)."""
+
+    def test_too_short_script_fails(self):
+        issues = validate_rewrite(BAD_REWRITE_TOO_SHORT)
+        self.assertTrue(issues)
+        self.assertTrue(any("word count" in i for i in issues))
+
+    def test_western_name_fails(self):
+        issues = validate_rewrite(BAD_REWRITE_WESTERN_NAME)
+        self.assertTrue(issues)
+        self.assertTrue(any("smith" in i for i in issues))
+
+    def test_us_culture_term_fails(self):
+        issues = validate_rewrite(BAD_REWRITE_US_CULTURE)
+        self.assertTrue(issues)
+        self.assertTrue(any("mall" in i for i in issues))
+
+    def test_short_commentary_fails(self):
+        issues = validate_rewrite(BAD_REWRITE_SHORT_COMMENTARY)
+        self.assertTrue(issues)
+        self.assertTrue(any("vn_commentary" in i for i in issues))
+
+    def test_missing_field_fails(self):
+        issues = validate_rewrite(BAD_REWRITE_MISSING_FIELD)
+        self.assertTrue(issues)
+        self.assertTrue(any("missing/empty" in i for i in issues))
+
+
+class TestQualityGateSummary(unittest.TestCase):
+    """Aggregate pass-rate check, mirroring how a human would eyeball a batch
+    of rewrites when tuning a new prompt version (see prompts-decisions.md)."""
+
+    def test_all_good_fixtures_pass_all_bad_fixtures_fail(self):
+        good = [GOOD_REWRITE_1, GOOD_REWRITE_2]
+        bad = [
+            BAD_REWRITE_TOO_SHORT, BAD_REWRITE_WESTERN_NAME, BAD_REWRITE_US_CULTURE,
+            BAD_REWRITE_SHORT_COMMENTARY, BAD_REWRITE_MISSING_FIELD,
+        ]
+        good_pass_rate = sum(1 for r in good if not validate_rewrite(r)) / len(good)
+        bad_fail_rate = sum(1 for r in bad if validate_rewrite(r)) / len(bad)
+        self.assertEqual(good_pass_rate, 1.0)
+        self.assertEqual(bad_fail_rate, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -1,0 +1,188 @@
+"""Tests for processors/drama_rewriter.py (Phase 3 — Drama Generation Layer)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+import processors.drama_rewriter as drama_rewriter
+
+
+def _good_rewrite(word_count: int = 900, commentary_words: int = 220) -> dict:
+    return {
+        "title": "Sếp bắt làm thêm giờ không lương",
+        "hook": "Ba năm đi làm, tôi chưa từng nghĩ mình sẽ bị đối xử như vậy.",
+        "script": " ".join(["từ"] * word_count),
+        "vn_commentary": " ".join(["bình_luận"] * commentary_words),
+        "thumbnail_prompt": "office worker looking stressed, dramatic lighting",
+        "tags": ["#drama", "#congso"],
+    }
+
+
+def _fake_message(json_dict: dict):
+    msg = MagicMock()
+    msg.usage = None
+    msg.content = [MagicMock(text=json.dumps(json_dict, ensure_ascii=False))]
+    return msg
+
+
+def _mock_anthropic(json_dict: dict):
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_message(json_dict)
+    return patch.object(drama_rewriter.anthropic, "Anthropic", return_value=fake_client)
+
+
+class TestValidateRewrite(unittest.TestCase):
+    def test_good_rewrite_has_no_issues(self):
+        self.assertEqual(drama_rewriter.validate_rewrite(_good_rewrite()), [])
+
+    def test_missing_field_flagged(self):
+        result = _good_rewrite()
+        del result["vn_commentary"]
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("missing/empty" in i for i in issues))
+
+    def test_script_too_short_flagged(self):
+        issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=100))
+        self.assertTrue(any("word count" in i for i in issues))
+
+    def test_script_too_long_flagged(self):
+        issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=2000))
+        self.assertTrue(any("word count" in i for i in issues))
+
+    def test_short_vn_commentary_flagged(self):
+        issues = drama_rewriter.validate_rewrite(_good_rewrite(commentary_words=50))
+        self.assertTrue(any("vn_commentary only" in i for i in issues))
+
+    def test_overlong_hook_flagged(self):
+        result = _good_rewrite()
+        result["hook"] = " ".join(["từ"] * 40)  # a paragraph, not a 3s line
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("hook has" in i for i in issues))
+
+    def test_short_hook_not_flagged(self):
+        result = _good_rewrite()
+        result["hook"] = "Ba năm đi làm, tôi chưa từng nghĩ mình sẽ bị đối xử như vậy."
+        self.assertEqual(drama_rewriter.validate_rewrite(result), [])
+
+    def test_western_name_fragment_flagged(self):
+        result = _good_rewrite()
+        result["title"] = "Linh Smith và câu chuyện của cô"
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("smith" in i for i in issues))
+
+    def test_foreign_culture_term_flagged(self):
+        result = _good_rewrite()
+        result["script"] = result["script"] + " đi đến mall mua đồ"
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("mall" in i for i in issues))
+
+    def test_dollar_symbol_flagged(self):
+        result = _good_rewrite()
+        result["script"] = result["script"] + " mất $500"
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("$" in i for i in issues))
+
+    def test_empty_tags_flagged(self):
+        result = _good_rewrite()
+        result["tags"] = []
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("tags" in i for i in issues))
+
+    def test_vietnamese_word_not_falsely_flagged_as_western_name(self):
+        # Sanity check: word-boundary regex shouldn't misfire on ordinary
+        # Vietnamese text that happens to contain a substring like "john".
+        result = _good_rewrite()
+        result["script"] = result["script"] + " không liên quan gì tới john cả"
+        issues = drama_rewriter.validate_rewrite(result)
+        # "john" IS a blacklisted fragment - this documents current behavior
+        # (whole-word match, still triggers on the literal word "john").
+        self.assertTrue(any("john" in i for i in issues))
+
+
+class RewriterTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+        self.story_id = stories.insert_story(
+            "reddit", "s1", "Some drama story content here.", track="drama",
+        )
+        stories.update_status(self.story_id, "pending", rubric_score=6)
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestRewriteStory(RewriterTestBase):
+    def test_valid_rewrite_sets_approved(self):
+        with _mock_anthropic(_good_rewrite()):
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+        self.assertIn("Sếp bắt", story["rewritten_content"])
+
+    def test_invalid_rewrite_sets_needs_review_and_alerts(self):
+        bad = _good_rewrite(word_count=50)
+        with _mock_anthropic(bad), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "needs_review")
+        # Output is still saved for human review, not discarded.
+        self.assertIsNotNone(story["rewritten_content"])
+        alert.assert_called_once()
+        self.assertIn(str(self.story_id), alert.call_args[0][0])
+
+    def test_missing_story_returns_none(self):
+        self.assertIsNone(drama_rewriter.rewrite_story(999999))
+
+    def test_malformed_json_leaves_story_untouched(self):
+        fake_client = MagicMock()
+        bad_message = MagicMock()
+        bad_message.usage = None
+        bad_message.content = [MagicMock(text="not json")]
+        fake_client.messages.create.return_value = bad_message
+        with patch.object(drama_rewriter.anthropic, "Anthropic", return_value=fake_client):
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "pending")
+        self.assertIsNone(story["rewritten_content"])
+
+
+class TestRewriteAllScored(RewriterTestBase):
+    def test_skips_stories_without_rubric_score(self):
+        unscored_id = stories.insert_story("reddit", "s2", "raw", track="drama")
+        with patch.object(drama_rewriter, "rewrite_story") as mocked:
+            drama_rewriter.rewrite_all_scored()
+        mocked.assert_called_once_with(self.story_id)
+
+    def test_skips_already_rewritten_stories(self):
+        stories.update_status(self.story_id, "approved", rewritten_content="{}")
+        with patch.object(drama_rewriter, "rewrite_story") as mocked:
+            count = drama_rewriter.rewrite_all_scored()
+        mocked.assert_not_called()
+        self.assertEqual(count, 0)
+
+    def test_rewrites_eligible_story(self):
+        with _mock_anthropic(_good_rewrite()):
+            count = drama_rewriter.rewrite_all_scored()
+        self.assertEqual(count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_drama_scorer.py
+++ b/content-pipeline/tests/test_drama_scorer.py
@@ -1,0 +1,139 @@
+"""Tests for processors/drama_scorer.py (Phase 3 — Drama Generation Layer)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+import processors.drama_scorer as drama_scorer
+
+
+def _fake_message(text: str):
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text)]
+    return msg
+
+
+def _mock_anthropic(json_text: str):
+    """Patch drama_scorer.anthropic.Anthropic so .messages.create(...) returns json_text."""
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_message(json_text)
+    return patch.object(drama_scorer.anthropic, "Anthropic", return_value=fake_client)
+
+
+class TestValidateAndNormalizeRubric(unittest.TestCase):
+    def test_recomputes_total_from_fields_ignoring_models_own_total(self):
+        result = {
+            "hook_3s": 1, "stakes": 1, "twist": 1,
+            "localizable": 1, "comment_bait": 1, "safe": 1,
+            "total": 999,  # model's own (wrong) arithmetic — must be ignored
+        }
+        normalized = drama_scorer._validate_and_normalize_rubric(result)
+        self.assertEqual(normalized["total"], 6)
+
+    def test_missing_field_raises(self):
+        with self.assertRaises(ValueError):
+            drama_scorer._validate_and_normalize_rubric({"hook_3s": 1})
+
+    def test_non_binary_field_raises(self):
+        bad = {"hook_3s": 2, "stakes": 1, "twist": 1,
+               "localizable": 1, "comment_bait": 1, "safe": 1}
+        with self.assertRaises(ValueError):
+            drama_scorer._validate_and_normalize_rubric(bad)
+
+    def test_default_reason_is_empty_string(self):
+        result = {"hook_3s": 1, "stakes": 1, "twist": 1,
+                  "localizable": 1, "comment_bait": 1, "safe": 1}
+        normalized = drama_scorer._validate_and_normalize_rubric(result)
+        self.assertEqual(normalized["reason"], "")
+
+
+class ScorerTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+        self.story_id = stories.insert_story(
+            "reddit", "s1", "Some drama story content here.", track="drama",
+        )
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestScoreStory(ScorerTestBase):
+    def test_passing_story_stays_pending_with_score(self):
+        json_text = ('{"hook_3s":1,"stakes":1,"twist":1,"localizable":1,'
+                     '"comment_bait":1,"safe":1,"reason":"good"}')
+        with _mock_anthropic(json_text):
+            result = drama_scorer.score_story(self.story_id)
+        self.assertEqual(result["total"], 6)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "pending")
+        self.assertEqual(story["rubric_score"], 6)
+
+    def test_low_score_rejected(self):
+        json_text = ('{"hook_3s":0,"stakes":0,"twist":0,"localizable":1,'
+                     '"comment_bait":0,"safe":1,"reason":"meh"}')
+        with _mock_anthropic(json_text):
+            drama_scorer.score_story(self.story_id)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "rejected")
+
+    def test_unsafe_story_rejected_even_with_high_total(self):
+        json_text = ('{"hook_3s":1,"stakes":1,"twist":1,"localizable":1,'
+                     '"comment_bait":1,"safe":0,"reason":"nsfw"}')
+        with _mock_anthropic(json_text):
+            result = drama_scorer.score_story(self.story_id)
+        self.assertEqual(result["total"], 5)  # 5/6 would normally pass
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "rejected")  # but safe=0 vetoes it
+
+    def test_missing_story_returns_none(self):
+        self.assertIsNone(drama_scorer.score_story(999999))
+
+    def test_malformed_json_leaves_story_untouched_for_retry(self):
+        with _mock_anthropic("this is not json at all"):
+            result = drama_scorer.score_story(self.story_id)
+        self.assertIsNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "pending")
+        self.assertIsNone(story["rubric_score"])
+
+
+class TestScoreAllPending(ScorerTestBase):
+    def test_skips_already_scored_stories(self):
+        stories.update_status(self.story_id, "pending", rubric_score=6)
+        with patch.object(drama_scorer, "score_story") as mocked:
+            count = drama_scorer.score_all_pending()
+        mocked.assert_not_called()
+        self.assertEqual(count, 0)
+
+    def test_scores_unscored_pending_story(self):
+        json_text = ('{"hook_3s":1,"stakes":1,"twist":1,"localizable":1,'
+                     '"comment_bait":1,"safe":1}')
+        with _mock_anthropic(json_text):
+            count = drama_scorer.score_all_pending()
+        self.assertEqual(count, 1)
+        self.assertEqual(stories.get_story(self.story_id)["rubric_score"], 6)
+
+    def test_ignores_non_drama_track(self):
+        stories.insert_story("reddit", "ai1", "an AI story", track="ai")
+        with patch.object(drama_scorer, "score_story") as mocked:
+            drama_scorer.score_all_pending()
+        # Only the 1 drama-track story from setUp should have been attempted.
+        self.assertEqual(mocked.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_migrate.py
+++ b/content-pipeline/tests/test_migrate.py
@@ -105,6 +105,83 @@ class TestMigrateUp(unittest.TestCase):
         self.assertIn("destination", cols)
 
 
+class TestMigrateUp002(unittest.TestCase):
+    """Migration 002 — stories.title/metadata columns + unique source_id
+    (Phase 2 — Drama Source Layer)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_stories_has_title_and_metadata_columns(self):
+        conn = db.get_connection()
+        try:
+            cols = {r["name"] for r in conn.execute("PRAGMA table_info(stories)")}
+        finally:
+            conn.close()
+        self.assertIn("title", cols)
+        self.assertIn("metadata", cols)
+
+    def test_source_id_is_unique(self):
+        conn = db.get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO stories (source, source_id, raw_content, track) "
+                "VALUES ('reddit', 'dup123', 'first', 'drama')"
+            )
+            conn.commit()
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO stories (source, source_id, raw_content, track) "
+                    "VALUES ('reddit', 'dup123', 'second', 'drama')"
+                )
+        finally:
+            conn.close()
+
+    def test_down_then_up_again_is_clean(self):
+        migrate.migrate_down()  # reverts 003 (most recent)
+        migrate.migrate_down()  # reverts 002
+        applied = migrate.migrate_up()
+        self.assertIn("002_stories_metadata", applied)
+
+
+class TestMigrateUp003(unittest.TestCase):
+    """Migration 003 — collector_health table (Phase 2 — Operational hardening)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_collector_health_table_created(self):
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='collector_health'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+
+    def test_down_then_up_again_is_clean(self):
+        migrate.migrate_down()
+        applied = migrate.migrate_up()
+        self.assertIn("003_collector_health", applied)
+
+
 class TestMigrateAtomicity(unittest.TestCase):
     """A migration script that fails partway through must leave neither a
     partial schema change nor a bookkeeping row — schema DDL and the
@@ -219,6 +296,10 @@ class TestTrackDestinationRoundtrip(unittest.TestCase):
 
 
 class TestMigrateDown(unittest.TestCase):
+    """migrate_down() reverts one migration at a time (the most recently
+    applied) — with 3 migrations now present, fully undoing the schema takes
+    3 calls."""
+
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.dbpath = os.path.join(self.tmp, "test.db")
@@ -230,8 +311,23 @@ class TestMigrateDown(unittest.TestCase):
     def tearDown(self):
         self._patch.stop()
 
-    def test_down_removes_stories_table(self):
-        migrate.migrate_down()
+    def test_down_reverts_most_recent_migration_only(self):
+        reverted = migrate.migrate_down()
+        self.assertEqual(reverted, "003_collector_health")
+        conn = db.get_connection()
+        try:
+            # 003 removed, but 001 (which created the table) is still applied.
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='stories'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+
+    def test_down_three_times_removes_stories_table(self):
+        migrate.migrate_down()  # reverts 003
+        migrate.migrate_down()  # reverts 002
+        migrate.migrate_down()  # reverts 001
         conn = db.get_connection()
         try:
             row = conn.execute(
@@ -241,10 +337,15 @@ class TestMigrateDown(unittest.TestCase):
             conn.close()
         self.assertIsNone(row)
 
-    def test_down_then_up_again_is_clean(self):
+    def test_down_three_times_then_up_again_is_clean(self):
+        migrate.migrate_down()
+        migrate.migrate_down()
         migrate.migrate_down()
         applied = migrate.migrate_up()
-        self.assertIn("001_multi_track", applied)
+        self.assertEqual(
+            applied,
+            ["001_multi_track", "002_stories_metadata", "003_collector_health"],
+        )
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_migrate.py
+++ b/content-pipeline/tests/test_migrate.py
@@ -15,6 +15,17 @@ import storage.database as db
 import storage.migrate as migrate
 
 
+def _revert_including(version: str) -> None:
+    """Call migrate_down() repeatedly until `version` itself is reverted.
+
+    Lets a "down the migration I'm testing" test stay correct regardless of
+    how many later migrations have been added since — no need to hardcode
+    "call migrate_down() N times".
+    """
+    while any(e["version"] == version and e["applied"] for e in migrate.status()):
+        migrate.migrate_down()
+
+
 class TestMigrateUpOnCleanCheckout(unittest.TestCase):
     """`migrate up` must work as the very first command on a brand-new DB
     file — no prior `init_db()` call — since that's the documented flow for
@@ -146,8 +157,7 @@ class TestMigrateUp002(unittest.TestCase):
             conn.close()
 
     def test_down_then_up_again_is_clean(self):
-        migrate.migrate_down()  # reverts 003 (most recent)
-        migrate.migrate_down()  # reverts 002
+        _revert_including("002_stories_metadata")
         applied = migrate.migrate_up()
         self.assertIn("002_stories_metadata", applied)
 
@@ -177,9 +187,69 @@ class TestMigrateUp003(unittest.TestCase):
         self.assertIsNotNone(row)
 
     def test_down_then_up_again_is_clean(self):
-        migrate.migrate_down()
+        _revert_including("003_collector_health")
         applied = migrate.migrate_up()
         self.assertIn("003_collector_health", applied)
+
+
+class TestMigrateUp004(unittest.TestCase):
+    """Migration 004 — compiled_videos table (Phase 3 EPIC #3.3 — Drama Compiler)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_compiled_videos_table_created(self):
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='compiled_videos'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+
+    def test_down_then_up_again_is_clean(self):
+        _revert_including("004_compiled_videos")
+        applied = migrate.migrate_up()
+        self.assertIn("004_compiled_videos", applied)
+
+
+class TestMigrateUp005(unittest.TestCase):
+    """Migration 005 — ab_runs table (Phase 3 EPIC #3.4 — A/B harness)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_ab_runs_table_created(self):
+        conn = db.get_connection()
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='ab_runs'"
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertIsNotNone(row)
+
+    def test_down_then_up_again_is_clean(self):
+        _revert_including("005_ab_runs")
+        applied = migrate.migrate_up()
+        self.assertIn("005_ab_runs", applied)
 
 
 class TestMigrateAtomicity(unittest.TestCase):
@@ -297,8 +367,10 @@ class TestTrackDestinationRoundtrip(unittest.TestCase):
 
 class TestMigrateDown(unittest.TestCase):
     """migrate_down() reverts one migration at a time (the most recently
-    applied) — with 3 migrations now present, fully undoing the schema takes
-    3 calls."""
+    applied). Deliberately derives the migration count/order from
+    `_discover_migrations()` instead of hardcoding it, so this test doesn't
+    need editing every time a new migration file is added (as the previous
+    3 versions of this test did — see git history)."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -306,6 +378,7 @@ class TestMigrateDown(unittest.TestCase):
         self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
         self._patch.start()
         db.init_db()
+        self.all_versions = [v for v, _ in migrate._discover_migrations()]
         migrate.migrate_up()
 
     def tearDown(self):
@@ -313,21 +386,13 @@ class TestMigrateDown(unittest.TestCase):
 
     def test_down_reverts_most_recent_migration_only(self):
         reverted = migrate.migrate_down()
-        self.assertEqual(reverted, "003_collector_health")
-        conn = db.get_connection()
-        try:
-            # 003 removed, but 001 (which created the table) is still applied.
-            row = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='stories'"
-            ).fetchone()
-        finally:
-            conn.close()
-        self.assertIsNotNone(row)
+        self.assertEqual(reverted, self.all_versions[-1])
+        remaining_applied = {e["version"] for e in migrate.status() if e["applied"]}
+        self.assertEqual(remaining_applied, set(self.all_versions[:-1]))
 
-    def test_down_three_times_removes_stories_table(self):
-        migrate.migrate_down()  # reverts 003
-        migrate.migrate_down()  # reverts 002
-        migrate.migrate_down()  # reverts 001
+    def test_down_all_removes_stories_table(self):
+        for _ in self.all_versions:
+            migrate.migrate_down()
         conn = db.get_connection()
         try:
             row = conn.execute(
@@ -336,16 +401,13 @@ class TestMigrateDown(unittest.TestCase):
         finally:
             conn.close()
         self.assertIsNone(row)
+        self.assertIsNone(migrate.migrate_down())  # nothing left to revert
 
-    def test_down_three_times_then_up_again_is_clean(self):
-        migrate.migrate_down()
-        migrate.migrate_down()
-        migrate.migrate_down()
+    def test_down_all_then_up_again_is_clean(self):
+        for _ in self.all_versions:
+            migrate.migrate_down()
         applied = migrate.migrate_up()
-        self.assertEqual(
-            applied,
-            ["001_multi_track", "002_stories_metadata", "003_collector_health"],
-        )
+        self.assertEqual(applied, self.all_versions)
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_prompt_loader.py
+++ b/content-pipeline/tests/test_prompt_loader.py
@@ -1,0 +1,60 @@
+"""Tests for processors/prompt_loader.py (Phase 3 — prompt versioning)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import processors.prompt_loader as prompt_loader
+
+
+class TestLoadPrompt(unittest.TestCase):
+    def test_loads_scorer_v1(self):
+        text = prompt_loader.load_prompt("drama", "scorer", version="v1")
+        self.assertIn("HOOK_3S", text)
+        self.assertIn("{{RAW_CONTENT}}", text)
+
+    def test_loads_rewriter_v1(self):
+        text = prompt_loader.load_prompt("drama", "rewriter", version="v1")
+        self.assertIn("vn_commentary", text)
+
+    def test_uses_config_prompt_version_by_default(self):
+        from unittest.mock import patch
+        with patch.object(prompt_loader.config, "PROMPT_VERSION", "v1"):
+            text = prompt_loader.load_prompt("drama", "scorer")
+        self.assertIn("HOOK_3S", text)
+
+    def test_missing_prompt_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            prompt_loader.load_prompt("drama", "does_not_exist", version="v1")
+
+    def test_missing_version_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            prompt_loader.load_prompt("drama", "scorer", version="v99")
+
+
+class TestRender(unittest.TestCase):
+    def test_replaces_single_placeholder(self):
+        result = prompt_loader.render("Hello {{NAME}}!", NAME="World")
+        self.assertEqual(result, "Hello World!")
+
+    def test_replaces_multiple_placeholders(self):
+        result = prompt_loader.render("{{A}} and {{B}}", A="x", B="y")
+        self.assertEqual(result, "x and y")
+
+    def test_leaves_literal_braces_untouched(self):
+        # JSON-schema examples in prompts use single braces — render() must
+        # not touch them, only {{DOUBLE_BRACE}} placeholders.
+        template = 'Output: {"key": "value"} then {{FILLER}}'
+        result = prompt_loader.render(template, FILLER="done")
+        self.assertEqual(result, 'Output: {"key": "value"} then done')
+
+    def test_unreferenced_kwarg_is_ignored(self):
+        result = prompt_loader.render("no placeholders here", UNUSED="x")
+        self.assertEqual(result, "no placeholders here")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_reddit_drama_collector.py
+++ b/content-pipeline/tests/test_reddit_drama_collector.py
@@ -135,12 +135,16 @@ class TestCollectSubreddit(unittest.TestCase):
         self._rss_patch.start()
 
         def fake_detail(subreddit, post_id):
-            return {
-                "aaa": {"selftext": "Body A", "ups": 6000, "over_18": False},
-                "bbb": {"selftext": "Body B", "ups": 8000, "over_18": False},
-                "ccc": {"selftext": "Body C", "ups": 9000, "over_18": True},
-                "ddd": {"selftext": "Body D", "ups": 10, "over_18": False},
+            # Return the RAW reddit JSON shape (list of 2 listings), same as
+            # the real _fetch_post_json — exercises the real parse_post_detail()
+            # call inside collect_subreddit() instead of bypassing it.
+            raw = {
+                "aaa": _detail_json(selftext="Body A", ups=6000, over_18=False),
+                "bbb": _detail_json(selftext="Body B", ups=8000, over_18=False),
+                "ccc": _detail_json(selftext="Body C", ups=9000, over_18=True),
+                "ddd": _detail_json(selftext="Body D", ups=10, over_18=False),
             }[post_id]
+            return raw
 
         self._detail_patch = patch.object(drama_collector, "_fetch_post_json", side_effect=fake_detail)
         self._detail_patch.start()
@@ -179,6 +183,65 @@ class TestCollectSubreddit(unittest.TestCase):
         self.assertEqual(first, 2)
         self.assertEqual(second, 0)
 
+    def test_fetch_post_json_raw_shape_is_actually_parsed(self):
+        # Regression test: _fetch_post_json returns Reddit's RAW JSON shape
+        # (a list of 2 listings), not a pre-parsed dict. collect_subreddit()
+        # must run it through parse_post_detail() itself — a prior version
+        # skipped that step and crashed with "list indices must be integers"
+        # on any real (non-mocked-as-a-dict) response.
+        with patch.object(
+            drama_collector, "_fetch_post_json",
+            return_value=_detail_json(selftext="Real body", ups=6000, over_18=False),
+        ):
+            count = drama_collector.collect_subreddit(
+                {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+            )
+        self.assertGreater(count, 0)
+
+
+class TestCollectSubredditRemovedPosts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+        self._rss_patch = patch.object(
+            drama_collector, "fetch_subreddit_rss",
+            return_value=[
+                {"post_id": "removed1", "title": "Removed post", "link": "https://x/r1", "summary": ""},
+                {"post_id": "deleted1", "title": "Deleted post", "link": "https://x/d1", "summary": ""},
+                {"post_id": "ok1", "title": "Fine post", "link": "https://x/ok1", "summary": ""},
+            ],
+        )
+        self._rss_patch.start()
+
+        def fake_detail(subreddit, post_id):
+            selftext = {
+                "removed1": "[removed]",
+                "deleted1": "[deleted]",
+                "ok1": "A real story body",
+            }[post_id]
+            return _detail_json(selftext=selftext, ups=6000, over_18=False)
+
+        self._detail_patch = patch.object(drama_collector, "_fetch_post_json", side_effect=fake_detail)
+        self._detail_patch.start()
+
+    def tearDown(self):
+        self._detail_patch.stop()
+        self._rss_patch.stop()
+        self._patch.stop()
+
+    def test_removed_and_deleted_bodies_are_skipped(self):
+        count = drama_collector.collect_subreddit(
+            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+        )
+        self.assertEqual(count, 1)
+        pending = stories.get_pending(track="drama")
+        self.assertEqual({s["source_id"] for s in pending}, {"reddit_ok1"})
+
 
 class TestCollectAllDrama(unittest.TestCase):
     def setUp(self):
@@ -202,6 +265,28 @@ class TestCollectAllDrama(unittest.TestCase):
             total = drama_collector.collect_all_drama()
         # 4 of 5 subreddits succeed with 1 each; AmItheAsshole raises and is skipped.
         self.assertEqual(total, 4)
+
+    def test_raises_when_every_subreddit_fails(self):
+        # Regression test: a total outage (every subreddit call raises) must
+        # NOT look like a quiet "0 new stories" success — the caller (see
+        # __main__) only records collector_health success after this
+        # function returns normally, so this has to actually raise.
+        with patch.object(
+            drama_collector, "collect_subreddit",
+            side_effect=RuntimeError("network blew up"),
+        ):
+            with self.assertRaises(RuntimeError):
+                drama_collector.collect_all_drama()
+
+    def test_partial_failure_does_not_raise(self):
+        def fake_collect(sub_config):
+            if sub_config["name"] == "AmItheAsshole":
+                raise RuntimeError("network blew up")
+            return 0
+
+        with patch.object(drama_collector, "collect_subreddit", side_effect=fake_collect):
+            total = drama_collector.collect_all_drama()  # must not raise
+        self.assertEqual(total, 0)
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_reddit_drama_collector.py
+++ b/content-pipeline/tests/test_reddit_drama_collector.py
@@ -1,0 +1,208 @@
+"""Tests for collectors/reddit_drama_collector.py (Phase 2 — Drama Source Layer)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import collectors.reddit_drama_collector as drama_collector
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+
+FIXTURE_RSS = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>reddit: the front page of the internet</title>
+  <entry>
+    <id>t3_abc111</id>
+    <link href="https://www.reddit.com/r/AskReddit/comments/abc111/some_title_here/"/>
+    <title>AITA for refusing to pay for the wedding?</title>
+    <summary>Some summary text here.</summary>
+  </entry>
+  <entry>
+    <id>t3_abc222</id>
+    <link href="https://www.reddit.com/r/AskReddit/comments/abc222/another_post/"/>
+    <title>My coworker took credit for my work</title>
+    <summary>Another summary.</summary>
+  </entry>
+  <entry>
+    <title>Entry with no resolvable post id</title>
+    <link href="https://www.reddit.com/r/AskReddit/weird_url_format/"/>
+  </entry>
+</feed>
+"""
+
+
+def _detail_json(selftext="Full story body.", ups=6000, over_18=False):
+    return [
+        {
+            "data": {
+                "children": [
+                    {"data": {"selftext": selftext, "score": ups, "over_18": over_18}}
+                ]
+            }
+        },
+        {"data": {"children": []}},
+    ]
+
+
+class TestExtractPostId(unittest.TestCase):
+    def test_extracts_from_comments_link(self):
+        entry = {"link": "https://www.reddit.com/r/AskReddit/comments/abc123/title_slug/"}
+        self.assertEqual(drama_collector._extract_post_id(entry), "abc123")
+
+    def test_extracts_from_fullname_id(self):
+        entry = {"id": "t3_xyz789", "link": ""}
+        self.assertEqual(drama_collector._extract_post_id(entry), "xyz789")
+
+    def test_returns_none_when_unresolvable(self):
+        entry = {"link": "https://www.reddit.com/r/AskReddit/weird/", "id": "not-a-fullname"}
+        self.assertIsNone(drama_collector._extract_post_id(entry))
+
+
+class TestParseRssEntries(unittest.TestCase):
+    def test_parses_valid_entries(self):
+        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["post_id"], "abc111")
+        self.assertEqual(entries[1]["post_id"], "abc222")
+
+    def test_skips_entries_without_resolvable_post_id(self):
+        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
+        titles = [e["title"] for e in entries]
+        self.assertNotIn("Entry with no resolvable post id", titles)
+
+    def test_title_and_link_captured(self):
+        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
+        self.assertEqual(entries[0]["title"], "AITA for refusing to pay for the wedding?")
+        self.assertIn("abc111", entries[0]["link"])
+
+
+class TestParsePostDetail(unittest.TestCase):
+    def test_extracts_fields(self):
+        detail = drama_collector.parse_post_detail(_detail_json(selftext="Body", ups=7000))
+        self.assertEqual(detail["selftext"], "Body")
+        self.assertEqual(detail["ups"], 7000)
+        self.assertFalse(detail["over_18"])
+
+    def test_over_18_flag(self):
+        detail = drama_collector.parse_post_detail(_detail_json(over_18=True))
+        self.assertTrue(detail["over_18"])
+
+    def test_malformed_response_returns_none(self):
+        self.assertIsNone(drama_collector.parse_post_detail({"unexpected": "shape"}))
+
+    def test_empty_list_returns_none(self):
+        self.assertIsNone(drama_collector.parse_post_detail([]))
+
+
+class TestRateLimiter(unittest.TestCase):
+    def test_second_call_waits_min_interval(self):
+        limiter = drama_collector._RateLimiter(min_interval=0.05)
+        start = time.monotonic()
+        limiter.wait()
+        limiter.wait()
+        elapsed = time.monotonic() - start
+        self.assertGreaterEqual(elapsed, 0.04)  # small tolerance for scheduler jitter
+
+
+class TestCollectSubreddit(unittest.TestCase):
+    """Integration-ish test: mocks the two network calls, exercises the real
+    dedupe + insert path against a temp DB."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+        self._rss_patch = patch.object(
+            drama_collector, "fetch_subreddit_rss",
+            return_value=[
+                {"post_id": "aaa", "title": "Story A", "link": "https://x/aaa", "summary": ""},
+                {"post_id": "bbb", "title": "Story B", "link": "https://x/bbb", "summary": ""},
+                {"post_id": "ccc", "title": "Story C (nsfw)", "link": "https://x/ccc", "summary": ""},
+                {"post_id": "ddd", "title": "Story D (low score)", "link": "https://x/ddd", "summary": ""},
+            ],
+        )
+        self._rss_patch.start()
+
+        def fake_detail(subreddit, post_id):
+            return {
+                "aaa": {"selftext": "Body A", "ups": 6000, "over_18": False},
+                "bbb": {"selftext": "Body B", "ups": 8000, "over_18": False},
+                "ccc": {"selftext": "Body C", "ups": 9000, "over_18": True},
+                "ddd": {"selftext": "Body D", "ups": 10, "over_18": False},
+            }[post_id]
+
+        self._detail_patch = patch.object(drama_collector, "_fetch_post_json", side_effect=fake_detail)
+        self._detail_patch.start()
+
+    def tearDown(self):
+        self._detail_patch.stop()
+        self._rss_patch.stop()
+        self._patch.stop()
+
+    def test_inserts_only_eligible_posts(self):
+        count = drama_collector.collect_subreddit(
+            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+        )
+        self.assertEqual(count, 2)  # aaa + bbb; ccc is nsfw, ddd is below threshold
+        pending = stories.get_pending(track="drama")
+        source_ids = {s["source_id"] for s in pending}
+        self.assertEqual(source_ids, {"reddit_aaa", "reddit_bbb"})
+
+    def test_metadata_stored(self):
+        drama_collector.collect_subreddit(
+            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.2}
+        )
+        pending = stories.get_pending(track="drama")
+        story = next(s for s in pending if s["source_id"] == "reddit_aaa")
+        self.assertEqual(story["metadata"]["subreddit"], "AskReddit")
+        self.assertEqual(story["metadata"]["upvotes"], 6000)
+        self.assertEqual(story["metadata"]["weight"], 1.2)
+
+    def test_second_run_skips_duplicates(self):
+        first = drama_collector.collect_subreddit(
+            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+        )
+        second = drama_collector.collect_subreddit(
+            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+        )
+        self.assertEqual(first, 2)
+        self.assertEqual(second, 0)
+
+
+class TestCollectAllDrama(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_continues_after_one_subreddit_errors(self):
+        def fake_collect(sub_config):
+            if sub_config["name"] == "AmItheAsshole":
+                raise RuntimeError("network blew up")
+            return 1
+
+        with patch.object(drama_collector, "collect_subreddit", side_effect=fake_collect):
+            total = drama_collector.collect_all_drama()
+        # 4 of 5 subreddits succeed with 1 each; AmItheAsshole raises and is skipped.
+        self.assertEqual(total, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_seed_bot.py
+++ b/content-pipeline/tests/test_seed_bot.py
@@ -113,6 +113,36 @@ class TestSeedUrlFlow(SeedBotTestBase):
         # No OG title available -> falls back to the raw URL as content.
         self.assertEqual(pending[0]["raw_content"], "https://tiktok.com/@x/video/1")
 
+    def test_same_url_submitted_twice_is_deduped(self):
+        # Regression test: source_id used to be a random UUID per submission,
+        # so resubmitting the same link created a duplicate row every time
+        # instead of being caught by the source_id unique index/dedupe_check.
+        with patch("requests.get", side_effect=Exception("network down")):
+            seed_bot.start_seed_url()
+            first_reply = seed_bot.handle_awaiting_message("https://facebook.com/same/post")
+            seed_bot.start_seed_url()
+            second_reply = seed_bot.handle_awaiting_message("https://facebook.com/same/post")
+
+        self.assertIn("Đã lưu", first_reply)
+        self.assertIn("đã được lưu", second_reply)
+        from storage.stories import get_pending
+        self.assertEqual(len(get_pending(track="drama")), 1)
+
+    def test_source_id_is_deterministic_for_same_url(self):
+        id1 = seed_bot._seed_url_source_id("https://facebook.com/x")
+        id2 = seed_bot._seed_url_source_id("https://facebook.com/x")
+        self.assertEqual(id1, id2)
+
+    def test_source_id_ignores_trailing_slash(self):
+        id1 = seed_bot._seed_url_source_id("https://facebook.com/x")
+        id2 = seed_bot._seed_url_source_id("https://facebook.com/x/")
+        self.assertEqual(id1, id2)
+
+    def test_source_id_differs_for_different_urls(self):
+        id1 = seed_bot._seed_url_source_id("https://facebook.com/x")
+        id2 = seed_bot._seed_url_source_id("https://facebook.com/y")
+        self.assertNotEqual(id1, id2)
+
 
 class TestHandleAwaitingMessageNoop(SeedBotTestBase):
     def test_returns_none_when_nothing_awaiting(self):

--- a/content-pipeline/tests/test_seed_bot.py
+++ b/content-pipeline/tests/test_seed_bot.py
@@ -1,0 +1,155 @@
+"""Tests for notifier/seed_bot.py (Phase 2 — Drama Source Layer)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import notifier.seed_bot as seed_bot
+import storage.database as db
+import storage.migrate as migrate
+
+
+class SeedBotTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._db_patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._db_patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+        # Isolate the conversation-state file per test so tests don't leak
+        # awaiting-state into each other via the real notifier/ directory.
+        self.state_file = os.path.join(self.tmp, ".seed_state.json")
+        self._state_patch = patch.object(seed_bot, "_STATE_FILE", self.state_file)
+        self._state_patch.start()
+
+    def tearDown(self):
+        self._state_patch.stop()
+        self._db_patch.stop()
+
+
+class TestSeedVnFlow(SeedBotTestBase):
+    def test_start_returns_prompt_and_sets_state(self):
+        reply = seed_bot.start_seed_vn()
+        self.assertIn("tình huống lõi", reply)
+        self.assertEqual(seed_bot._get_awaiting(), "vn_seed")
+
+    def test_message_after_start_is_saved(self):
+        seed_bot.start_seed_vn()
+        reply = seed_bot.handle_awaiting_message("Sếp bắt tôi làm thêm giờ không lương.")
+        self.assertIn("Đã lưu", reply)
+        self.assertIsNone(seed_bot._get_awaiting())  # state cleared after use
+
+    def test_saved_story_has_expected_fields(self):
+        seed_bot.start_seed_vn()
+        seed_bot.handle_awaiting_message("Một tình huống drama.")
+        from storage.stories import get_pending
+        pending = get_pending(track="drama")
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0]["source"], "vn_original")
+        self.assertEqual(pending[0]["raw_content"], "Một tình huống drama.")
+        self.assertTrue(pending[0]["source_id"].startswith("vn_"))
+
+    def test_empty_message_not_saved(self):
+        seed_bot.start_seed_vn()
+        reply = seed_bot.handle_awaiting_message("   ")
+        self.assertIn("trống", reply)
+        from storage.stories import get_pending
+        self.assertEqual(get_pending(track="drama"), [])
+
+    def test_two_seeds_get_distinct_ids(self):
+        seed_bot.start_seed_vn()
+        seed_bot.handle_awaiting_message("Seed 1")
+        seed_bot.start_seed_vn()
+        seed_bot.handle_awaiting_message("Seed 2")
+        from storage.stories import get_pending
+        self.assertEqual(len(get_pending(track="drama")), 2)
+
+
+class TestSeedUrlFlow(SeedBotTestBase):
+    def test_invalid_url_rejected(self):
+        seed_bot.start_seed_url()
+        reply = seed_bot.handle_awaiting_message("not a url")
+        self.assertIn("hợp lệ", reply)
+        from storage.stories import get_pending
+        self.assertEqual(get_pending(track="drama"), [])
+
+    def test_valid_url_saved_with_og_metadata(self):
+        fake_resp = MagicMock()
+        fake_resp.text = (
+            '<html><head>'
+            '<meta content="Some Title" property="og:title">'
+            '<meta property="og:description" content="Some description here">'
+            '</head></html>'
+        )
+        fake_resp.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=fake_resp):
+            seed_bot.start_seed_url()
+            reply = seed_bot.handle_awaiting_message("https://facebook.com/some/post")
+        self.assertIn("Đã lưu", reply)
+        self.assertIn("Some Title", reply)
+
+        from storage.stories import get_pending
+        pending = get_pending(track="drama")
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0]["title"], "Some Title")
+        self.assertEqual(pending[0]["raw_content"], "Some description here")
+        self.assertEqual(pending[0]["metadata"]["url"], "https://facebook.com/some/post")
+
+    def test_fetch_failure_still_saves_seed(self):
+        with patch("requests.get", side_effect=Exception("network down")):
+            seed_bot.start_seed_url()
+            reply = seed_bot.handle_awaiting_message("https://tiktok.com/@x/video/1")
+        self.assertIn("Đã lưu", reply)
+        from storage.stories import get_pending
+        pending = get_pending(track="drama")
+        self.assertEqual(len(pending), 1)
+        # No OG title available -> falls back to the raw URL as content.
+        self.assertEqual(pending[0]["raw_content"], "https://tiktok.com/@x/video/1")
+
+
+class TestHandleAwaitingMessageNoop(SeedBotTestBase):
+    def test_returns_none_when_nothing_awaiting(self):
+        self.assertIsNone(seed_bot.handle_awaiting_message("just a regular message"))
+
+
+class TestListPendingText(SeedBotTestBase):
+    def test_empty_state(self):
+        text = seed_bot.list_pending_text()
+        self.assertIn("Không có story", text)
+
+    def test_lists_pending_stories(self):
+        from storage.stories import insert_story
+        insert_story("reddit", "r1", "raw content here", track="drama", title="A drama title")
+        text = seed_bot.list_pending_text()
+        self.assertIn("A drama title", text)
+
+    def test_respects_limit(self):
+        from storage.stories import insert_story
+        for i in range(10):
+            insert_story("reddit", f"r{i}", "raw", track="drama")
+        text = seed_bot.list_pending_text(limit=3)
+        self.assertIn("3 story", text)
+
+    def test_falls_back_to_raw_content_when_no_title(self):
+        from storage.stories import insert_story
+        insert_story("vn_original", "v1", "no title here just raw content", track="drama")
+        text = seed_bot.list_pending_text()
+        self.assertIn("no title here", text)
+
+
+class TestHelpText(unittest.TestCase):
+    def test_mentions_all_commands(self):
+        text = seed_bot.help_text()
+        for cmd in ("/seed_vn", "/seed_url", "/list_pending"):
+            self.assertIn(cmd, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_stories.py
+++ b/content-pipeline/tests/test_stories.py
@@ -114,6 +114,27 @@ class TestGetPending(StoriesTestBase):
         self.assertEqual(pending[1]["id"], id1)
 
 
+class TestGetByStatus(StoriesTestBase):
+    def test_returns_matching_status_only(self):
+        id1 = stories.insert_story("reddit", "g1", "raw")
+        stories.update_status(id1, "produced")
+        id2 = stories.insert_story("reddit", "g2", "raw")
+        stories.update_status(id2, "produced")
+        stories.insert_story("reddit", "g3", "raw")  # stays pending
+
+        produced = stories.get_by_status("produced")
+        ids = {s["id"] for s in produced}
+        self.assertEqual(ids, {id1, id2})
+
+    def test_empty_when_no_match(self):
+        stories.insert_story("reddit", "g4", "raw")
+        self.assertEqual(stories.get_by_status("produced"), [])
+
+    def test_get_pending_is_shortcut_for_pending_status(self):
+        stories.insert_story("reddit", "g5", "raw")
+        self.assertEqual(stories.get_pending(), stories.get_by_status("pending"))
+
+
 class TestUpdateStatus(StoriesTestBase):
     def test_updates_status(self):
         story_id = stories.insert_story("reddit", "u1", "raw")

--- a/content-pipeline/tests/test_stories.py
+++ b/content-pipeline/tests/test_stories.py
@@ -1,0 +1,151 @@
+"""Tests for storage/stories.py (Phase 2 — Drama Source Layer)."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+
+
+class StoriesTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestInsertStory(StoriesTestBase):
+    def test_insert_returns_id(self):
+        story_id = stories.insert_story("reddit", "abc1", "raw text")
+        self.assertIsInstance(story_id, int)
+
+    def test_default_track_is_drama(self):
+        story_id = stories.insert_story("reddit", "abc2", "raw text")
+        story = stories.get_story(story_id)
+        self.assertEqual(story["track"], "drama")
+
+    def test_default_status_is_pending(self):
+        story_id = stories.insert_story("reddit", "abc3", "raw text")
+        story = stories.get_story(story_id)
+        self.assertEqual(story["status"], "pending")
+
+    def test_metadata_roundtrips_as_dict(self):
+        story_id = stories.insert_story(
+            "reddit", "abc4", "raw text",
+            metadata={"subreddit": "AmItheAsshole", "upvotes": 5000},
+        )
+        story = stories.get_story(story_id)
+        self.assertEqual(story["metadata"], {"subreddit": "AmItheAsshole", "upvotes": 5000})
+
+    def test_no_metadata_stays_none(self):
+        story_id = stories.insert_story("reddit", "abc5", "raw text")
+        story = stories.get_story(story_id)
+        self.assertIsNone(story["metadata"])
+
+    def test_title_stored(self):
+        story_id = stories.insert_story("reddit", "abc6", "raw text", title="Some title")
+        story = stories.get_story(story_id)
+        self.assertEqual(story["title"], "Some title")
+
+    def test_duplicate_source_id_raises(self):
+        stories.insert_story("reddit", "dup1", "first")
+        with self.assertRaises(sqlite3.IntegrityError):
+            stories.insert_story("reddit", "dup1", "second")
+
+    def test_vn_original_without_source_id(self):
+        # Manual VN seeds may not have a natural source_id (None allowed,
+        # multiple NULLs don't violate the unique index).
+        id1 = stories.insert_story("vn_original", None, "seed 1")
+        id2 = stories.insert_story("vn_original", None, "seed 2")
+        self.assertNotEqual(id1, id2)
+
+
+class TestDedupeCheck(StoriesTestBase):
+    def test_true_for_existing(self):
+        stories.insert_story("reddit", "exists1", "raw")
+        self.assertTrue(stories.dedupe_check("exists1"))
+
+    def test_false_for_missing(self):
+        self.assertFalse(stories.dedupe_check("does-not-exist"))
+
+
+class TestGetPending(StoriesTestBase):
+    def test_only_pending_returned(self):
+        id1 = stories.insert_story("reddit", "p1", "raw")
+        stories.update_status(id1, "approved")
+        id2 = stories.insert_story("reddit", "p2", "raw")
+        pending = stories.get_pending()
+        ids = {s["id"] for s in pending}
+        self.assertIn(id2, ids)
+        self.assertNotIn(id1, ids)
+
+    def test_respects_limit(self):
+        for i in range(5):
+            stories.insert_story("reddit", f"limit{i}", "raw")
+        pending = stories.get_pending(limit=2)
+        self.assertEqual(len(pending), 2)
+
+    def test_filters_by_track(self):
+        stories.insert_story("reddit", "drama1", "raw", track="drama")
+        stories.insert_story("reddit", "ai1", "raw", track="ai")
+        pending = stories.get_pending(track="ai")
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0]["source_id"], "ai1")
+
+    def test_sorted_newest_first(self):
+        id1 = stories.insert_story("reddit", "old", "raw")
+        id2 = stories.insert_story("reddit", "new", "raw")
+        pending = stories.get_pending()
+        self.assertEqual(pending[0]["id"], id2)
+        self.assertEqual(pending[1]["id"], id1)
+
+
+class TestUpdateStatus(StoriesTestBase):
+    def test_updates_status(self):
+        story_id = stories.insert_story("reddit", "u1", "raw")
+        stories.update_status(story_id, "approved")
+        self.assertEqual(stories.get_story(story_id)["status"], "approved")
+
+    def test_updates_extra_field(self):
+        story_id = stories.insert_story("reddit", "u2", "raw")
+        stories.update_status(story_id, "approved", rubric_score=5)
+        story = stories.get_story(story_id)
+        self.assertEqual(story["status"], "approved")
+        self.assertEqual(story["rubric_score"], 5)
+
+    def test_updates_multiple_extra_fields(self):
+        story_id = stories.insert_story("reddit", "u3", "raw")
+        stories.update_status(story_id, "produced", rubric_score=6,
+                              rewritten_content="{}", destination="drama_youtube")
+        story = stories.get_story(story_id)
+        self.assertEqual(story["rubric_score"], 6)
+        self.assertEqual(story["rewritten_content"], "{}")
+        self.assertEqual(story["destination"], "drama_youtube")
+
+    def test_unknown_field_raises(self):
+        story_id = stories.insert_story("reddit", "u4", "raw")
+        with self.assertRaises(ValueError):
+            stories.update_status(story_id, "approved", source="evil; DROP TABLE stories")
+
+
+class TestGetStory(StoriesTestBase):
+    def test_missing_returns_none(self):
+        self.assertIsNone(stories.get_story(999999))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_telegram_seed_dispatch.py
+++ b/content-pipeline/tests/test_telegram_seed_dispatch.py
@@ -1,0 +1,94 @@
+"""Tests for the Drama seed bot commands wired into telegram_bot._handle_update
+(Phase 2 — Drama Source Layer).
+
+Verifies the dispatch/plumbing only — notifier/seed_bot.py's own logic
+(saving stories, OG scraping, ...) is covered by tests/test_seed_bot.py.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import notifier.telegram_bot as tb
+import notifier.seed_bot as seed_bot
+
+
+def _update(text: str, chat_id: str = "123"):
+    return {"message": {"text": text, "chat": {"id": chat_id}}}
+
+
+class TestSeedCommandDispatch(unittest.TestCase):
+    def setUp(self):
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.cfg.TELEGRAM_CHAT_ID = "123"
+        self.addCleanup(self.p_cfg.stop)
+
+    def test_seed_vn_command_calls_start_seed_vn(self):
+        with patch.object(seed_bot, "start_seed_vn", return_value="prompt text") as start, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("/seed_vn"), publish_callback=None)
+        start.assert_called_once()
+        send_text.assert_called_once_with("prompt text")
+
+    def test_seed_url_command_calls_start_seed_url(self):
+        with patch.object(seed_bot, "start_seed_url", return_value="prompt url") as start, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("/seed_url"), publish_callback=None)
+        start.assert_called_once()
+        send_text.assert_called_once_with("prompt url")
+
+    def test_list_pending_command_calls_list_pending_text(self):
+        with patch.object(seed_bot, "list_pending_text", return_value="list here") as lp, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("/list_pending"), publish_callback=None)
+        lp.assert_called_once()
+        send_text.assert_called_once_with("list here")
+
+    def test_help_command_includes_seed_bot_help(self):
+        with patch.object(seed_bot, "help_text", return_value="SEED HELP TEXT") as ht, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("/help"), publish_callback=None)
+        ht.assert_called_once()
+        sent = send_text.call_args[0][0]
+        self.assertIn("SEED HELP TEXT", sent)
+        self.assertIn("/approve_<id>", sent)  # existing video-approval help untouched
+
+    def test_plain_text_with_awaiting_state_is_consumed(self):
+        with patch.object(seed_bot, "handle_awaiting_message", return_value="saved!") as haw, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("Sếp bắt làm thêm giờ."), publish_callback=None)
+        haw.assert_called_once_with("Sếp bắt làm thêm giờ.")
+        send_text.assert_called_once_with("saved!")
+
+    def test_plain_text_without_awaiting_state_sends_nothing(self):
+        with patch.object(seed_bot, "handle_awaiting_message", return_value=None), \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("just chatting"), publish_callback=None)
+        send_text.assert_not_called()
+
+    def test_wrong_chat_id_ignored(self):
+        with patch.object(seed_bot, "handle_awaiting_message") as haw, \
+             patch.object(tb, "_send_text") as send_text:
+            tb._handle_update(_update("/seed_vn", chat_id="999"), publish_callback=None)
+        haw.assert_not_called()
+        send_text.assert_not_called()
+
+    def test_approve_command_still_works_mid_seed_conversation(self):
+        # /approve_<id> must dispatch normally even if a seed prompt is
+        # technically "awaiting" — commands always take priority.
+        with patch.object(seed_bot, "handle_awaiting_message") as haw, \
+             patch("video.review_service.approve", return_value=(True, "ok")) as approve, \
+             patch.object(tb, "_send_text"):
+            tb._handle_update(_update("/approve_5"), publish_callback=lambda vid: None)
+        haw.assert_not_called()
+        approve.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/current/prompts-decisions.md
+++ b/docs/current/prompts-decisions.md
@@ -1,0 +1,84 @@
+# Prompt decisions — Drama track (Phase 3)
+
+> Decision log cho các prompt trong `content-pipeline/prompts/drama/`. Cập
+> nhật file này mỗi khi tune sang version mới, kèm timestamp + lý do.
+
+## Cách hoạt động
+
+- Mỗi prompt có version riêng: `prompts/drama/{name}.{version}.txt`.
+- `config.PROMPT_VERSION` (env var, mặc định `v1`) chọn version dùng cho
+  toàn bộ processor. Đổi env var để rollback — không cần sửa code.
+- `processors/prompt_loader.py::load_prompt(module, name, version=None)`
+  đọc file; `render(template, **values)` điền placeholder dạng `{{KEY}}`.
+- A/B test có kiểm soát: `processors/ab_harness.py::choose_version()` chọn
+  version theo hash ổn định của `(experiment, story_id)` — không cần
+  `config.PROMPT_VERSION` toàn cục nếu muốn so sánh 2 version song song trên
+  cùng 1 batch story (xem "A/B harness" bên dưới).
+
+## v1 — 2026-07-06 (khởi tạo)
+
+| Prompt | File | Model | Ghi chú |
+|--------|------|-------|---------|
+| Rubric scorer | `scorer.v1.txt` | claude-haiku-4-5 | 6 tiêu chí 0/1; `total` luôn được tính lại server-side, không tin số model tự báo cáo |
+| Rewriter | `rewriter.v1.txt` | claude-sonnet-4-5 | 9 quy tắc bắt buộc (2 quy tắc thêm so với bản gốc phase-3-detailed.md — xem "Cải tiến so với thiết kế gốc" bên dưới) |
+| Theme detection | `theme_detect.v1.txt` | claude-sonnet-4-5 | Chạy weekly, tìm theme ≥3 story |
+| Long-form compiler | `longform.v1.txt` | claude-sonnet-4-5 | Gộp 3-5 story cùng theme, target 8-15 phút (~1100-2100 từ, xem `drama_compiler.py`) |
+
+### Cải tiến so với thiết kế gốc (`phase-3-detailed.md`)
+
+`phase-3-detailed.md` mục 5 ("Rủi ro & cảnh báo") liệt kê 2 vấn đề chất
+lượng dự kiến sẽ gặp và đề xuất sửa ở v2 sau khi thấy lỗi thực tế:
+
+1. "Hallucination tên VN không tự nhiên... Thêm rule 'tên thuần Việt 2-3 từ'"
+2. "Bias dịch sang văn hoá Mỹ... Prompt phải nhấn mạnh 'đặt câu chuyện hoàn
+   toàn ở VN, KHÔNG nhắc tới $1 USD, mall, prom, Thanksgiving...'"
+
+Thay vì đợi v2, `rewriter.v1.txt` đã đưa thẳng 2 rule này vào (rule 8, 9)
+— không có lý do để đợi lỗi xảy ra rồi mới sửa khi rủi ro đã biết trước.
+`processors/drama_rewriter.py::validate_rewrite()` cũng chấm lại bằng
+heuristic (blacklist tên Tây phổ biến + từ văn hoá Mỹ) như một lớp phòng vệ
+thứ 2 độc lập với prompt.
+
+### Word count — điểm cần lưu ý khi đọc `phase-3-detailed.md`
+
+Tài liệu gốc ghi rewriter script "800-1200 từ (tương đương 60-90 giây TTS)".
+Con số 800-1200 từ khớp với **acceptance criteria tường minh** ở
+`phase-3-issues.md` EPIC #3.2 ("Generate 10 script... đủ cấu trúc... 800-1200
+từ") nên `validate_rewrite()` dùng đúng ngưỡng này. Nhưng "60-90 giây" nhiều
+khả năng là lỗi copy-paste: ở tốc độ đọc ~120-160 từ/phút (tốc độ mà chính
+codebase này dùng cho video AI dài — xem `video/script_generator.py`,
+800-1200 từ ứng với 5-10 PHÚT chứ không phải 60-90 giây). Cấu trúc timing
+(Hook 3s → ... → 15s, tổng ~85s) trong tài liệu gốc có vẻ mới là phần bị
+nhầm — không sửa số liệu này vì acceptance criteria đã rõ ràng và không có
+bằng chứng nào cho biết bên nào đúng; chỉ ghi chú lại ở đây để người tune
+prompt sau này không bị nhầm lẫn thêm.
+
+`processors/drama_compiler.py`'s `TARGET_MIN_WORDS`/`TARGET_MAX_WORDS`
+(1100-2100 từ cho video long-form 8-15 phút) được suy ra từ tốc độ đọc
+~140 từ/phút này — xem comment trong code.
+
+## A/B harness
+
+`processors/ab_harness.py` — thiết kế rút gọn so với `phase-3-issues.md`
+(bản gốc muốn hạ tầng traffic-split đầy đủ + bảng `ab_runs` chi tiết):
+
+- `choose_version(experiment, story_id)` — deterministic (hash), không phải
+  random thật, để cùng 1 story luôn ra cùng 1 version (nhất quán giữa
+  scorer/rewriter, và giữa các lần retry).
+- `record_ab_result(experiment, version, story_id, heuristic_score)` — ghi
+  vào bảng `ab_runs` (migration 005).
+- `compare_ab_results(experiment, min_samples=10)` — so sánh mean
+  heuristic_score mỗi version, trả `None` nếu chưa đủ mẫu.
+
+`heuristic_score` cần được tính bởi caller (vd: điểm rubric, hoặc số lỗi từ
+`validate_rewrite()` quy đổi ngược thành điểm) — hàm này không tự tính điểm,
+chỉ lưu/so sánh những gì được truyền vào.
+
+## Cách tune sang v2 (khi cần)
+
+1. Tạo file mới `prompts/drama/{name}.v2.txt`.
+2. Test trên vài chục story bằng `ab_harness.choose_version()` (hoặc set
+   `PROMPT_VERSION=v2` tạm thời cho một run thủ công).
+3. Ghi lại kết quả (`compare_ab_results()` sau khi đủ mẫu) + quyết định vào
+   bảng ở trên (thêm dòng "v2 — <ngày>", giữ lại dòng v1 cũ làm lịch sử).
+4. Nếu v2 tốt hơn rõ ràng: đổi `PROMPT_VERSION=v2` trong `.env` để chuyển hẳn.


### PR DESCRIPTION
## Summary

This PR now covers both Phase 2 and Phase 3 (pushed as two commits on the same branch).

### Phase 2 — Drama Source Layer (`docs/current/phase-2-detailed.md`)

- **`storage/stories.py`** — CRUD for the `stories` table: `insert_story` (raises `sqlite3.IntegrityError` on duplicate `source_id`), `dedupe_check`, `get_pending`/`get_by_status`, `update_status` (extra fields restricted to an allowlist).
- **`storage/migrations/002_stories_metadata`** — adds `stories.title`/`metadata` columns + a unique index on `source_id`.
- **`collectors/reddit_drama_collector.py`** — RSS listing + JSON detail fetch (rate-limited 1 req/2s, retried 3x) for 5 drama subreddits, filtered by per-subreddit upvote threshold, deduped, inserted as `track='drama'`.
- **`notifier/seed_bot.py`** — `/seed_vn`, `/seed_url` (Open Graph scrape via `requests`), `/list_pending` command handlers.
- **`storage/collector_health.py` + migration 003** — alerts Telegram if a collector hasn't succeeded in 2+ days.
- **`launchd/`** — daily collector cron + health-check cron, rotating log handler.

Two deliberate deviations (documented inline + CLAUDE.md): NSFW filtering uses the official `over_18` JSON field instead of guessing at undocumented RSS markup; the seed bot commands run inside `telegram_bot.py`'s existing long-poll loop rather than a second process, since Telegram only allows one `getUpdates` connection per bot token (two pollers on one token would 409-conflict).

### Phase 3 — Drama Generation Layer (`docs/current/phase-3-detailed.md`)

- **`processors/prompt_loader.py`** — `load_prompt(module, name, version)` reads `prompts/{module}/{name}.{version}.txt` (`config.PROMPT_VERSION` default, so rollback = change an env var); `render()` fills `{{PLACEHOLDER}}` via `str.replace` so prompts with literal JSON-schema braces don't need escaping.
- **`processors/drama_scorer.py`** — 6-criteria Haiku rubric. `total` is always recomputed server-side from the 6 fields (never trusts the model's own arithmetic); `safe=0` always rejects regardless of total.
- **`processors/drama_rewriter.py`** — the core module: Sonnet Vietnamization + `validate_rewrite()` heuristic gate (word count, `vn_commentary` length, short-hook structure proxy, Western-name/US-culture blocklist). Failed validation still saves the output (`status='needs_review'` + Telegram alert) instead of discarding it.
- **`processors/drama_compiler.py` + `storage/compiled_videos.py` + migration 004** — weekly theme detection across produced stories, long-form script compilation with chapter-marker/word-count validation.
- **`processors/ab_harness.py` + `storage/ab_runs.py` + migration 005** — prompt version A/B testing, deliberately scoped down from the doc's full traffic-split design: `choose_version()` is a deterministic hash of `(experiment, story_id)`, not a random draw, so retries/repeated calls for one story stay consistent.
- **`processors/ai_usage.py`** — shared token-usage logging for the Anthropic calls above.

Notable deviations/decisions (see `docs/current/prompts-decisions.md`):
- `rewriter.v1.txt` bakes in 2 rules the doc's own risk section flagged as "fix in v2 after we see it fail" (pure-Vietnamese names, no US-culture leakage) — no reason to wait for the known failure.
- Documented a likely pre-existing inconsistency in `phase-3-detailed.md`: the rewriter's "800-1200 words ≈ 60-90s TTS" doesn't match this codebase's own established narration rate (`video/script_generator.py`: 800-1200 words ≈ 5-10 min). Kept the word-count range (it matches the explicit acceptance criteria in `phase-3-issues.md`) and flagged the duration claim instead of guessing which number is the typo.

### Bugs found and fixed while writing tests

- `storage/stories.py`'s `get_pending()` ordered by `created_at DESC` only — SQLite's `CURRENT_TIMESTAMP` has 1-second resolution, so same-second inserts (normal for one collector run) had nondeterministic order. Added `id DESC` as a tie-breaker.
- `ai_usage.py`'s `log_token_usage()` used `%d` formatting, which would crash the moment INFO-level logging was enabled with a non-int usage value — masked in the test suite because `unittest discover` never configures the root logger above WARNING. Switched to `%s` and added a regression test that actually enables INFO logging.
- Generalized `tests/test_migrate.py`'s down-migration tests: 3 prior migrations each required hand-editing a hardcoded "call `migrate_down()` N times" assertion whenever a new migration was added. Replaced with a helper that derives the count from `_discover_migrations()`.

## Out of scope (per the phase docs)

- Video render / TTS (Phase 4).
- Actual multi-channel upload routing (Phase 5).

## Test plan

- [x] `python3 -m unittest discover -s content-pipeline/tests` — 422 tests pass (2 skipped, missing optional `Pillow`).
- [x] `python3 -m py_compile` on all new/changed modules.
- [x] Manually exercised the migration runner end-to-end (`status` → `up` → `down` → `up` again) for migrations 002-005 against a scratch DB.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
