### PR TITLE
Phase 4: Drama Video Production — scene composer, TTS voice, overlays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,59 @@ phạm vi: TTS/render video thật (Phase 4).
 
 ---
 
+## Drama Video Production Layer (Phase 4)
+
+Xem `docs/current/phase-4-detailed.md`/`phase-4-issues.md`. Biến story
+`status='approved'` (đã Việt hoá — Phase 3) thành video Shorts thật (audio +
+hình + phụ đề). Ngoài phạm vi: orchestration nối vào `main.py` (chọn story,
+gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
+
+- **`video/tts/`** (per-track voice) — thay vì xây lại abstraction TTS mới
+  như tài liệu đề xuất (EPIC #4.1: `ElevenLabsProvider`/`FPTAIProvider`),
+  package `video/tts/` (base/factory/nuitruc/edge) đã có sẵn và đủ tốt —
+  chỉ thêm tham số `voice_id` xuyên suốt chain (`TTSProvider.synthesize`,
+  `factory.synthesize`, `tts_client.text_to_speech`). Hàm mới
+  `tts_client.synthesize_for_track(text, track, output_path)` tra
+  `config.TTS_VOICE_ID_AI`/`TTS_VOICE_ID_DRAMA` (mặc định rỗng → dùng voice
+  mặc định của provider, không ép phải cấu hình).
+- **`video/lower_third.py`** — `render_lower_third(name, role, ...)` render
+  PNG tên/vai trò nhân vật (Pillow), overlay bằng ffmpeg `overlay` filter.
+  **`video/commentary_card.py`** — `render_commentary_card(text, ...)` render
+  thẻ bình luận (`vn_commentary`) dạng card nền tối bo góc mờ. Cả hai trả
+  `None` nếu input rỗng — không ép caller phải luôn có overlay.
+- **`video/image_generator.py`** — minh hoạ AI qua Replicate
+  (`REPLICATE_API_TOKEN`/`REPLICATE_MODEL_VERSION`, cả hai mặc định rỗng —
+  không tự bịa model/preset). Cache theo hash prompt tại
+  `video/assets/illustrations/cache/`. Thiếu token/model/API lỗi → trả
+  `None`, KHÔNG làm hỏng cả video (composer tự fallback sang gradient).
+- **`video/templates/`** — `load_template(track, format)` tra bảng scene cố
+  định (`drama.py`/`ai.py`). Track AI vẫn dùng composer đơn-nền cũ
+  (template chỉ để tài liệu hoá scene shape, xem docstring `ai.py`) — chỉ
+  track Drama thật sự render multi-scene. **Sửa lỗi tài liệu:** per-scene
+  duration của `phase-4-detailed.md` cộng lại ra 90s nhưng doc ghi
+  `duration_target: 75` — giữ tổng 90 (khớp các duration cụ thể có lý do rõ
+  ràng: "Hook 3s", "Twist 25s"...) thay vì đoán scene nào sai, tương tự lỗi
+  word-count Phase 3 (`docs/current/prompts-decisions.md`).
+- **`video/drama_composer.py`** — `compose_drama_video()`: pre-render mỗi
+  scene thành 1 đoạn ffmpeg riêng (nền + overlay lower-third/commentary nếu
+  có), nối (`concat` demuxer, `-c copy`) thành 1 "scene reel", rồi đưa reel
+  đó làm `bg_video` cho `compose_video()` **đã có sẵn** (video_composer.py)
+  để tái dùng pipeline audio/phụ đề/crop đã ổn định — không viết lại logic
+  đó. Scene reel lỗi → fallback về compose đơn-nền cũ (không bao giờ ra
+  video rỗng). Nhạc nền: nếu `ENABLE_BGM=1`, mix nhạc từ
+  `config.DRAMA_MUSIC_DIR` (pool riêng, khác `MUSIC_DIR` của track AI) —
+  ưu tiên file tên trùng `template["music_track"]`, thiếu thì chọn ngẫu
+  nhiên trong pool (không chặn render nếu chưa có file nhạc, xem
+  `video/assets/music_drama/CREDITS.md` — cần thêm nhạc thủ công, giống
+  bước branding thủ công ở Phase 1).
+  **Khoảng trống đã biết:** `drama_rewriter.py` (Phase 3) chưa có field
+  tên/vai trò nhân vật có cấu trúc, nên `lower_third`/`vn_commentary` là
+  tham số optional caller tự truyền vào (không đoán parse từ `script` tự
+  do) — bước gọi thực tế (orchestration) cần cung cấp dữ liệu này.
+- Không có migration DB mới ở Phase 4 (chỉ thêm code + asset directories).
+
+---
+
 ## Nguồn dữ liệu cần thu thập
 
 ### RSS Feeds (dùng feedparser)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,34 @@ production thật (TTS/render) vẫn thuộc Phase 4:
   [`docs/current/prompts-decisions.md`](docs/current/prompts-decisions.md).
 - Chi tiết thiết kế: [`docs/current/phase-3-detailed.md`](docs/current/phase-3-detailed.md).
 
+## Drama Video Production (Phase 4)
+
+Biến story đã Việt hoá (Phase 3) thành video Shorts thật — audio, hình, phụ đề:
+
+- **`video/tts/`** — TTS provider abstraction (`nuitruc`/`edge`, đã có sẵn từ
+  trước) nay hỗ trợ voice riêng theo track qua
+  `tts_client.synthesize_for_track(text, track, output_path)`
+  (`TTS_VOICE_ID_AI`/`TTS_VOICE_ID_DRAMA` trong `.env`).
+- **`video/lower_third.py`** / **`video/commentary_card.py`** — render PNG
+  tên/vai trò nhân vật và thẻ bình luận (`vn_commentary`) bằng Pillow, overlay
+  vào video bằng ffmpeg.
+- **`video/image_generator.py`** — minh hoạ AI qua Replicate
+  (`REPLICATE_API_TOKEN`/`REPLICATE_MODEL_VERSION`), cache theo prompt; thiếu
+  cấu hình hoặc lỗi mạng → fallback gradient, không chặn render.
+- **`video/templates/`** — `load_template(track, format)` — bảng scene cố
+  định cho track Drama (`hook → setup → escalation → twist →
+  vn_commentary_overlay → reflection_cta`) và AI (giữ nguyên composer đơn-nền
+  cũ, template chỉ để tài liệu hoá).
+- **`video/drama_composer.py`** — `compose_drama_video()`: render từng scene
+  thành đoạn ffmpeg riêng rồi nối thành 1 "scene reel", đưa reel vào
+  `compose_video()` sẵn có để tái dùng pipeline audio/phụ đề/crop đã ổn định.
+  Nhạc nền lấy từ `video/assets/music_drama/` khi `ENABLE_BGM=1` (thêm file
+  `.mp3` thủ công — xem `CREDITS.md` trong thư mục đó).
+  ```bash
+  python -m video.drama_composer
+  ```
+- Chi tiết thiết kế: [`docs/current/phase-4-detailed.md`](docs/current/phase-4-detailed.md).
+
 ## Cài đặt
 
 ```bash

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -7,11 +7,24 @@ PRODUCTHUNT_API_TOKEN=...
 # --- Pexels (free stock video backgrounds) ---
 PEXELS_API_KEY=...
 
+# --- AI illustration (Phase 4 — Drama backgrounds via Replicate) ---
+# Optional: leave empty to always fall back to solid/gradient Drama
+# backgrounds (see video/image_generator.py).
+REPLICATE_API_TOKEN=
+# Pin a specific model version hash from replicate.com/<model>/versions —
+# do not leave this pointed at "latest".
+REPLICATE_MODEL_VERSION=
+
 # --- TTS (Núi Trúc) ---
 TTS_API_URL=http://tts.nuitruc.ai/api/tts
 TTS_API_KEY=
 TTS_VOICE_ID=preset_my_duyen
 TTS_VOICE_SPEED=1.0
+# Per-track voice override (Phase 4 — Drama Video Production). Leave empty to
+# keep using TTS_VOICE_ID for that track. Confirm the preset/voice id actually
+# exists with your TTS provider before setting — do not guess a name.
+TTS_VOICE_ID_AI=
+TTS_VOICE_ID_DRAMA=
 # HTTP tuning (issue #58). On a stalled endpoint the client now fails fast and
 # the provider fallback chain takes over, so keep TTS_TIMEOUT modest. Raise it
 # only for a genuinely slow self-hosted backend. Timeouts are NOT retried;

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -51,6 +51,13 @@ TTS_API_URL = os.getenv("TTS_API_URL", "http://tts.nuitruc.ai/api/tts")
 TTS_API_KEY = os.getenv("TTS_API_KEY", "")           # Optional
 TTS_VOICE_ID = os.getenv("TTS_VOICE_ID", "preset_my_duyen")
 TTS_VOICE_SPEED = float(os.getenv("TTS_VOICE_SPEED", "1.0"))
+# Per-track voice override (Phase 4 — Drama Video Production). Empty string
+# means "no override, use the legacy global TTS_VOICE_ID" — deliberately NOT
+# defaulted to a guessed nuitruc preset name for drama (we don't have a
+# verified catalog of preset ids beyond "preset_my_duyen"); set this once you
+# confirm a real preset/voice id with the TTS provider.
+TTS_VOICE_ID_AI = os.getenv("TTS_VOICE_ID_AI", "")
+TTS_VOICE_ID_DRAMA = os.getenv("TTS_VOICE_ID_DRAMA", "")
 # TTS HTTP tuning (issue #58). A black-hole endpoint (TCP connect OK but no
 # response) used to stall the whole cron window: 400s timeout × 3 retries
 # ≈ 20 min before the fallback provider even ran. Defaults now fail fast and let
@@ -68,6 +75,16 @@ TTS_POLL_INTERVAL = int(os.getenv("TTS_POLL_INTERVAL", "12"))      # seconds bet
 TTS_POLL_TIMEOUT = int(os.getenv("TTS_POLL_TIMEOUT", "600"))       # max total wait for a job (s)
 TTS_POLL_MAX_FAILURES = int(os.getenv("TTS_POLL_MAX_FAILURES", "3"))  # consecutive poll errors before failover
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY", "")     # Free API key from pexels.com/api
+
+# --- AI illustration generation (Phase 4 — Drama Visual Assets) ---
+# Replaces Pexels stock footage for Drama scenes (stock clips don't fit drama
+# story illustration well) via Replicate's prediction API. Optional: with no
+# token configured, video/image_generator.py returns None and the composer
+# falls back to a solid/gradient background — never a hard failure.
+REPLICATE_API_TOKEN = os.getenv("REPLICATE_API_TOKEN", "")
+# Model version hash to run (see replicate.com/<model>/versions). Left empty
+# by default — pick and pin a specific image model/version before enabling.
+REPLICATE_MODEL_VERSION = os.getenv("REPLICATE_MODEL_VERSION", "")
 
 # Video output
 VIDEO_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
@@ -132,6 +149,10 @@ BG_VARIETY_TOPK = int(os.getenv("BG_VARIETY_TOPK", "3"))
 BG_RECENT_WINDOW = int(os.getenv("BG_RECENT_WINDOW", "8"))
 # Background music (ENABLE_BGM=1): directory + level under the narration.
 MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music")
+# Drama track uses its own pool (tense/dramatic loops) instead of the AI
+# track's — templates (video/templates/drama.py) name a preferred track by
+# filename, with a random pick from this dir as fallback.
+DRAMA_MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music_drama")
 BGM_VOLUME_DB = float(os.getenv("BGM_VOLUME_DB", "-18"))  # music gain relative to voice
 
 # Allowed values for the string-valued flags above (used by validate_flags()).

--- a/content-pipeline/tests/test_audio_mixer.py
+++ b/content-pipeline/tests/test_audio_mixer.py
@@ -61,6 +61,19 @@ class TestPickMusic(unittest.TestCase):
         open(track, "w").close()
         self.assertEqual(pick_music(tmp), track)
 
+    def test_preferred_name_used_when_present(self):
+        tmp = tempfile.mkdtemp()
+        open(os.path.join(tmp, "calm.mp3"), "w").close()
+        preferred = os.path.join(tmp, "tense_minimal_loop.mp3")
+        open(preferred, "w").close()
+        self.assertEqual(pick_music(tmp, preferred_name="tense_minimal_loop.mp3"), preferred)
+
+    def test_preferred_name_missing_falls_back_to_random(self):
+        tmp = tempfile.mkdtemp()
+        track = os.path.join(tmp, "calm.mp3")
+        open(track, "w").close()
+        self.assertEqual(pick_music(tmp, preferred_name="nope.mp3"), track)
+
 
 class TestMixBackgroundMusic(unittest.TestCase):
     def test_no_music_returns_voice(self):

--- a/content-pipeline/tests/test_commentary_card.py
+++ b/content-pipeline/tests/test_commentary_card.py
@@ -5,16 +5,30 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 try:
-    from PIL import Image
+    from PIL import Image, ImageFont
     HAS_PIL = True
 except ImportError:
     HAS_PIL = False
 
-from video.commentary_card import render_commentary_card
+from video.commentary_card import (
+    render_commentary_card,
+    _fit_commentary_text,
+    CARD_FONTSIZE_RATIO,
+)
+
+
+def _resizable_default_font(size):
+    """A `_load_font` stand-in that actually honors `size` (unlike the
+    no-args ``ImageFont.load_default()`` fallback `_load_font` uses when no
+    system TTF is found — see video_composer._FALLBACK_FONTS, all macOS
+    paths). Keeps the shrink-to-fit tests deterministic regardless of which
+    fonts happen to be installed on the machine running the suite."""
+    return ImageFont.load_default(size=size)
 
 
 @unittest.skipUnless(HAS_PIL, "Pillow not installed")
@@ -43,6 +57,34 @@ class TestRenderCommentaryCard(unittest.TestCase):
         long_text = " ".join(["từ"] * 100)
         result = render_commentary_card(long_text, 1080, 1920, self.out)
         self.assertIsNotNone(result)  # must not crash on long wrapped text
+
+    def test_long_commentary_shrinks_font_to_fit_and_stays_on_canvas(self):
+        # Phase 3's drama_rewriter validates vn_commentary at >=200 words —
+        # at the default font size that wraps into more lines than a 1920px
+        # frame is tall, which (before the fix) pushed the earliest lines to
+        # a negative y (drawn off-canvas, silently lost).
+        long_commentary = " ".join(["đây", "là", "một", "câu", "bình", "luận"] * 40)
+        with patch("video.commentary_card._load_font", side_effect=_resizable_default_font):
+            font, lines, line_h, line_spacing = _fit_commentary_text(long_commentary, 1080, 1920)
+        total_h = len(lines) * line_h + max(0, len(lines) - 1) * line_spacing
+        top = max(0, (1920 - total_h) // 2)
+        self.assertGreaterEqual(top, 0)
+        default_fontsize = max(16, int(1920 * CARD_FONTSIZE_RATIO))
+        self.assertLess(font.size, default_fontsize)
+
+    def test_short_text_keeps_default_fontsize(self):
+        with patch("video.commentary_card._load_font", side_effect=_resizable_default_font):
+            font, _, _, _ = _fit_commentary_text("Góc nhìn của tôi", 1080, 1920)
+        default_fontsize = max(16, int(1920 * CARD_FONTSIZE_RATIO))
+        self.assertEqual(font.size, default_fontsize)
+
+    def test_render_long_commentary_end_to_end_with_real_load_font(self):
+        # Integration check with the real (possibly no-op-on-this-box)
+        # _load_font: must still not crash, and must not raise even when the
+        # fallback bitmap font can't actually shrink.
+        long_commentary = " ".join(["đây", "là", "một", "câu", "bình", "luận"] * 40)
+        result = render_commentary_card(long_commentary, 1080, 1920, self.out)
+        self.assertIsNotNone(result)
 
     def test_empty_text_returns_none(self):
         self.assertIsNone(render_commentary_card("", 1080, 1920, self.out))

--- a/content-pipeline/tests/test_commentary_card.py
+++ b/content-pipeline/tests/test_commentary_card.py
@@ -1,0 +1,62 @@
+"""Tests for video/commentary_card.py (Phase 4 — Drama Video Production)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from PIL import Image
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
+
+from video.commentary_card import render_commentary_card
+
+
+@unittest.skipUnless(HAS_PIL, "Pillow not installed")
+class TestRenderCommentaryCard(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.out = os.path.join(self.tmp, "commentary.png")
+
+    def test_creates_file(self):
+        result = render_commentary_card("Góc nhìn của tôi là...", 1080, 1920, self.out)
+        self.assertEqual(result, self.out)
+        self.assertTrue(os.path.exists(self.out))
+
+    def test_output_matches_requested_dimensions(self):
+        render_commentary_card("Góc nhìn của tôi", 1080, 1920, self.out)
+        with Image.open(self.out) as img:
+            self.assertEqual(img.size, (1080, 1920))
+
+    def test_background_is_tinted_not_transparent(self):
+        render_commentary_card("Góc nhìn của tôi", 1080, 1920, self.out)
+        with Image.open(self.out) as img:
+            corner = img.getpixel((0, 0))
+            self.assertEqual(corner[3], 235)  # near-opaque, matches CARD_BG_COLOR alpha
+
+    def test_long_text_wraps_into_multiple_lines(self):
+        long_text = " ".join(["từ"] * 100)
+        result = render_commentary_card(long_text, 1080, 1920, self.out)
+        self.assertIsNotNone(result)  # must not crash on long wrapped text
+
+    def test_empty_text_returns_none(self):
+        self.assertIsNone(render_commentary_card("", 1080, 1920, self.out))
+        self.assertFalse(os.path.exists(self.out))
+
+    def test_whitespace_only_text_returns_none(self):
+        self.assertIsNone(render_commentary_card("   ", 1080, 1920, self.out))
+
+    def test_creates_parent_directory(self):
+        nested_out = os.path.join(self.tmp, "nested", "cc.png")
+        result = render_commentary_card("Test", 1080, 1920, nested_out)
+        self.assertEqual(result, nested_out)
+        self.assertTrue(os.path.exists(nested_out))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_drama_composer.py
+++ b/content-pipeline/tests/test_drama_composer.py
@@ -1,0 +1,403 @@
+"""Tests for video/drama_composer.py (Phase 4 EPIC #4.2 — scene reel builder).
+
+Command-building/pure-logic functions are tested with mocks. A skippable
+real-ffmpeg smoke test exercises the full build_drama_scene_reel() pipeline
+end-to-end (concat + overlay) when ffmpeg is actually installed.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from video.drama_composer import (
+    _lavfi_source,
+    _resolve_scene_background,
+    _write_scene_concat_playlist,
+    build_scene_concat_command,
+    build_scene_segment_command,
+    build_drama_scene_reel,
+    scaled_scene_durations,
+    compose_drama_video,
+)
+
+HAS_FFMPEG = shutil.which("ffmpeg") is not None
+HAS_FFPROBE = shutil.which("ffprobe") is not None
+
+
+class TestLavfiSource(unittest.TestCase):
+    def test_gradient_spec(self):
+        src = _lavfi_source("gradient_warm", 1080, 1920)
+        self.assertTrue(src.startswith("gradients=s=1080x1920:"))
+        self.assertIn("c0=0xFF6B35", src)
+        self.assertIn("c1=0xF7C59F", src)
+
+    def test_solid_spec(self):
+        src = _lavfi_source("solid_blue", 1080, 1920)
+        self.assertEqual(src, "color=c=0x1B3A5C:s=1080x1920")
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(_lavfi_source("illustration", 1080, 1920))
+        self.assertIsNone(_lavfi_source("screen_record", 1080, 1920))
+
+
+class TestBuildSceneSegmentCommand(unittest.TestCase):
+    def test_lavfi_no_overlay(self):
+        cmd = build_scene_segment_command(
+            "color=c=0x000000:s=1080x1920", is_lavfi=True, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg0.mp4",
+        )
+        self.assertEqual(cmd[:4], ["ffmpeg", "-y", "-f", "lavfi"])
+        self.assertIn("-i", cmd)
+        self.assertIn("color=c=0x000000:s=1080x1920:d=3.0", cmd)
+        self.assertIn("-map", cmd)
+        self.assertIn("0:v", cmd)
+        self.assertNotIn("-filter_complex", cmd)
+        self.assertIn("/tmp/seg0.mp4", cmd)
+
+    def test_file_source_no_overlay(self):
+        cmd = build_scene_segment_command(
+            "/tmp/illustration.png", is_lavfi=False, duration=5.0,
+            width=1080, height=1920, output_path="/tmp/seg1.mp4",
+        )
+        self.assertIn("-stream_loop", cmd)
+        self.assertIn("-1", cmd)
+        self.assertIn("/tmp/illustration.png", cmd)
+
+    def test_with_overlay_uses_filter_complex(self):
+        cmd = build_scene_segment_command(
+            "color=c=0x000000:s=1080x1920", is_lavfi=True, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg0.mp4",
+            overlay_png="/tmp/overlay.png",
+        )
+        self.assertIn("-filter_complex", cmd)
+        idx = cmd.index("-filter_complex")
+        self.assertIn("overlay=shortest=0", cmd[idx + 1])
+        self.assertIn("[v]", cmd)
+        self.assertIn("/tmp/overlay.png", cmd)
+
+    def test_output_codec_settings(self):
+        cmd = build_scene_segment_command(
+            "color=c=0x000000:s=1080x1920", is_lavfi=True, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg0.mp4",
+        )
+        self.assertIn("libx264", cmd)
+        self.assertIn("yuv420p", cmd)
+        self.assertIn("-t", cmd)
+        self.assertIn("3.0", cmd)
+
+
+class TestBuildSceneConcatCommand(unittest.TestCase):
+    def test_stream_copy_concat(self):
+        cmd = build_scene_concat_command("/tmp/scenes.concat", "/tmp/reel.mp4")
+        self.assertEqual(
+            cmd,
+            ["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", "/tmp/scenes.concat",
+             "-c", "copy", "/tmp/reel.mp4"],
+        )
+
+
+class TestWriteSceneConcatPlaylist(unittest.TestCase):
+    def test_writes_one_line_per_segment(self):
+        tmp = tempfile.mkdtemp()
+        concat_path = os.path.join(tmp, "scenes.concat")
+        _write_scene_concat_playlist(["/tmp/a.mp4", "/tmp/b.mp4"], concat_path)
+        with open(concat_path, encoding="utf-8") as f:
+            content = f.read()
+        self.assertEqual(content, "file '/tmp/a.mp4'\nfile '/tmp/b.mp4'\n")
+
+
+class TestScaledSceneDurations(unittest.TestCase):
+    def test_scales_proportionally(self):
+        template = {
+            "duration_target": 90,
+            "scenes": [{"duration": 3}, {"duration": 12}, {"duration": 75}],
+        }
+        durations = scaled_scene_durations(template, 45.0)
+        self.assertAlmostEqual(sum(durations), 45.0, places=5)
+        self.assertAlmostEqual(durations[0], 1.5)
+        self.assertAlmostEqual(durations[1], 6.0)
+        self.assertAlmostEqual(durations[2], 37.5)
+
+    def test_falls_back_to_scene_sum_when_no_target(self):
+        template = {"scenes": [{"duration": 1}, {"duration": 1}]}
+        durations = scaled_scene_durations(template, 10.0)
+        self.assertAlmostEqual(sum(durations), 10.0, places=5)
+
+    def test_minimum_duration_floor(self):
+        template = {"duration_target": 1000, "scenes": [{"duration": 1}, {"duration": 999}]}
+        durations = scaled_scene_durations(template, 0.001)
+        self.assertGreaterEqual(durations[0], 0.1)
+
+
+class TestResolveSceneBackground(unittest.TestCase):
+    def test_gradient_resolves_lavfi(self):
+        scene = {"background": "gradient_warm"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, None)
+        self.assertTrue(is_lavfi)
+        self.assertIn("gradients=", source)
+
+    @patch("video.drama_composer.generate_illustration")
+    def test_illustration_success(self, mock_gen):
+        mock_gen.return_value = "/tmp/illustration_0.png"
+        scene = {"background": "illustration"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a lonely office")
+        self.assertFalse(is_lavfi)
+        self.assertEqual(source, "/tmp/illustration_0.png")
+        mock_gen.assert_called_once_with("a lonely office", index=0)
+
+    @patch("video.drama_composer.generate_illustration")
+    def test_illustration_failure_falls_back(self, mock_gen):
+        mock_gen.return_value = None
+        scene = {"background": "illustration_dark"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 1, "a prompt")
+        self.assertTrue(is_lavfi)
+        self.assertIn("color=c=0x1B3A5C", source)
+
+    def test_illustration_without_prompt_falls_back(self):
+        scene = {"background": "illustration"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, None)
+        self.assertTrue(is_lavfi)
+        self.assertIn("color=c=0x1B3A5C", source)
+
+    def test_unknown_background_falls_back(self):
+        scene = {"background": "screen_record"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, None)
+        self.assertTrue(is_lavfi)
+        self.assertIn("color=c=0x1B3A5C", source)
+
+
+class TestBuildDramaSceneReelMocked(unittest.TestCase):
+    """Exercise the orchestration logic with ffmpeg calls stubbed out."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.template = {
+            "duration_target": 10,
+            "scenes": [
+                {"type": "hook", "duration": 5, "background": "gradient_warm",
+                 "lower_third": False, "commentary": False},
+                {"type": "cta", "duration": 5, "background": "solid_blue",
+                 "lower_third": False, "commentary": False},
+            ],
+        }
+
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_returns_reel_path_on_success(self, mock_run):
+        mock_run.side_effect = lambda cmd, out: out
+        reel = build_drama_scene_reel(self.template, 10.0, 1080, 1920, self.tmp)
+        self.assertEqual(reel, os.path.join(self.tmp, "scene_reel.mp4"))
+        self.assertEqual(mock_run.call_count, 3)  # 2 segments + 1 concat
+
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_segment_failure_returns_none(self, mock_run):
+        mock_run.return_value = None
+        reel = build_drama_scene_reel(self.template, 10.0, 1080, 1920, self.tmp)
+        self.assertIsNone(reel)
+
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_concat_failure_returns_none(self, mock_run):
+        def side_effect(cmd, out):
+            return None if "scene_reel.mp4" in out else out
+        mock_run.side_effect = side_effect
+        reel = build_drama_scene_reel(self.template, 10.0, 1080, 1920, self.tmp)
+        self.assertIsNone(reel)
+
+    @patch("video.drama_composer.render_lower_third")
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_lower_third_only_rendered_when_scene_wants_it_and_data_given(self, mock_run, mock_lt):
+        mock_run.side_effect = lambda cmd, out: out
+        mock_lt.return_value = "/tmp/overlay.png"
+        template = {
+            "duration_target": 10,
+            "scenes": [
+                {"type": "escalation", "duration": 10, "background": "solid_blue",
+                 "lower_third": True, "commentary": False},
+            ],
+        }
+        build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp,
+                               lower_third={"name": "Minh", "role": "Nhân vật chính"})
+        mock_lt.assert_called_once()
+
+    @patch("video.drama_composer.render_lower_third")
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_lower_third_skipped_without_data(self, mock_run, mock_lt):
+        mock_run.side_effect = lambda cmd, out: out
+        template = {
+            "duration_target": 10,
+            "scenes": [
+                {"type": "escalation", "duration": 10, "background": "solid_blue",
+                 "lower_third": True, "commentary": False},
+            ],
+        }
+        build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp, lower_third=None)
+        mock_lt.assert_not_called()
+
+    @patch("video.drama_composer.render_commentary_card")
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_commentary_rendered_when_scene_wants_it_and_text_given(self, mock_run, mock_card):
+        mock_run.side_effect = lambda cmd, out: out
+        mock_card.return_value = "/tmp/card.png"
+        template = {
+            "duration_target": 10,
+            "scenes": [
+                {"type": "vn_commentary_overlay", "duration": 10, "background": "solid_blue",
+                 "lower_third": False, "commentary": True},
+            ],
+        }
+        build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp,
+                               vn_commentary="Bình luận của mình...")
+        mock_card.assert_called_once()
+
+
+class TestComposeDramaVideo(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.audio_path = os.path.join(self.tmp, "audio.mp3")
+        with open(self.audio_path, "wb") as f:
+            f.write(b"fake")
+
+    def test_missing_audio_returns_none(self):
+        result = compose_drama_video(
+            os.path.join(self.tmp, "nope.mp3"), None, os.path.join(self.tmp, "out.mp4"),
+        )
+        self.assertIsNone(result)
+
+    @patch("video.tts_client.get_audio_duration")
+    def test_zero_duration_returns_none(self, mock_dur):
+        mock_dur.return_value = 0
+        result = compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+        self.assertIsNone(result)
+
+    @patch("video.drama_composer.compose_video")
+    @patch("video.drama_composer.build_drama_scene_reel")
+    @patch("video.tts_client.get_audio_duration")
+    def test_falls_back_to_plain_compose_when_reel_fails(self, mock_dur, mock_reel, mock_compose):
+        mock_dur.return_value = 30.0
+        mock_reel.return_value = None
+        mock_compose.return_value = "/tmp/out.mp4"
+        result = compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+        self.assertEqual(result, "/tmp/out.mp4")
+        _, kwargs = mock_compose.call_args
+        self.assertNotIn("bg_video", kwargs)
+
+    @patch("video.drama_composer.compose_video")
+    @patch("video.drama_composer.build_drama_scene_reel")
+    @patch("video.tts_client.get_audio_duration")
+    def test_uses_reel_as_bg_video_when_available(self, mock_dur, mock_reel, mock_compose):
+        mock_dur.return_value = 30.0
+        mock_reel.return_value = "/tmp/scene_reel.mp4"
+        mock_compose.return_value = "/tmp/out.mp4"
+        result = compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+        self.assertEqual(result, "/tmp/out.mp4")
+        _, kwargs = mock_compose.call_args
+        self.assertEqual(kwargs.get("bg_video"), "/tmp/scene_reel.mp4")
+
+    @patch("video.drama_composer.compose_video")
+    @patch("video.drama_composer.build_drama_scene_reel")
+    @patch("video.tts_client.get_audio_duration")
+    @patch("video.audio_mixer.mix_background_music")
+    @patch("video.audio_mixer.pick_music")
+    @patch("video.drama_composer.config")
+    def test_bgm_mixed_in_when_enabled_and_music_available(
+        self, mock_config, mock_pick, mock_mix, mock_dur, mock_reel, mock_compose,
+    ):
+        mock_config.ENABLE_BGM = True
+        mock_config.DRAMA_MUSIC_DIR = "/fake/music_drama"
+        mock_dur.return_value = 30.0
+        mock_pick.return_value = "/fake/music_drama/tense_minimal_loop.mp3"
+        mock_mix.return_value = "/tmp/mixed.m4a"
+        mock_reel.return_value = "/tmp/scene_reel.mp4"
+        mock_compose.return_value = "/tmp/out.mp4"
+
+        compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+
+        mock_pick.assert_called_once_with("/fake/music_drama", preferred_name="tense_minimal_loop.mp3")
+        mock_mix.assert_called_once()
+        args, kwargs = mock_mix.call_args
+        self.assertEqual(args[0], self.audio_path)
+        self.assertEqual(kwargs.get("music_path"), "/fake/music_drama/tense_minimal_loop.mp3")
+        # The mixed audio path should flow into compose_video, not the raw voice track.
+        compose_args, _ = mock_compose.call_args
+        self.assertEqual(compose_args[0], "/tmp/mixed.m4a")
+
+    @patch("video.drama_composer.compose_video")
+    @patch("video.drama_composer.build_drama_scene_reel")
+    @patch("video.tts_client.get_audio_duration")
+    @patch("video.audio_mixer.mix_background_music")
+    @patch("video.audio_mixer.pick_music")
+    @patch("video.drama_composer.config")
+    def test_bgm_skipped_when_disabled(
+        self, mock_config, mock_pick, mock_mix, mock_dur, mock_reel, mock_compose,
+    ):
+        mock_config.ENABLE_BGM = False
+        mock_dur.return_value = 30.0
+        mock_reel.return_value = "/tmp/scene_reel.mp4"
+        mock_compose.return_value = "/tmp/out.mp4"
+
+        compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+
+        mock_pick.assert_not_called()
+        mock_mix.assert_not_called()
+        compose_args, _ = mock_compose.call_args
+        self.assertEqual(compose_args[0], self.audio_path)
+
+    @patch("video.drama_composer.compose_video")
+    @patch("video.drama_composer.build_drama_scene_reel")
+    @patch("video.tts_client.get_audio_duration")
+    @patch("video.audio_mixer.mix_background_music")
+    @patch("video.audio_mixer.pick_music")
+    @patch("video.drama_composer.config")
+    def test_bgm_skipped_when_no_music_available(
+        self, mock_config, mock_pick, mock_mix, mock_dur, mock_reel, mock_compose,
+    ):
+        mock_config.ENABLE_BGM = True
+        mock_config.DRAMA_MUSIC_DIR = "/fake/music_drama"
+        mock_dur.return_value = 30.0
+        mock_pick.return_value = None
+        mock_reel.return_value = "/tmp/scene_reel.mp4"
+        mock_compose.return_value = "/tmp/out.mp4"
+
+        compose_drama_video(self.audio_path, None, os.path.join(self.tmp, "out.mp4"))
+
+        mock_mix.assert_not_called()
+        compose_args, _ = mock_compose.call_args
+        self.assertEqual(compose_args[0], self.audio_path)
+
+
+@unittest.skipUnless(HAS_FFMPEG and HAS_FFPROBE, "ffmpeg/ffprobe not installed")
+class TestBuildDramaSceneReelRealFfmpeg(unittest.TestCase):
+    """End-to-end smoke test: real ffmpeg renders + concats a tiny scene reel."""
+
+    def test_real_reel_render(self):
+        tmp = tempfile.mkdtemp()
+        template = {
+            "duration_target": 2,
+            "scenes": [
+                {"type": "hook", "duration": 1, "background": "gradient_warm",
+                 "lower_third": False, "commentary": False},
+                {"type": "cta", "duration": 1, "background": "solid_blue",
+                 "lower_third": False, "commentary": False},
+            ],
+        }
+        reel = build_drama_scene_reel(template, 2.0, 320, 240, tmp)
+        self.assertIsNotNone(reel)
+        self.assertTrue(os.path.exists(reel))
+
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "stream=width,height",
+             "-of", "csv=p=0", reel],
+            capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(probe.returncode, 0)
+        self.assertIn("320,240", probe.stdout.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_image_generator.py
+++ b/content-pipeline/tests/test_image_generator.py
@@ -1,0 +1,184 @@
+"""Tests for video/image_generator.py (Phase 4 — Drama Visual Assets)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+from urllib.error import HTTPError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.image_generator as image_generator
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _json_resp(obj):
+    return _FakeResp(json.dumps(obj).encode("utf-8"))
+
+
+class ImageGeneratorTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._cache_patch = patch.object(image_generator, "CACHE_DIR", self.tmp)
+        self._cache_patch.start()
+        self._cfg_patch = patch.multiple(
+            image_generator.config,
+            REPLICATE_API_TOKEN="fake-token",
+            REPLICATE_MODEL_VERSION="fake-version-hash",
+        )
+        self._cfg_patch.start()
+        self._sleep_patch = patch.object(image_generator.time, "sleep")
+        self._sleep_patch.start()
+
+    def tearDown(self):
+        self._sleep_patch.stop()
+        self._cfg_patch.stop()
+        self._cache_patch.stop()
+
+
+class TestGenerateIllustrationGuards(ImageGeneratorTestBase):
+    def test_empty_prompt_returns_none_without_network(self):
+        with patch.object(image_generator, "urlopen") as mocked:
+            result = image_generator.generate_illustration("")
+        self.assertIsNone(result)
+        mocked.assert_not_called()
+
+    def test_no_api_token_returns_none_without_network(self):
+        with patch.object(image_generator.config, "REPLICATE_API_TOKEN", ""), \
+             patch.object(image_generator, "urlopen") as mocked:
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+        mocked.assert_not_called()
+
+    def test_no_model_version_returns_none(self):
+        with patch.object(image_generator.config, "REPLICATE_MODEL_VERSION", ""):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_cache_hit_skips_network(self):
+        cache_path = image_generator._cache_path("a dramatic scene", 0)
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with open(cache_path, "wb") as f:
+            f.write(b"cached-bytes")
+        with patch.object(image_generator, "urlopen") as mocked:
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertEqual(result, cache_path)
+        mocked.assert_not_called()
+
+
+class TestGenerateIllustrationHappyPath(ImageGeneratorTestBase):
+    def test_full_flow_downloads_and_caches(self):
+        responses = [
+            _json_resp({"id": "pred123"}),                                  # create
+            _json_resp({"status": "processing"}),                          # poll 1
+            _json_resp({"status": "succeeded", "output": ["http://x/img.png"]}),  # poll 2
+            _FakeResp(b"PNGDATA"),                                          # download
+        ]
+        with patch.object(image_generator, "urlopen", side_effect=responses):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNotNone(result)
+        with open(result, "rb") as f:
+            self.assertEqual(f.read(), b"PNGDATA")
+
+    def test_second_call_hits_cache(self):
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "succeeded", "output": ["http://x/img.png"]}),
+            _FakeResp(b"PNGDATA"),
+        ]
+        with patch.object(image_generator, "urlopen", side_effect=responses):
+            first = image_generator.generate_illustration("a dramatic scene")
+        with patch.object(image_generator, "urlopen") as mocked_second:
+            second = image_generator.generate_illustration("a dramatic scene")
+        self.assertEqual(first, second)
+        mocked_second.assert_not_called()
+
+    def test_string_output_also_accepted(self):
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "succeeded", "output": "http://x/img.png"}),
+            _FakeResp(b"PNGDATA"),
+        ]
+        with patch.object(image_generator, "urlopen", side_effect=responses):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNotNone(result)
+
+
+class TestGenerateIllustrationFailureModes(ImageGeneratorTestBase):
+    def test_create_http_error_returns_none(self):
+        with patch.object(image_generator, "urlopen",
+                          side_effect=HTTPError("url", 500, "boom", None, None)):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_create_returns_no_id(self):
+        with patch.object(image_generator, "urlopen", return_value=_json_resp({})):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_prediction_failed_status_returns_none(self):
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "failed", "error": "model exploded"}),
+        ]
+        with patch.object(image_generator, "urlopen", side_effect=responses):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_poll_timeout_returns_none(self):
+        # First monotonic() call computes the deadline (0 + POLL_TIMEOUT_SECONDS);
+        # the second is the in-loop deadline check, made to exceed it — so the
+        # loop returns None after exactly one poll fetch (matching the single
+        # "processing" response provided below).
+        with patch.object(image_generator, "urlopen") as mocked, \
+             patch.object(image_generator.time, "monotonic", side_effect=[0, 1000]):
+            mocked.side_effect = [
+                _json_resp({"id": "pred123"}),
+                _json_resp({"status": "processing"}),
+            ]
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_download_failure_returns_none(self):
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "succeeded", "output": ["http://x/img.png"]}),
+        ]
+        with patch.object(image_generator, "urlopen") as mocked:
+            mocked.side_effect = responses + [HTTPError("url", 404, "gone", None, None)]
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+
+class TestGenerateIllustrations(ImageGeneratorTestBase):
+    def test_returns_only_successful_variants(self):
+        call_count = {"n": 0}
+
+        def fake_generate(prompt, index=0):
+            call_count["n"] += 1
+            return f"/fake/path_{index}.png" if index != 1 else None
+
+        with patch.object(image_generator, "generate_illustration", side_effect=fake_generate):
+            results = image_generator.generate_illustrations("a scene", count=3)
+        self.assertEqual(results, ["/fake/path_0.png", "/fake/path_2.png"])
+        self.assertEqual(call_count["n"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_image_generator.py
+++ b/content-pipeline/tests/test_image_generator.py
@@ -165,6 +165,31 @@ class TestGenerateIllustrationFailureModes(ImageGeneratorTestBase):
             result = image_generator.generate_illustration("a dramatic scene")
         self.assertIsNone(result)
 
+    def test_malformed_output_list_entry_returns_none_without_raising(self):
+        # A non-image model or unexpected Replicate response could return an
+        # empty/non-URL first list entry — this must degrade to None (the
+        # gradient fallback), not raise ValueError out of generate_illustration.
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "succeeded", "output": [""]}),
+        ]
+        with patch.object(image_generator, "urlopen", side_effect=responses):
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
+    def test_malformed_url_reaching_download_returns_none_without_raising(self):
+        # Defense in depth: even if a schemeless/malformed string reaches
+        # _download_image, urlopen's ValueError ("unknown url type") must be
+        # caught like any other download failure, not propagate.
+        responses = [
+            _json_resp({"id": "pred123"}),
+            _json_resp({"status": "succeeded", "output": ["not-a-real-url"]}),
+        ]
+        with patch.object(image_generator, "urlopen") as mocked:
+            mocked.side_effect = responses + [ValueError("unknown url type: 'not-a-real-url'")]
+            result = image_generator.generate_illustration("a dramatic scene")
+        self.assertIsNone(result)
+
 
 class TestGenerateIllustrations(ImageGeneratorTestBase):
     def test_returns_only_successful_variants(self):

--- a/content-pipeline/tests/test_lower_third.py
+++ b/content-pipeline/tests/test_lower_third.py
@@ -1,0 +1,69 @@
+"""Tests for video/lower_third.py (Phase 4 — Drama Visual Assets)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from PIL import Image
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
+
+from video.lower_third import render_lower_third
+
+
+@unittest.skipUnless(HAS_PIL, "Pillow not installed")
+class TestRenderLowerThird(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.out = os.path.join(self.tmp, "lower_third.png")
+
+    def test_creates_file(self):
+        result = render_lower_third("Mai", "Chị dâu", 1080, 1920, self.out)
+        self.assertEqual(result, self.out)
+        self.assertTrue(os.path.exists(self.out))
+
+    def test_output_matches_requested_dimensions(self):
+        render_lower_third("Mai", "Chị dâu", 1080, 1920, self.out)
+        with Image.open(self.out) as img:
+            self.assertEqual(img.size, (1080, 1920))
+
+    def test_output_is_rgba_with_transparent_areas(self):
+        render_lower_third("Mai", "Chị dâu", 1080, 1920, self.out)
+        with Image.open(self.out) as img:
+            self.assertEqual(img.mode, "RGBA")
+            # Top-left corner (well above the bar) must be fully transparent.
+            self.assertEqual(img.getpixel((0, 0))[3], 0)
+
+    def test_bar_region_is_not_fully_transparent(self):
+        render_lower_third("Mai", "Chị dâu", 1080, 1920, self.out)
+        with Image.open(self.out) as img:
+            bar_y = int(1920 * 0.72) + 5
+            pixel = img.getpixel((5, bar_y))
+            self.assertGreater(pixel[3], 0)
+
+    def test_no_role_uses_name_only(self):
+        result = render_lower_third("Mai", "", 1080, 1920, self.out)
+        self.assertIsNotNone(result)
+
+    def test_empty_name_returns_none(self):
+        self.assertIsNone(render_lower_third("", "Chị dâu", 1080, 1920, self.out))
+        self.assertFalse(os.path.exists(self.out))
+
+    def test_whitespace_only_name_returns_none(self):
+        self.assertIsNone(render_lower_third("   ", "Chị dâu", 1080, 1920, self.out))
+
+    def test_creates_parent_directory(self):
+        nested_out = os.path.join(self.tmp, "nested", "lt.png")
+        result = render_lower_third("Mai", "Chị dâu", 1080, 1920, nested_out)
+        self.assertEqual(result, nested_out)
+        self.assertTrue(os.path.exists(nested_out))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_templates.py
+++ b/content-pipeline/tests/test_templates.py
@@ -1,0 +1,73 @@
+"""Tests for video/templates/ (Phase 4 EPIC #4.2 — scene template registry)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from video.templates import load_template, DRAMA_SHORTS_TEMPLATE, AI_SHORTS_TEMPLATE
+
+_REQUIRED_SCENE_KEYS = {"type", "duration", "background"}
+
+
+class TestLoadTemplate(unittest.TestCase):
+    def test_loads_drama_shorts(self):
+        self.assertIs(load_template("drama", "shorts"), DRAMA_SHORTS_TEMPLATE)
+
+    def test_loads_ai_shorts(self):
+        self.assertIs(load_template("ai", "shorts"), AI_SHORTS_TEMPLATE)
+
+    def test_defaults_to_shorts_format(self):
+        self.assertIs(load_template("drama"), DRAMA_SHORTS_TEMPLATE)
+
+    def test_unknown_track_raises(self):
+        with self.assertRaises(ValueError):
+            load_template("nonexistent_track", "shorts")
+
+    def test_unknown_format_raises(self):
+        with self.assertRaises(ValueError):
+            load_template("drama", "long")
+
+
+class TestTemplateStructure(unittest.TestCase):
+    """Structural invariants both templates must satisfy — a template that
+    fails these would break video/drama_composer.py's assumptions."""
+
+    def _check_template(self, template: dict):
+        self.assertIn("format", template)
+        self.assertIn("duration_target", template)
+        self.assertIn("scenes", template)
+        self.assertGreater(len(template["scenes"]), 0)
+        for scene in template["scenes"]:
+            missing = _REQUIRED_SCENE_KEYS - scene.keys()
+            self.assertFalse(missing, f"scene {scene} missing keys: {missing}")
+            self.assertGreater(scene["duration"], 0)
+
+    def test_drama_shorts_structure(self):
+        self._check_template(DRAMA_SHORTS_TEMPLATE)
+
+    def test_ai_shorts_structure(self):
+        self._check_template(AI_SHORTS_TEMPLATE)
+
+    def test_drama_scene_durations_sum_close_to_target(self):
+        total = sum(s["duration"] for s in DRAMA_SHORTS_TEMPLATE["scenes"])
+        self.assertEqual(total, DRAMA_SHORTS_TEMPLATE["duration_target"])
+
+    def test_ai_scene_durations_sum_close_to_target(self):
+        total = sum(s["duration"] for s in AI_SHORTS_TEMPLATE["scenes"])
+        self.assertEqual(total, AI_SHORTS_TEMPLATE["duration_target"])
+
+    def test_drama_has_exactly_one_commentary_scene(self):
+        commentary_scenes = [s for s in DRAMA_SHORTS_TEMPLATE["scenes"] if s.get("commentary")]
+        self.assertEqual(len(commentary_scenes), 1)
+
+    def test_drama_has_exactly_one_lower_third_scene(self):
+        lt_scenes = [s for s in DRAMA_SHORTS_TEMPLATE["scenes"] if s.get("lower_third")]
+        self.assertEqual(len(lt_scenes), 1)
+        self.assertEqual(lt_scenes[0]["type"], "escalation")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_tts_client.py
+++ b/content-pipeline/tests/test_tts_client.py
@@ -232,6 +232,71 @@ class TestAsyncHappyPath(_AsyncFlowBase):
         self.assertGreaterEqual(opener.count("/status/abc"), 2)
 
 
+class TestSubmitJobVoiceId(unittest.TestCase):
+    """Phase 4 — per-call voice_id override on the /submit payload."""
+
+    def setUp(self):
+        self.cfg = patch.multiple(
+            tts.config,
+            TTS_API_URL="http://tts.nuitruc.ai/api/tts",
+            TTS_API_KEY="",
+            TTS_VOICE_ID="default_voice",
+            TTS_VOICE_SPEED=1.0,
+        )
+        self.cfg.start()
+        self.addCleanup(self.cfg.stop)
+
+    def _capture_submit(self):
+        captured = {}
+
+        class FakeOpener:
+            def open(self, req, timeout=None):
+                captured["body"] = json.loads(req.data)
+                return _FakeResp(_json({"job_id": "abc"}))
+
+        return FakeOpener(), captured
+
+    def test_custom_voice_id_included_in_payload(self):
+        opener, captured = self._capture_submit()
+        job_id = tts._submit_job(opener, "xin chào", voice_id="preset_custom")
+        self.assertEqual(job_id, "abc")
+        self.assertEqual(captured["body"]["voice_id"], "preset_custom")
+
+    def test_no_override_falls_back_to_config(self):
+        opener, captured = self._capture_submit()
+        tts._submit_job(opener, "xin chào")
+        self.assertEqual(captured["body"]["voice_id"], "default_voice")
+
+
+class TestSynthesizeForTrack(unittest.TestCase):
+    """Phase 4 — synthesize_for_track() picks the right per-track voice."""
+
+    def test_ai_track_uses_ai_voice(self):
+        with patch.multiple(tts.config, TTS_VOICE_ID_AI="preset_ai", TTS_VOICE_ID_DRAMA="preset_drama"), \
+             patch.object(tts, "text_to_speech", return_value="out.mp3") as mocked:
+            tts.synthesize_for_track("xin chào", "ai", "out.mp3")
+        mocked.assert_called_once_with("xin chào", "out.mp3", voice_id="preset_ai")
+
+    def test_drama_track_uses_drama_voice(self):
+        with patch.multiple(tts.config, TTS_VOICE_ID_AI="preset_ai", TTS_VOICE_ID_DRAMA="preset_drama"), \
+             patch.object(tts, "text_to_speech", return_value="out.mp3") as mocked:
+            tts.synthesize_for_track("kịch bản", "drama", "out.mp3")
+        mocked.assert_called_once_with("kịch bản", "out.mp3", voice_id="preset_drama")
+
+    def test_unconfigured_voice_falls_back_to_none(self):
+        # Empty string config (the default) must become None, not "" —
+        # an empty voice_id string would be sent to the provider as-is.
+        with patch.multiple(tts.config, TTS_VOICE_ID_AI="", TTS_VOICE_ID_DRAMA=""), \
+             patch.object(tts, "text_to_speech", return_value="out.mp3") as mocked:
+            tts.synthesize_for_track("xin chào", "ai", "out.mp3")
+        mocked.assert_called_once_with("xin chào", "out.mp3", voice_id=None)
+
+    def test_unknown_track_falls_back_to_none(self):
+        with patch.object(tts, "text_to_speech", return_value="out.mp3") as mocked:
+            tts.synthesize_for_track("xin chào", "unknown_track", "out.mp3")
+        mocked.assert_called_once_with("xin chào", "out.mp3", voice_id=None)
+
+
 class TestAsyncFailureModes(_AsyncFlowBase):
     def test_status_error_fails_over_without_fetching_result(self):
         opener = _FakeOpener({

--- a/content-pipeline/tests/test_tts_factory.py
+++ b/content-pipeline/tests/test_tts_factory.py
@@ -18,8 +18,9 @@ class FakeProvider:
         self.result = result
         self.called = False
 
-    def synthesize(self, text, output_path):
+    def synthesize(self, text, output_path, voice_id=None):
         self.called = True
+        self.voice_id = voice_id
         return self.result
 
 
@@ -67,6 +68,22 @@ class TestSynthesizeFallback(unittest.TestCase):
         self.assertTrue(primary.called)
         self.assertFalse(secondary.called)
 
+    def test_voice_id_passed_through_to_provider(self):
+        primary = FakeProvider("nuitruc", "out.mp3")
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", return_value=primary), \
+             patch("os.makedirs"):
+            synthesize("xin chào", "out.mp3", voice_id="preset_custom")
+        self.assertEqual(primary.voice_id, "preset_custom")
+
+    def test_none_voice_id_passed_through_by_default(self):
+        primary = FakeProvider("nuitruc", "out.mp3")
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", return_value=primary), \
+             patch("os.makedirs"):
+            synthesize("xin chào", "out.mp3")
+        self.assertIsNone(primary.voice_id)
+
     def test_falls_back_when_primary_fails(self):
         primary = FakeProvider("nuitruc", None)
         secondary = FakeProvider("edge", "edge.mp3")
@@ -94,7 +111,7 @@ class TestSynthesizeFallback(unittest.TestCase):
         class Cap:
             name = "nuitruc"
 
-            def synthesize(self, text, output_path):
+            def synthesize(self, text, output_path, voice_id=None):
                 captured["text"] = text
                 return output_path
 

--- a/content-pipeline/tests/test_tts_factory.py
+++ b/content-pipeline/tests/test_tts_factory.py
@@ -95,6 +95,20 @@ class TestSynthesizeFallback(unittest.TestCase):
         self.assertEqual(result, "edge.mp3")
         self.assertTrue(secondary.called)
 
+    def test_voice_override_not_leaked_to_fallback_provider(self):
+        # A Núi Trúc preset id (e.g. "preset_my_duyen") is meaningless to
+        # EdgeProvider's voice_id — passing it along would break the very
+        # fallback this override is meant to survive.
+        primary = FakeProvider("nuitruc", None)
+        secondary = FakeProvider("edge", "edge.mp3")
+        providers = {"nuitruc": primary, "edge": secondary}
+        with patch.object(factory.config, "TTS_PROVIDER", "nuitruc"), \
+             patch.object(factory, "get_provider", side_effect=lambda n: providers[n]), \
+             patch("os.makedirs"):
+            synthesize("xin chào", "out.mp3", voice_id="preset_my_duyen")
+        self.assertEqual(primary.voice_id, "preset_my_duyen")
+        self.assertIsNone(secondary.voice_id)
+
     def test_all_fail_returns_none(self):
         providers = {"nuitruc": FakeProvider("nuitruc", None),
                      "edge": FakeProvider("edge", None)}

--- a/content-pipeline/video/assets/music_drama/CREDITS.md
+++ b/content-pipeline/video/assets/music_drama/CREDITS.md
@@ -1,0 +1,18 @@
+# Drama Background Music Credits
+
+Nhạc nền riêng cho track Drama (khác thư mục `video/assets/music/` của track
+AI) — nên chọn nhạc **tense/dramatic**, hợp không khí kịch tính hơn nhạc nền
+tips/news. Chỉ dùng nhạc **royalty-free / Creative Commons**. Mỗi track liệt
+kê tại đây kèm nguồn + giấy phép trước khi commit/sử dụng.
+
+| File | Nguồn | Giấy phép | Ghi chú |
+|------|-------|-----------|---------|
+| _(chưa có track nào)_ | | | Thêm file `.mp3` vào thư mục này rồi điền dòng tương ứng |
+
+> `video/templates/drama.py` khai báo `music_track: "tense_minimal_loop.mp3"`
+> làm gợi ý tên file ưu tiên (`pick_music(preferred_name=...)` trong
+> `video/audio_mixer.py`) — nếu file đó chưa có trong thư mục này, hệ thống
+> tự chọn ngẫu nhiên trong các track khác đã thêm, không chặn render.
+>
+> Gợi ý nguồn: YouTube Audio Library, Pixabay Music, Free Music Archive (CC0/CC-BY).
+> Bật bằng `ENABLE_BGM=1`. Âm lượng nhạc điều chỉnh qua `BGM_VOLUME_DB`.

--- a/content-pipeline/video/audio_mixer.py
+++ b/content-pipeline/video/audio_mixer.py
@@ -25,8 +25,15 @@ logger = logging.getLogger(__name__)
 _MUSIC_EXTS = (".mp3", ".m4a", ".aac", ".wav", ".ogg")
 
 
-def pick_music(music_dir: str | None = None) -> str | None:
-    """Return a random royalty-free music file from the music dir, or None."""
+def pick_music(music_dir: str | None = None, preferred_name: str | None = None) -> str | None:
+    """Return a music file from the music dir, or None.
+
+    Args:
+        preferred_name: filename (e.g. a template's ``music_track``) to use
+            when present in `music_dir`; falls back to a random track from
+            the dir when absent, so a missing preferred file never blocks
+            rendering — it's a manually-acquired asset (see CREDITS.md).
+    """
     music_dir = music_dir or getattr(config, "MUSIC_DIR", "")
     if not music_dir or not os.path.isdir(music_dir):
         return None
@@ -35,6 +42,10 @@ def pick_music(music_dir: str | None = None) -> str | None:
         for f in sorted(os.listdir(music_dir))
         if f.lower().endswith(_MUSIC_EXTS)
     ]
+    if preferred_name:
+        preferred_path = os.path.join(music_dir, preferred_name)
+        if preferred_path in tracks:
+            return preferred_path
     if not tracks:
         return None
     return random.choice(tracks)

--- a/content-pipeline/video/commentary_card.py
+++ b/content-pipeline/video/commentary_card.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""
+VN Commentary Card (Phase 4 EPIC #4.2/#4.3 — Drama Video Production).
+
+Full-screen text card used as the background for the "vn_commentary_overlay"
+Drama scene — the ≥20% "góc nhìn Việt" segment from processors/drama_rewriter.py
+gets its own distinct visual treatment (solid tinted card + large centered
+text) instead of looking like a regular subtitle over b-roll, so viewers can
+tell "this part is commentary, not the story."
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from video.video_composer import _load_font, _wrap_text
+
+logger = logging.getLogger(__name__)
+
+CARD_FONTSIZE_RATIO = 0.045
+CARD_BG_COLOR = (13, 27, 42, 235)   # near-opaque dark navy tint
+CARD_TEXT_COLOR = (255, 255, 255, 255)
+CARD_TEXT_WIDTH_RATIO = 0.82        # max text width as a fraction of frame width
+
+
+def render_commentary_card(text: str, width: int, height: int,
+                           output_path: str) -> str | None:
+    """Render a full-screen semi-opaque card with centered, wrapped text.
+
+    Returns `output_path` on success, or None if Pillow/font is unavailable
+    or the text is empty.
+    """
+    if not text or not text.strip():
+        logger.warning("render_commentary_card: empty text — skipping")
+        return None
+
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError:
+        logger.error("Pillow not installed — cannot render commentary card")
+        return None
+
+    fontsize = max(16, int(height * CARD_FONTSIZE_RATIO))
+    font = _load_font(fontsize)
+    if font is None:
+        logger.error("No usable font found for commentary card")
+        return None
+
+    img = Image.new("RGBA", (width, height), CARD_BG_COLOR)
+    draw = ImageDraw.Draw(img)
+
+    max_text_width = int(width * CARD_TEXT_WIDTH_RATIO)
+    lines = _wrap_text(text.strip(), font, max_text_width)
+
+    sample_bbox = draw.textbbox((0, 0), "Ag", font=font)
+    line_h = sample_bbox[3] - sample_bbox[1]
+    line_spacing = int(line_h * 0.4)
+    total_h = len(lines) * line_h + (len(lines) - 1) * line_spacing
+    top = (height - total_h) // 2
+
+    for i, line in enumerate(lines):
+        bbox = draw.textbbox((0, 0), line, font=font)
+        line_w = bbox[2] - bbox[0]
+        x = (width - line_w) // 2
+        y = top + i * (line_h + line_spacing)
+        draw.text((x, y), line, font=font, fill=CARD_TEXT_COLOR)
+
+    try:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        img.save(output_path, "PNG")
+    except OSError as e:
+        logger.error("Failed to save commentary card PNG: %s", e)
+        return None
+    return output_path

--- a/content-pipeline/video/commentary_card.py
+++ b/content-pipeline/video/commentary_card.py
@@ -20,9 +20,55 @@ from video.video_composer import _load_font, _wrap_text
 logger = logging.getLogger(__name__)
 
 CARD_FONTSIZE_RATIO = 0.045
+CARD_MIN_FONTSIZE_RATIO = 0.02       # floor while shrinking to fit long commentary
+CARD_FONTSIZE_SHRINK_STEP = 0.9
 CARD_BG_COLOR = (13, 27, 42, 235)   # near-opaque dark navy tint
 CARD_TEXT_COLOR = (255, 255, 255, 255)
 CARD_TEXT_WIDTH_RATIO = 0.82        # max text width as a fraction of frame width
+CARD_TEXT_HEIGHT_RATIO = 0.86       # max text block height as a fraction of frame height
+
+
+def _fit_commentary_text(text: str, width: int, height: int):
+    """Find the largest font size (down to a floor) whose wrapped `text` fits
+    within the card's height.
+
+    `vn_commentary` (Phase 3's rewriter validates it at >=200 words) is much
+    longer than a lower-third label — at a fixed font size it can wrap into
+    more lines than the frame is tall, silently pushing the earliest lines to
+    a negative y (drawn off-canvas, invisible) while the card still "renders
+    successfully". Shrinking the font until the whole block fits keeps all of
+    the commentary visible instead of losing its start.
+
+    Returns (font, lines, line_h, line_spacing), or None if no usable font.
+    """
+    max_text_width = int(width * CARD_TEXT_WIDTH_RATIO)
+    max_text_height = int(height * CARD_TEXT_HEIGHT_RATIO)
+    fontsize = max(16, int(height * CARD_FONTSIZE_RATIO))
+    min_fontsize = max(12, int(height * CARD_MIN_FONTSIZE_RATIO))
+
+    from PIL import Image, ImageDraw
+    tmp = Image.new("RGBA", (1, 1))
+    measure = ImageDraw.Draw(tmp)
+
+    best = None
+    while True:
+        font = _load_font(fontsize)
+        if font is None:
+            return None
+        lines = _wrap_text(text, font, max_text_width)
+        bbox = measure.textbbox((0, 0), "Ag", font=font)
+        line_h = bbox[3] - bbox[1]
+        line_spacing = int(line_h * 0.4)
+        total_h = len(lines) * line_h + max(0, len(lines) - 1) * line_spacing
+        best = (font, lines, line_h, line_spacing)
+        if total_h <= max_text_height or fontsize <= min_fontsize:
+            if total_h > max_text_height:
+                logger.warning(
+                    "Commentary text still exceeds card height at minimum "
+                    "font size (%dpx) — rendering best-effort", fontsize,
+                )
+            return best
+        fontsize = max(min_fontsize, int(fontsize * CARD_FONTSIZE_SHRINK_STEP))
 
 
 def render_commentary_card(text: str, width: int, height: int,
@@ -42,23 +88,17 @@ def render_commentary_card(text: str, width: int, height: int,
         logger.error("Pillow not installed — cannot render commentary card")
         return None
 
-    fontsize = max(16, int(height * CARD_FONTSIZE_RATIO))
-    font = _load_font(fontsize)
-    if font is None:
+    fit = _fit_commentary_text(text.strip(), width, height)
+    if fit is None:
         logger.error("No usable font found for commentary card")
         return None
+    font, lines, line_h, line_spacing = fit
 
     img = Image.new("RGBA", (width, height), CARD_BG_COLOR)
     draw = ImageDraw.Draw(img)
 
-    max_text_width = int(width * CARD_TEXT_WIDTH_RATIO)
-    lines = _wrap_text(text.strip(), font, max_text_width)
-
-    sample_bbox = draw.textbbox((0, 0), "Ag", font=font)
-    line_h = sample_bbox[3] - sample_bbox[1]
-    line_spacing = int(line_h * 0.4)
-    total_h = len(lines) * line_h + (len(lines) - 1) * line_spacing
-    top = (height - total_h) // 2
+    total_h = len(lines) * line_h + max(0, len(lines) - 1) * line_spacing
+    top = max(0, (height - total_h) // 2)
 
     for i, line in enumerate(lines):
         bbox = draw.textbbox((0, 0), line, font=font)

--- a/content-pipeline/video/drama_composer.py
+++ b/content-pipeline/video/drama_composer.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+"""
+Drama Scene Composer (Phase 4 EPIC #4.2 — Video Composer Multi-track).
+
+Builds a Drama Shorts video: pre-renders each template scene as its own short
+segment (background + optional lower-third/commentary overlay baked in),
+concatenates them into one "scene reel", then feeds that reel as the
+background into the EXISTING `video_composer.compose_video()` — reusing its
+already-robust audio/subtitle/crop pipeline rather than duplicating it.
+
+Note on `lower_third`/`vn_commentary` inputs: processors/drama_rewriter.py's
+output schema (Phase 3) has no structured per-character name/role field —
+only free-text `script`. Rather than guess at parsing character names out of
+the script, this module takes lower-third data as an explicit optional
+argument; callers that have it (e.g. a future manual-annotation step, or a
+Phase 3 prompt/schema extension) pass it in, and a scene simply skips its
+overlay when it's not supplied — never a hard failure.
+"""
+
+import logging
+import os
+import tempfile
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from video.video_composer import _scale_filter, _run_ffmpeg, compose_video
+from video.templates import load_template
+from video.lower_third import render_lower_third
+from video.commentary_card import render_commentary_card
+from video.image_generator import generate_illustration
+
+logger = logging.getLogger(__name__)
+
+# Plain ffmpeg lavfi sources — no external dependency, always available.
+GRADIENT_SPECS = {
+    "gradient_warm": ("0xFF6B35", "0xF7C59F"),
+    "gradient_cool": ("0x2C3E50", "0x4A6FA5"),
+}
+SOLID_SPECS = {
+    "solid_blue": "0x1B3A5C",
+    "solid_brand": "0x0D1B2A",
+}
+_FALLBACK_BACKGROUND = "solid_blue"
+
+
+def _lavfi_source(background: str, width: int, height: int) -> str | None:
+    """ffmpeg lavfi source spec (no duration) for a symbolic background name.
+
+    Returns None if `background` isn't a known lavfi spec — caller should
+    then treat it as something else (a real file / AI illustration prompt).
+    """
+    if background in GRADIENT_SPECS:
+        c0, c1 = GRADIENT_SPECS[background]
+        return f"gradients=s={width}x{height}:c0={c0}:c1={c1}"
+    if background in SOLID_SPECS:
+        color = SOLID_SPECS[background]
+        return f"color=c={color}:s={width}x{height}"
+    return None
+
+
+def build_scene_segment_command(background: str, is_lavfi: bool, duration: float,
+                                width: int, height: int, output_path: str,
+                                overlay_png: str | None = None,
+                                fill: bool = True) -> list[str]:
+    """Build the ffmpeg command for ONE scene segment (pure, unit-testable).
+
+    Args:
+        background: an lavfi source spec string (is_lavfi=True) or a real
+            file path to loop (is_lavfi=False, e.g. an AI illustration PNG).
+        overlay_png: lower-third or commentary-card PNG, composited for the
+            full segment duration when given.
+    """
+    scale_pad = _scale_filter(width, height, fill)
+
+    if is_lavfi:
+        cmd = ["ffmpeg", "-y", "-f", "lavfi", "-i", f"{background}:d={duration}"]
+    else:
+        cmd = ["ffmpeg", "-y", "-stream_loop", "-1", "-i", background]
+
+    if overlay_png:
+        cmd += ["-i", overlay_png]
+        cmd += [
+            "-filter_complex",
+            f"[0:v]{scale_pad}[base];[base][1:v]overlay=shortest=0[v]",
+            "-map", "[v]",
+        ]
+    else:
+        cmd += ["-vf", scale_pad, "-map", "0:v"]
+
+    cmd += [
+        "-t", str(duration),
+        "-c:v", "libx264", "-preset", "medium", "-crf", "23",
+        "-pix_fmt", "yuv420p",
+        output_path,
+    ]
+    return cmd
+
+
+def build_scene_concat_command(concat_path: str, output_path: str) -> list[str]:
+    """Build the ffmpeg command that concatenates pre-rendered scene segments.
+
+    All segments share the same codec/size/pix_fmt (encoded that way by
+    build_scene_segment_command), so a stream copy concat is safe and fast.
+    """
+    return [
+        "ffmpeg", "-y",
+        "-f", "concat", "-safe", "0", "-i", concat_path,
+        "-c", "copy",
+        output_path,
+    ]
+
+
+def _write_scene_concat_playlist(segment_paths: list[str], concat_path: str) -> str:
+    lines = [f"file '{p}'" for p in segment_paths]
+    with open(concat_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    return concat_path
+
+
+def scaled_scene_durations(template: dict, total_duration: float) -> list[float]:
+    """Scale each scene's template duration proportionally to sum to `total_duration`.
+
+    Real narration length varies per story; the template's per-scene
+    durations are a relative-weight guideline, not a hard cut.
+    """
+    scenes = template["scenes"]
+    target_total = template.get("duration_target") or sum(s["duration"] for s in scenes)
+    if target_total <= 0:
+        target_total = len(scenes)
+    scale = total_duration / target_total
+    return [max(0.1, s["duration"] * scale) for s in scenes]
+
+
+def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
+                              thumbnail_prompt: str | None) -> tuple[str, bool]:
+    """Resolve a scene's symbolic `background` key to an ffmpeg input source.
+
+    Returns (source, is_lavfi). AI illustrations that fail to generate (no
+    API token, network error, ...) fall back to a plain gradient rather than
+    failing the whole scene.
+    """
+    background_key = scene["background"]
+
+    lavfi = _lavfi_source(background_key, width, height)
+    if lavfi is not None:
+        return lavfi, True
+
+    if background_key in ("illustration", "illustration_dark") and thumbnail_prompt:
+        illustration = generate_illustration(thumbnail_prompt, index=index)
+        if illustration is not None:
+            return illustration, False
+        logger.info("No AI illustration available for scene %d — using fallback background", index)
+
+    # Unresolvable symbolic background (e.g. "screen_record" outside the AI
+    # track, or illustration unavailable) — safe, always-available fallback.
+    return _lavfi_source(_FALLBACK_BACKGROUND, width, height), True
+
+
+def build_drama_scene_reel(
+    template: dict,
+    total_duration: float,
+    width: int,
+    height: int,
+    tmpdir: str,
+    thumbnail_prompt: str | None = None,
+    lower_third: dict | None = None,
+    vn_commentary: str | None = None,
+    fill: bool = True,
+) -> str | None:
+    """Render every scene as its own segment and concat them into one reel.
+
+    Returns the reel's path, or None on failure (caller should fall back to
+    a plain single-background compose rather than produce nothing).
+    """
+    scenes = template["scenes"]
+    durations = scaled_scene_durations(template, total_duration)
+
+    segment_paths = []
+    for i, (scene, duration) in enumerate(zip(scenes, durations)):
+        overlay_png = None
+        if scene.get("lower_third") and lower_third and lower_third.get("name"):
+            overlay_png = render_lower_third(
+                lower_third.get("name", ""), lower_third.get("role", ""),
+                width, height, os.path.join(tmpdir, f"overlay_{i}.png"),
+            )
+        elif scene.get("commentary") and vn_commentary:
+            overlay_png = render_commentary_card(
+                vn_commentary, width, height, os.path.join(tmpdir, f"overlay_{i}.png"),
+            )
+
+        source, is_lavfi = _resolve_scene_background(scene, width, height, i, thumbnail_prompt)
+
+        seg_path = os.path.join(tmpdir, f"scene_{i}.mp4")
+        cmd = build_scene_segment_command(source, is_lavfi, duration, width, height,
+                                          seg_path, overlay_png=overlay_png, fill=fill)
+        if _run_ffmpeg(cmd, seg_path) is None:
+            logger.error("Failed to render scene %d (%s) — aborting scene reel",
+                         i, scene["type"])
+            return None
+        segment_paths.append(seg_path)
+
+    concat_path = os.path.join(tmpdir, "scenes.concat")
+    _write_scene_concat_playlist(segment_paths, concat_path)
+    reel_path = os.path.join(tmpdir, "scene_reel.mp4")
+    if _run_ffmpeg(build_scene_concat_command(concat_path, reel_path), reel_path) is None:
+        logger.error("Failed to concatenate scene reel")
+        return None
+    return reel_path
+
+
+def compose_drama_video(
+    audio_path: str,
+    subtitle_path: str | None,
+    output_path: str,
+    thumbnail_prompt: str | None = None,
+    lower_third: dict | None = None,
+    vn_commentary: str | None = None,
+    video_format: str = "shorts",
+) -> str | None:
+    """Compose a full Drama video: multi-scene reel + audio + subtitles.
+
+    Falls back to the plain single-background compose (video_composer's
+    existing behaviour, no scene reel) if the reel fails to render, so a
+    Drama render never produces nothing at all.
+    """
+    from video.tts_client import get_audio_duration
+
+    if not os.path.exists(audio_path):
+        logger.error("Audio file not found: %s", audio_path)
+        return None
+    audio_duration = get_audio_duration(audio_path)
+    if audio_duration <= 0:
+        logger.error("Could not determine audio duration")
+        return None
+
+    template = load_template("drama", video_format)
+    width, height = (1080, 1920) if template["format"] == "9:16" else (1920, 1080)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        if config.ENABLE_BGM:
+            from video.audio_mixer import mix_background_music, pick_music
+            music_path = pick_music(config.DRAMA_MUSIC_DIR, preferred_name=template.get("music_track"))
+            if music_path:
+                # .m4a: the mixer encodes AAC, which an .mp3 muxer rejects.
+                mixed_path = os.path.join(tmpdir, "audio_bgm.m4a")
+                audio_path = mix_background_music(audio_path, mixed_path, music_path=music_path)
+
+        reel = build_drama_scene_reel(
+            template, audio_duration, width, height, tmpdir,
+            thumbnail_prompt=thumbnail_prompt, lower_third=lower_third,
+            vn_commentary=vn_commentary, fill=True,
+        )
+        if reel is None:
+            logger.warning("Scene reel failed — falling back to plain background compose")
+            return compose_video(audio_path, subtitle_path, output_path, video_type="short")
+
+        return compose_video(audio_path, subtitle_path, output_path,
+                             video_type="short", bg_video=reel)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print("Drama composer ready — call compose_drama_video() with real audio/story data.")

--- a/content-pipeline/video/image_generator.py
+++ b/content-pipeline/video/image_generator.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+"""
+AI Image Generator (Phase 4 EPIC #4.3 — Drama Visual Assets).
+
+Turns a `thumbnail_prompt` (from processors/drama_rewriter.py's rewrite
+output) into a background illustration for Drama scenes, via Replicate's
+prediction API (create -> poll -> download). Cached by prompt hash + index so
+the same story's illustrations are never regenerated (cost control — see
+phase-4-detailed.md's risk section on AI image cost).
+
+Falls back to None (never raises) on a missing API token/model version,
+network failure, or unexpected response shape — video/drama_composer.py then
+uses a solid/gradient background instead. This mirrors this codebase's
+existing external-service fallback philosophy (pexels_downloader.py,
+video/tts/factory.py): an optional paid service being unavailable must never
+crash the pipeline.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+
+logger = logging.getLogger(__name__)
+
+REPLICATE_API_BASE = "https://api.replicate.com/v1"
+CACHE_DIR = os.path.join(os.path.dirname(__file__), "assets", "illustrations", "cache")
+
+POLL_INTERVAL_SECONDS = 2
+POLL_TIMEOUT_SECONDS = 90
+
+
+def _cache_path(prompt: str, index: int) -> str:
+    """Deterministic cache filename for (prompt, index).
+
+    Same prompt+index always maps to the same file, so re-running the
+    pipeline for the same story/scene hits cache instead of re-generating.
+    """
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+    return os.path.join(CACHE_DIR, f"{digest}_{index}.png")
+
+
+def generate_illustration(prompt: str, index: int = 0) -> str | None:
+    """Generate (or reuse a cached) AI illustration for `prompt`.
+
+    Returns the local file path, or None if Replicate isn't configured or
+    generation fails for any reason. Callers must treat None as "no
+    illustration available, use a fallback background."
+    """
+    if not prompt or not prompt.strip():
+        return None
+
+    cache_path = _cache_path(prompt, index)
+    if os.path.exists(cache_path):
+        logger.debug("Illustration cache hit: %s", cache_path)
+        return cache_path
+
+    api_token = getattr(config, "REPLICATE_API_TOKEN", "")
+    if not api_token:
+        logger.info("REPLICATE_API_TOKEN not configured — skipping AI illustration")
+        return None
+
+    prediction_id = _create_prediction(prompt, api_token)
+    if prediction_id is None:
+        return None
+
+    image_url = _poll_prediction(prediction_id, api_token)
+    if image_url is None:
+        return None
+
+    return _download_image(image_url, cache_path)
+
+
+def generate_illustrations(prompt: str, count: int = 3) -> list[str]:
+    """Generate up to `count` illustration variants for `prompt`.
+
+    One API call per variant (Replicate model support for n>1 outputs isn't
+    consistent across models). Returns only the ones that succeeded — may be
+    fewer than `count`, or empty if generation isn't available at all.
+    """
+    results = []
+    for i in range(count):
+        path = generate_illustration(prompt, index=i)
+        if path:
+            results.append(path)
+    return results
+
+
+def _create_prediction(prompt: str, api_token: str) -> str | None:
+    model_version = getattr(config, "REPLICATE_MODEL_VERSION", "")
+    if not model_version:
+        logger.error("REPLICATE_MODEL_VERSION not configured — cannot generate illustration")
+        return None
+
+    payload = json.dumps({
+        "version": model_version,
+        "input": {"prompt": prompt},
+    }).encode("utf-8")
+    req = Request(
+        f"{REPLICATE_API_BASE}/predictions",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+    except (HTTPError, URLError, TimeoutError) as e:
+        logger.error("Replicate prediction create failed: %s", e)
+        return None
+    except (ValueError, json.JSONDecodeError) as e:
+        logger.error("Replicate prediction create returned invalid JSON: %s", e)
+        return None
+
+    prediction_id = data.get("id")
+    if not prediction_id:
+        logger.error("Replicate prediction create returned no id: %r", data)
+        return None
+    return prediction_id
+
+
+def _poll_prediction(prediction_id: str, api_token: str) -> str | None:
+    """Poll until the prediction succeeds/fails/times out. Returns the first
+    output image URL, or None."""
+    deadline = time.monotonic() + POLL_TIMEOUT_SECONDS
+    req = Request(
+        f"{REPLICATE_API_BASE}/predictions/{prediction_id}",
+        headers={"Authorization": f"Bearer {api_token}"},
+    )
+    while True:
+        try:
+            with urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read().decode())
+        except (HTTPError, URLError, TimeoutError) as e:
+            logger.error("Replicate prediction poll failed: %s", e)
+            return None
+        except (ValueError, json.JSONDecodeError) as e:
+            logger.error("Replicate prediction poll returned invalid JSON: %s", e)
+            return None
+
+        status = data.get("status")
+        if status == "succeeded":
+            output = data.get("output")
+            if isinstance(output, list) and output:
+                return output[0]
+            if isinstance(output, str) and output:
+                return output
+            logger.error("Replicate prediction succeeded but no usable output: %r", output)
+            return None
+        if status in ("failed", "canceled"):
+            logger.error("Replicate prediction %s: %s", status, data.get("error"))
+            return None
+
+        if time.monotonic() >= deadline:
+            logger.error("Replicate prediction %s timed out after %ds",
+                         prediction_id, POLL_TIMEOUT_SECONDS)
+            return None
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def _download_image(url: str, output_path: str) -> str | None:
+    try:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        req = Request(url)
+        with urlopen(req, timeout=30) as resp:
+            data = resp.read()
+        with open(output_path, "wb") as f:
+            f.write(data)
+    except (HTTPError, URLError, OSError, TimeoutError) as e:
+        logger.error("Failed to download illustration from %s: %s", url, e)
+        return None
+    return output_path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print(f"REPLICATE_API_TOKEN configured: {bool(config.REPLICATE_API_TOKEN)}")
+    print(f"REPLICATE_MODEL_VERSION: {config.REPLICATE_MODEL_VERSION or '(not set)'}")

--- a/content-pipeline/video/image_generator.py
+++ b/content-pipeline/video/image_generator.py
@@ -153,7 +153,7 @@ def _poll_prediction(prediction_id: str, api_token: str) -> str | None:
         if status == "succeeded":
             output = data.get("output")
             if isinstance(output, list) and output:
-                return output[0]
+                output = output[0]
             if isinstance(output, str) and output:
                 return output
             logger.error("Replicate prediction succeeded but no usable output: %r", output)
@@ -177,7 +177,10 @@ def _download_image(url: str, output_path: str) -> str | None:
             data = resp.read()
         with open(output_path, "wb") as f:
             f.write(data)
-    except (HTTPError, URLError, OSError, TimeoutError) as e:
+    # ValueError: urlopen raises this (not URLError) for a malformed/schemeless
+    # URL, e.g. "unknown url type: ''" — possible if Replicate ever returns a
+    # non-image/malformed `output` that slipped past _poll_prediction's checks.
+    except (HTTPError, URLError, OSError, TimeoutError, ValueError) as e:
         logger.error("Failed to download illustration from %s: %s", url, e)
         return None
     return output_path

--- a/content-pipeline/video/lower_third.py
+++ b/content-pipeline/video/lower_third.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""
+Lower-third overlay generator (Phase 4 EPIC #4.3 — Drama Visual Assets).
+
+Renders a transparent PNG with a semi-transparent bar + character name/role
+text (e.g. "Mai (Chị dâu)"), meant to be composited via FFmpeg's `overlay`
+filter during the "escalation" scene of a Drama video (see
+video/drama_composer.py) — the same "pre-render a PNG, overlay once" pattern
+the subtitle system already uses (video_composer.py's `_render_one_subtitle`),
+reused here rather than duplicated.
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from video.video_composer import _load_font
+
+logger = logging.getLogger(__name__)
+
+BAR_HEIGHT_RATIO = 0.09      # bar height as a fraction of frame height
+BAR_Y_RATIO = 0.72           # bar top position as a fraction of frame height
+BAR_OPACITY = 160            # 0-255
+NAME_FONTSIZE_RATIO = 0.032  # relative to frame height
+TEXT_LEFT_MARGIN_RATIO = 0.06
+
+
+def render_lower_third(name: str, role: str, width: int, height: int,
+                       output_path: str) -> str | None:
+    """Render a transparent WxH PNG: a semi-transparent bar + "Name (Role)" text.
+
+    Returns `output_path` on success, or None if Pillow is unavailable, no
+    usable font is found, or the name is empty — callers should skip the
+    overlay entirely in that case rather than composite a blank/broken PNG.
+    """
+    if not name or not name.strip():
+        logger.warning("render_lower_third: empty name — skipping overlay")
+        return None
+
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError:
+        logger.error("Pillow not installed — cannot render lower-third")
+        return None
+
+    text = f"{name.strip()} ({role.strip()})" if role and role.strip() else name.strip()
+
+    fontsize = max(12, int(height * NAME_FONTSIZE_RATIO))
+    font = _load_font(fontsize)
+    if font is None:
+        logger.error("No usable font found for lower-third")
+        return None
+
+    img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    bar_h = int(height * BAR_HEIGHT_RATIO)
+    bar_y = int(height * BAR_Y_RATIO)
+    draw.rectangle([(0, bar_y), (width, bar_y + bar_h)], fill=(0, 0, 0, BAR_OPACITY))
+
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_h = bbox[3] - bbox[1]
+    x = int(width * TEXT_LEFT_MARGIN_RATIO)
+    y = bar_y + (bar_h - text_h) // 2 - bbox[1]
+    draw.text((x, y), text, font=font, fill=(255, 255, 255, 255))
+
+    try:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        img.save(output_path, "PNG")
+    except OSError as e:
+        logger.error("Failed to save lower-third PNG: %s", e)
+        return None
+    return output_path

--- a/content-pipeline/video/templates/__init__.py
+++ b/content-pipeline/video/templates/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Scene template registry (Phase 4 EPIC #4.2) — load_template(track, format)."""
+
+from .ai import AI_SHORTS_TEMPLATE
+from .drama import DRAMA_SHORTS_TEMPLATE
+
+_TEMPLATES = {
+    ("ai", "shorts"): AI_SHORTS_TEMPLATE,
+    ("drama", "shorts"): DRAMA_SHORTS_TEMPLATE,
+}
+
+
+def load_template(track: str, format: str = "shorts") -> dict:
+    """Look up a scene template by (track, format).
+
+    Raises:
+        ValueError: if no template is registered for that combination.
+    """
+    key = (track, format)
+    if key not in _TEMPLATES:
+        raise ValueError(f"No template for track={track!r} format={format!r}")
+    return _TEMPLATES[key]

--- a/content-pipeline/video/templates/ai.py
+++ b/content-pipeline/video/templates/ai.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""
+AI Shorts template (Phase 4 EPIC #4.2 — kept for template-system symmetry).
+
+The AI track's actual rendering still goes through the existing single-
+background composer (video/video_composer.py) — this template documents its
+scene shape for `load_template()` rather than changing how it renders today.
+"screen_record" is a manually-provided screen-recording clip (Phuong quay tay
+phần demo — see phase-4-detailed.md §3.4); the pipeline only ghép (composes),
+it never generates that footage.
+"""
+
+AI_SHORTS_TEMPLATE = {
+    "format": "9:16",
+    "duration_target": 45,  # seconds
+    "scenes": [
+        {"type": "hook", "duration": 3, "background": "screen_record"},
+        {"type": "tip_demo", "duration": 35, "background": "screen_record"},
+        {"type": "cta", "duration": 7, "background": "solid_brand"},
+    ],
+}

--- a/content-pipeline/video/templates/drama.py
+++ b/content-pipeline/video/templates/drama.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""
+Drama Shorts template (Phase 4 EPIC #4.2/#4.3).
+
+Scene list + target timing for a 75s TikTok/Shorts-format Drama video.
+Per-scene ``duration`` is a guideline for the composer (video/drama_composer.py
+scales scenes to fit the actual narration length) — not a hard cut.
+
+``background`` is a symbolic key the composer resolves:
+- "illustration" / "illustration_dark" — AI-generated (video/image_generator.py),
+  falling back to a gradient/solid color if generation is unavailable.
+- "gradient_warm" / "gradient_cool" / "solid_blue" — plain ffmpeg lavfi sources,
+  no external dependency.
+"""
+
+DRAMA_SHORTS_TEMPLATE = {
+    "format": "9:16",
+    # phase-4-detailed.md states duration_target=75 but its own per-scene
+    # durations below (copied verbatim: 3+12+30+25+8+12) sum to 90 — another
+    # doc inconsistency (see docs/current/prompts-decisions.md for the
+    # similar word-count/duration mismatch found in Phase 3). Corrected here
+    # to match the actual scene sum rather than silently drifting from it;
+    # kept the specific named-scene durations since those came with an
+    # explicit rationale ("Hook 3s", "Twist 25s", ...).
+    "duration_target": 90,  # seconds
+    "scenes": [
+        {"type": "hook", "duration": 3, "background": "illustration",
+         "lower_third": False, "commentary": False},
+        {"type": "setup", "duration": 12, "background": "gradient_warm",
+         "lower_third": False, "commentary": False},
+        {"type": "escalation", "duration": 30, "background": "illustration",
+         "lower_third": True, "commentary": False},
+        {"type": "twist", "duration": 25, "background": "illustration_dark",
+         "lower_third": False, "commentary": False},
+        {"type": "vn_commentary_overlay", "duration": 8, "background": "solid_blue",
+         "lower_third": False, "commentary": True},
+        {"type": "reflection_cta", "duration": 12, "background": "gradient_cool",
+         "lower_third": False, "commentary": False},
+    ],
+    "transitions": "match_cut",
+    "music_track": "tense_minimal_loop.mp3",
+}

--- a/content-pipeline/video/tts/base.py
+++ b/content-pipeline/video/tts/base.py
@@ -17,6 +17,13 @@ class TTSProvider(abc.ABC):
     name: str = "base"
 
     @abc.abstractmethod
-    def synthesize(self, text: str, output_path: str) -> str | None:
-        """Synthesize *text* to ``output_path``; return the path or None."""
+    def synthesize(self, text: str, output_path: str,
+                   voice_id: str | None = None) -> str | None:
+        """Synthesize *text* to ``output_path``; return the path or None.
+
+        ``voice_id`` is an opaque per-provider voice identifier (Phase 4 —
+        per-track voice selection). None means "use this provider's default
+        (config-driven) voice" — every concrete provider must treat it that
+        way so passing it is always backward compatible.
+        """
         raise NotImplementedError

--- a/content-pipeline/video/tts/edge.py
+++ b/content-pipeline/video/tts/edge.py
@@ -27,7 +27,8 @@ def _speed_to_rate(speed: float) -> str:
 class EdgeProvider(TTSProvider):
     name = "edge"
 
-    def synthesize(self, text: str, output_path: str) -> str | None:
+    def synthesize(self, text: str, output_path: str,
+                   voice_id: str | None = None) -> str | None:
         try:
             import asyncio
             import edge_tts
@@ -38,7 +39,7 @@ class EdgeProvider(TTSProvider):
             )
             return None
 
-        voice = getattr(config, "EDGE_VOICE", "vi-VN-HoaiMyNeural")
+        voice = voice_id or getattr(config, "EDGE_VOICE", "vi-VN-HoaiMyNeural")
         rate = _speed_to_rate(getattr(config, "TTS_VOICE_SPEED", 1.0))
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 

--- a/content-pipeline/video/tts/factory.py
+++ b/content-pipeline/video/tts/factory.py
@@ -44,13 +44,24 @@ def synthesize(text: str, output_path: str, voice_id: str | None = None) -> str 
     upstream); providers must not re-process it. ``voice_id`` (Phase 4) is an
     opaque per-provider voice override — None uses each provider's own
     config-driven default.
+
+    ``voice_id`` is only meaningful for the provider it was configured for
+    (e.g. a Núi Trúc ``preset_*`` id vs. an Edge voice name like
+    ``vi-VN-HoaiMyNeural`` — the two are not interchangeable). It is honored
+    only for the primary (configured) provider; if that fails over to a
+    different provider, the override is dropped so the fallback uses its own
+    default voice instead of an opaque id it can't interpret.
     """
     if output_path:
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
-    for name in _provider_order():
+    order = _provider_order()
+    primary = order[0] if order else None
+
+    for name in order:
         provider = get_provider(name)
-        result = provider.synthesize(text, output_path, voice_id=voice_id)
+        this_voice_id = voice_id if name == primary else None
+        result = provider.synthesize(text, output_path, voice_id=this_voice_id)
         if result:
             return result
         logger.warning("TTS provider %r failed — trying next", name)

--- a/content-pipeline/video/tts/factory.py
+++ b/content-pipeline/video/tts/factory.py
@@ -37,18 +37,20 @@ def _provider_order() -> list[str]:
     return [primary] + [p for p in _KNOWN if p != primary]
 
 
-def synthesize(text: str, output_path: str) -> str | None:
+def synthesize(text: str, output_path: str, voice_id: str | None = None) -> str | None:
     """Synthesize via the configured provider, falling back to the others.
 
     The text is assumed already speech-normalized (preprocess_for_tts ran
-    upstream); providers must not re-process it.
+    upstream); providers must not re-process it. ``voice_id`` (Phase 4) is an
+    opaque per-provider voice override — None uses each provider's own
+    config-driven default.
     """
     if output_path:
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     for name in _provider_order():
         provider = get_provider(name)
-        result = provider.synthesize(text, output_path)
+        result = provider.synthesize(text, output_path, voice_id=voice_id)
         if result:
             return result
         logger.warning("TTS provider %r failed — trying next", name)

--- a/content-pipeline/video/tts/nuitruc.py
+++ b/content-pipeline/video/tts/nuitruc.py
@@ -22,10 +22,11 @@ logger = logging.getLogger(__name__)
 class NuiTrucProvider(TTSProvider):
     name = "nuitruc"
 
-    def synthesize(self, text: str, output_path: str) -> str | None:
+    def synthesize(self, text: str, output_path: str,
+                   voice_id: str | None = None) -> str | None:
         if not config.TTS_API_URL:
             logger.error("TTS_API_URL not configured — nuitruc unavailable")
             return None
         # Reuse the hardened HTTP call (secure SSL + retry) from tts_client.
         from video.tts_client import _tts_single
-        return _tts_single(text, output_path)
+        return _tts_single(text, output_path, voice_id=voice_id)

--- a/content-pipeline/video/tts_client.py
+++ b/content-pipeline/video/tts_client.py
@@ -45,7 +45,7 @@ TTS_POLL_TIMEOUT = config.TTS_POLL_TIMEOUT        # max total wait for a job (s)
 TTS_POLL_MAX_FAILURES = config.TTS_POLL_MAX_FAILURES  # consecutive poll errors before failover
 
 
-def text_to_speech(text: str, output_path: str) -> str | None:
+def text_to_speech(text: str, output_path: str, voice_id: str | None = None) -> str | None:
     """Convert text to speech audio file (facade over the TTS provider factory).
 
     Dispatches to the provider chosen by ``config.TTS_PROVIDER`` and falls back
@@ -55,12 +55,29 @@ def text_to_speech(text: str, output_path: str) -> str | None:
     Args:
         text: Script text to convert.
         output_path: Path to save final audio file.
+        voice_id: Optional per-provider voice override (Phase 4). None uses
+            the provider's own config-driven default.
 
     Returns:
         Path to the audio file, or None on failure.
     """
     from video.tts.factory import synthesize
-    return synthesize(text, output_path)
+    return synthesize(text, output_path, voice_id=voice_id)
+
+
+def synthesize_for_track(text: str, track: str, output_path: str) -> str | None:
+    """Synthesize using the voice configured for `track` ('ai' | 'drama').
+
+    Falls back to the legacy global TTS_VOICE_ID (i.e. no override) when no
+    per-track voice is configured (config.TTS_VOICE_ID_AI / TTS_VOICE_ID_DRAMA
+    empty) — an unconfigured Drama voice silently reusing the AI voice is a
+    much safer failure mode than silently producing no audio.
+    """
+    voice_id = {
+        "ai": config.TTS_VOICE_ID_AI,
+        "drama": config.TTS_VOICE_ID_DRAMA,
+    }.get(track) or None
+    return text_to_speech(text, output_path, voice_id=voice_id)
 
 
 def _build_opener(insecure: bool | None = None) -> object:
@@ -175,11 +192,11 @@ def _open_with_retry(opener, url: str, *, data: bytes | None, timeout: int,
     return None
 
 
-def _submit_job(opener, text: str) -> str | None:
+def _submit_job(opener, text: str, voice_id: str | None = None) -> str | None:
     """POST /submit and return the job id, or None on failure."""
     payload = json.dumps({
         "text": text,
-        "voice_id": config.TTS_VOICE_ID or "preset_my_duyen",
+        "voice_id": voice_id or config.TTS_VOICE_ID or "preset_my_duyen",
         "speed": config.TTS_VOICE_SPEED,
     }).encode("utf-8")
     body = _open_with_retry(opener, _endpoint("submit"), data=payload,
@@ -235,7 +252,7 @@ def _await_job(opener, job_id: str) -> bool:
         time.sleep(TTS_POLL_INTERVAL)
 
 
-def _tts_single(text: str, output_path: str) -> str | None:
+def _tts_single(text: str, output_path: str, voice_id: str | None = None) -> str | None:
     """Synthesize one text chunk via the Núi Trúc async job API.
 
     submit -> poll /status -> download /result (one-shot). Returns the output
@@ -243,11 +260,13 @@ def _tts_single(text: str, output_path: str) -> str | None:
     The /result download is fetched into memory then written, and is retried only
     on transient 5xx (which means it was NOT delivered, so the one-shot job is not
     yet consumed) — never after a successful 200.
+
+    ``voice_id`` (Phase 4) overrides ``config.TTS_VOICE_ID`` for this call only.
     """
     # Secure-by-default opener (verifies TLS unless TTS_ALLOW_INSECURE_SSL).
     opener = _build_opener()
 
-    job_id = _submit_job(opener, text)
+    job_id = _submit_job(opener, text, voice_id=voice_id)
     if not job_id:
         return None
 


### PR DESCRIPTION
## Summary

Implements Phase 4 (Drama Video Production) — turns an approved, Việt-hoá story (Phase 3) into a real Drama Shorts video: audio, illustrations/overlays, and subtitles.

- **Per-track TTS voice**: threaded `voice_id` through the existing `video/tts/` provider chain (`base.py`/`factory.py`/`nuitruc.py`/`edge.py`) instead of building a new abstraction — `tts_client.synthesize_for_track(text, track, output_path)` picks `TTS_VOICE_ID_AI`/`TTS_VOICE_ID_DRAMA` from config.
- **Overlays**: `video/lower_third.py` (character name/role) and `video/commentary_card.py` (`vn_commentary`) — Pillow-rendered PNGs composited via ffmpeg `overlay`; both skip gracefully when their input is empty.
- **AI illustrations**: `video/image_generator.py` — Replicate-based, cached by prompt hash, falls back to a gradient background on any failure (missing token, network error, timeout) rather than failing the render.
- **Scene templates**: `video/templates/` — `load_template(track, format)` registry (`drama.py`/`ai.py`). Fixed a doc inconsistency in the Drama template: per-scene durations summed to 90s but the doc's `duration_target` said 75 — kept 90 to match the individually-justified scene durations (documented inline, same pattern as a prior Phase 3 doc fix).
- **Scene composer**: `video/drama_composer.py` — `compose_drama_video()` pre-renders each scene as its own ffmpeg segment (background + optional overlay), concatenates them into a "scene reel" (`concat` demuxer, stream copy), then feeds that reel into the **existing** `compose_video()` as `bg_video` — reusing its already-tested audio/subtitle/crop pipeline instead of duplicating it. Falls back to a plain single-background compose if the reel fails, so a render never produces nothing.
- **Drama background music**: new `DRAMA_MUSIC_DIR` pool (separate from the AI track's `MUSIC_DIR`); `audio_mixer.pick_music()` now accepts a `preferred_name` so the template's `music_track` field is honored when present, with a random fallback. `video/assets/music_drama/CREDITS.md` documents the manual-acquisition step (same pattern as Phase 1 branding assets).

## Verification

- Full unit test suite: 510 tests passing (all new modules covered with mocks; pure command-building functions tested directly).
- Real-ffmpeg smoke tests included (skipped automatically if ffmpeg isn't installed) for the scene reel concat/overlay path.
- Ran a full manual end-to-end render (`compose_drama_video()` with synthetic ffmpeg-generated audio + a real SRT + lower-third + commentary overlays) and verified the output via `ffprobe`: valid 1080×1920 H.264/AAC MP4 with correct duration.

## Known scope boundary

`drama_rewriter.py`'s Phase 3 output schema has no structured character name/role field, so `lower_third`/`vn_commentary` are optional caller-supplied arguments to `compose_drama_video()` rather than parsed from free text — the future orchestration step (wiring this into `main.py`) needs to supply them. This is documented in `video/drama_composer.py`'s module docstring and in `CLAUDE.md`.

## Test plan

- [x] `python3 -m unittest discover -s tests -p "test_*.py"` — 510 passed
- [x] Real ffmpeg scene-reel smoke test (`TestBuildDramaSceneReelRealFfmpeg`)
- [x] Manual end-to-end `compose_drama_video()` render, verified with `ffprobe`
- [ ] Human listening/visual quality pass on real story data (manual follow-up, needs real API keys — same as Phase 1's branding EPIC)
