### PR TITLE
feat(phase-5): Distribution — review gate, multi-channel upload, scheduler, drama orchestrator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,14 +46,28 @@ content-pipeline/
 │   ├── compiled_videos.py      # CRUD cho bảng compiled_videos (Phase 3)
 │   ├── ab_runs.py              # CRUD cho bảng ab_runs (Phase 3)
 │   ├── collector_health.py     # Theo dõi last_success/alert nếu collector im lặng (Phase 2)
+│   ├── scheduled_posts.py      # CRUD queue upload theo cadence + atomic claim (Phase 5)
+│   ├── quota.py                # Track unit YouTube API/ngày (reset giờ Pacific) + alert 80% (Phase 5)
 │   ├── migrate.py              # Migration runner (up/down/status)
 │   └── migrations/             # File SQL versioned, vd 001_multi_track.sql
 ├── notifier/
-│   ├── telegram_bot.py         # Bot chính: báo cáo sáng + approve/reject + dispatch seed bot
-│   └── seed_bot.py             # Command handlers /seed_vn, /seed_url, /list_pending (Phase 2)
+│   ├── telegram_bot.py         # Bot chính: báo cáo sáng + approve/reject + dispatch seed/review bot
+│   ├── seed_bot.py             # Command handlers /seed_vn, /seed_url, /list_pending (Phase 2)
+│   └── review_bot.py           # Review gate: nút ✅/❌/✏️ + FSM edit metadata (Phase 5)
+├── publisher/
+│   ├── youtube_uploader.py     # Upload YouTube; upload_to_youtube(video_id, channel_key) multi-channel (Phase 5)
+│   ├── tiktok_uploader.py      # TikTok Content Posting API
+│   ├── tiktok_manual.py        # Export queue_tiktok/YYYY-MM-DD/ cho upload tay (Phase 5)
+│   └── scheduler.py            # Lịch NGÀY nào tạo video loại gì (legacy, track AI)
+├── scheduler/
+│   └── post_scheduler.py       # Queue GIỜ đăng theo cadence + tick 5 phút (Phase 5)
+├── webui/
+│   ├── app.py                  # Streamlit approve/reject UI (local-only)
+│   └── health.py               # GET /health — trạng thái module (Phase 5)
 ├── channels.py                 # Channel registry — nguồn sự thật cho mọi destination
 ├── config.py                   # API keys, keywords, thresholds
-├── main.py                     # Orchestrator — chạy toàn bộ pipeline
+├── main.py                     # Orchestrator track AI — chạy toàn bộ pipeline
+├── main_drama.py               # Orchestrator track Drama end-to-end (Phase 5)
 ├── requirements.txt
 └── .env                        # API keys (không commit lên git)
 ```
@@ -70,7 +84,8 @@ Từ Phase 1, pipeline hỗ trợ nhiều kênh/nhiều track thay vì 1 kênh A
   `tiktok_main`. Dùng `get_channel(key)` để tra cứu (raise `ValueError` nếu
   key sai). Module khác (uploader, scheduler) nên import từ đây thay vì
   hard-code tên kênh — logic routing thực tế (chọn đúng channel để upload)
-  sẽ được nối dây ở Phase 5.
+  đã được nối dây ở Phase 5 (`publisher/youtube_uploader.upload_to_youtube`,
+  `scheduler/post_scheduler.py`, `notifier/review_bot._destinations_for`).
 - Mọi bài viết (`articles`) và video (`videos`) mang thêm 2 cột:
   `track` (`'ai'` | `'drama'`, mặc định `'ai'` để không phá logic cũ) và
   `destination` (khoá trong `channels.py`, `NULL` nếu chưa quyết định).
@@ -219,6 +234,76 @@ gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
   tham số optional caller tự truyền vào (không đoán parse từ `script` tự
   do) — bước gọi thực tế (orchestration) cần cung cấp dữ liệu này.
 - Không có migration DB mới ở Phase 4 (chỉ thêm code + asset directories).
+
+---
+
+## Distribution Layer (Phase 5)
+
+Xem `docs/current/phase-5-detailed.md`/`phase-5-issues.md`. Đưa video đã
+render tới đúng kênh: review gate → duyệt → xếp lịch theo cadence → upload
+multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
+
+- **`notifier/review_bot.py`** — review gate với inline keyboard ✅/❌/✏️.
+  **Khác với tài liệu thiết kế:** doc vẽ `review_bot.py` như bot mới; thực tế
+  đây là các handler THUẦN được `telegram_bot._handle_update()` /
+  `_handle_callback_query()` gọi trong CÙNG vòng long-polling — cùng lý do
+  seed_bot Phase 2 (2 process cùng token → 409 Conflict). ✅ Approve → xếp
+  lịch qua scheduler (KHÔNG publish ngay như flow `/approve_<id>` cũ — flow
+  cũ vẫn giữ cho track AI); ❌ Reject → hỏi lý do, lưu `videos.review_note`;
+  ✏️ Edit → FSM chọn field (allowlist trong
+  `storage.database._VIDEO_METADATA_FIELDS`) → nhập giá trị. State chờ input
+  lưu `notifier/.review_state.json` (persisted qua restart); `/skip` huỷ.
+  Preview >50MB được NÉN (2 nấc 720p/CRF28 → 480p/CRF32,
+  `video/preview.py`) thay vì bỏ qua như trước — file gốc không bị đụng;
+  nén thất bại → fallback script-only review như cũ (issue #60). Flow duyệt
+  cũ (`send_video_for_approval`, track AI) cũng dùng compressor này.
+- **`publisher/youtube_uploader.py`** — `upload_to_youtube(video_id,
+  channel_key)`: token OAuth tra qua `channels.py[key]["oauth_token_env"]` →
+  env var trỏ tới file token (đúng convention Phase 1/oauth-setup.md,
+  **không** hardcode `tokens/{key}.json` như doc). Resumable upload retry
+  transient (429/5xx/mạng) backoff 2/4/8/16s; thumbnail
+  (`videos.thumbnail_path`) + caption track upload best-effort SAU khi có
+  `youtube_video_id` — fail sau điểm đó chỉ warning, không kích re-upload.
+  **Khác doc:** categoryId track AI giữ 28 (Science & Tech, hành vi cũ) thay
+  vì 22; Drama dùng 24 (Entertainment) như doc. `YOUTUBE_PRIVACY=unlisted`
+  để chạy E2E test không public.
+- **`scheduler/post_scheduler.py`** — `CADENCE` key theo `(channel_key,
+  track, video_type)` (doc dùng key phẳng `drama_youtube_shorts`... không có
+  trong registry). `schedule_video()` idempotent (video đã có post
+  queued/uploading/done cho kênh đó → trả post cũ); slot trống dò tuần tự,
+  double-book bị chặn thêm bằng partial unique index. `tick` (launchd
+  `com.ai5phut.post-scheduler.plist`, 5 phút/lần) claim atomic
+  queued→uploading rồi upload; **post kẹt 'uploading' không bao giờ tự
+  retry** — video có thể ĐÃ lên platform trước khi crash, chỉ alert Telegram
+  để xử lý tay (chống upload trùng, rủi ro §5 của doc). TikTok: có
+  `TIKTOK_ACCESS_TOKEN` → API; chưa có → tự rơi về queue tay.
+- **`publisher/tiktok_manual.py`** — `export_for_manual_upload(video_id)`
+  copy MP4 + file `.txt` (caption + hashtags) vào `queue_tiktok/YYYY-MM-DD/`
+  (gitignored). Được gọi ngay lúc approve khi chưa có TikTok API token.
+- **`main_drama.py`** — orchestrator: collect → score → rewrite → render
+  (TTS voice drama + `compose_drama_video`) → push review. Resume: trạng
+  thái nằm hết trong DB; video row được insert TRƯỚC khi render (gắn
+  `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
+  row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn
+  auto-render lại, chờ xử lý tay — không bao giờ render trùng. Narration =
+  hook + script + vn_commentary (check containment tránh đọc lặp — prompt
+  rewriter không nói rõ script có chứa hook hay không). Chạy 06:40
+  (`com.ai5phut.drama-pipeline.plist`), sau collector 06:06, trước pipeline
+  AI 07:00.
+- **`storage/quota.py`** — đếm unit YouTube API (upload 1600, thumbnail 50,
+  caption 400) theo NGÀY PACIFIC (quota Google reset nửa đêm PT, không phải
+  giờ VN); alert Telegram đúng 1 lần khi băng qua
+  `YOUTUBE_DAILY_QUOTA × QUOTA_ALERT_RATIO` (mặc định 10000 × 0.8).
+- **`webui/health.py`** — `python -m webui.health` → `GET /health`
+  (127.0.0.1, port `HEALTH_PORT`=8686): videos/stories theo status, queue
+  scheduler, quota hôm nay, last_success collectors. Mỗi section bọc lỗi
+  riêng — DB thiếu bảng không làm sập cả payload.
+- Migration 006 (`scheduled_posts`, `quota_usage`, cột
+  `videos.story_id/thumbnail_path/review_note`) — chạy
+  `python -m storage.migrate up` sau khi pull.
+- TikTok Content Posting API uploader (`publisher/tiktok_uploader.py`) có từ
+  trước, giữ nguyên — phần "3-step upload" của doc đã được cover; approval
+  app TikTok là task external (2-4 tuần), pipeline không block nhờ queue tay.
 
 ---
 

--- a/content-pipeline/.gitignore
+++ b/content-pipeline/.gitignore
@@ -8,8 +8,11 @@ logs/*.log
 .DS_Store
 output/long/
 output/short/
+output/drama/
+queue_tiktok/
 publisher/.youtube_token*.json
 notifier/.telegram_offset
 notifier/.seed_state.json
+notifier/.review_state.json
 video/assets/backgrounds/*.mp4
 video/assets/fonts/*.ttf

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -110,6 +110,21 @@ YOUTUBE_DRAMA_CHANNEL_ID = os.getenv("YOUTUBE_DRAMA_CHANNEL_ID", "")
 TIKTOK_TOKEN = os.getenv("TIKTOK_TOKEN", "")
 TIKTOK_OPEN_ID = os.getenv("TIKTOK_OPEN_ID", "")
 
+# --- Distribution (Phase 5) ---
+# privacyStatus khi upload YouTube. Đặt "unlisted" khi chạy E2E test để video
+# test không public (phase-5-issues.md EPIC #5.2).
+YOUTUBE_PRIVACY = os.getenv("YOUTUBE_PRIVACY", "public")
+# Quota YouTube Data API v3 mỗi ngày/project + ngưỡng alert (storage/quota.py).
+YOUTUBE_DAILY_QUOTA = int(os.getenv("YOUTUBE_DAILY_QUOTA", "10000"))
+QUOTA_ALERT_RATIO = float(os.getenv("QUOTA_ALERT_RATIO", "0.8"))
+# Số story Drama tối đa render thành video mỗi lần chạy main_drama.py
+# (kiểm soát chi phí TTS/render, giống MAX_DEEP_ANALYSIS cho track AI).
+DRAMA_VIDEOS_PER_RUN = int(os.getenv("DRAMA_VIDEOS_PER_RUN", "2"))
+# Thư mục queue cho TikTok upload tay (publisher/tiktok_manual.py).
+TIKTOK_QUEUE_DIR = os.path.join(os.path.dirname(__file__), "queue_tiktok")
+# Health endpoint (webui/health.py) — chỉ bind 127.0.0.1.
+HEALTH_PORT = int(os.getenv("HEALTH_PORT", "8686"))
+
 # --- Video engine flags (Video Enhancement roadmap; default = legacy behaviour) ---
 # Each flag has a "legacy" default so the pipeline behaves exactly as before
 # unless explicitly opted in. See docs/current/video-enhancement/.

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -15,6 +15,8 @@ cp com.ai5phut.pipeline.plist ~/Library/LaunchAgents/
 cp com.ai5phut.bot.plist ~/Library/LaunchAgents/
 cp com.ai5phut.reddit-drama.plist ~/Library/LaunchAgents/
 cp com.ai5phut.drama-health.plist ~/Library/LaunchAgents/
+cp com.ai5phut.drama-pipeline.plist ~/Library/LaunchAgents/
+cp com.ai5phut.post-scheduler.plist ~/Library/LaunchAgents/
 ```
 
 ## Bước 3: Load services
@@ -32,6 +34,12 @@ launchctl load ~/Library/LaunchAgents/com.ai5phut.reddit-drama.plist
 # Load Drama collector health check (chạy 06:30 + 18:30 — alert Telegram nếu
 # reddit_drama chưa chạy thành công quá 2 ngày)
 launchctl load ~/Library/LaunchAgents/com.ai5phut.drama-health.plist
+
+# Load Drama orchestrator (chạy 06:40 sáng — collect→score→rewrite→render→review, Phase 5)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.drama-pipeline.plist
+
+# Load post scheduler (tick mỗi 5 phút — upload video đã duyệt đúng giờ cadence, Phase 5)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.post-scheduler.plist
 ```
 
 ## Bước 4: Kiểm tra
@@ -64,4 +72,11 @@ cd ~/ContentCreator/content-pipeline && python3 -m collectors.reddit_drama_colle
 
 # Chạy health check thủ công
 cd ~/ContentCreator/content-pipeline && python3 -m storage.collector_health
+
+# Chạy Drama orchestrator thủ công (Phase 5; --step render để chạy riêng 1 bước)
+cd ~/ContentCreator/content-pipeline && python3 main_drama.py
+
+# Xem/kick queue upload thủ công (Phase 5)
+cd ~/ContentCreator/content-pipeline && python3 -m scheduler.post_scheduler list
+cd ~/ContentCreator/content-pipeline && python3 -m scheduler.post_scheduler tick
 ```

--- a/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.drama-pipeline</string>
+
+    <!-- Use the venv Python directly.
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>main_drama.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- 06:40 sáng — sau reddit_drama_collector (06:06) để có story mới;
+         trước pipeline AI (07:00) để 2 pipeline không giành TTS/ffmpeg cùng lúc.
+         (Phase 5 — Drama orchestrator end-to-end) -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>40</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_pipeline_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_pipeline_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
+++ b/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.post-scheduler</string>
+
+    <!-- Use the venv Python directly.
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>-m</string>
+        <string>scheduler.post_scheduler</string>
+        <string>tick</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- Tick mỗi 5 phút (Phase 5 — Distribution): upload các post tới giờ
+         theo cadence. Acceptance: đúng giờ ±5 phút. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/post_scheduler_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/post_scheduler_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -81,6 +81,30 @@ def build_narration(rewrite: dict) -> str:
     return "\n\n".join(parts)
 
 
+def _repush_stuck_reviews() -> int:
+    """Gửi duyệt lại video drama đã render xong nhưng chưa tới tay reviewer.
+
+    push_review() lỗi (Telegram down lúc render) để video kẹt 'ready' trong
+    khi story đã 'produced' — resume guard chặn render lại nên không gì tự
+    đẩy video đó vào flow duyệt nữa (finding của Codex review PR #70). Mỗi
+    lần chạy render, thử push lại các video như vậy; thành công thì
+    push_review tự chuyển 'pending_approval' nên không bao giờ push trùng.
+    """
+    from storage.database import get_videos_by_status
+    from notifier.review_bot import push_review
+    count = 0
+    for video in get_videos_by_status("ready"):
+        if video.get("track") != "drama":
+            continue
+        if push_review(video["id"]):
+            count += 1
+        else:
+            logger.warning("Re-push review failed again for video %d", video["id"])
+    if count:
+        logger.info("Re-pushed %d stuck 'ready' drama video(s) for review", count)
+    return count
+
+
 def render_approved_stories(limit: int | None = None) -> list[int]:
     """Render các story 'approved' (đã Việt hoá) thành video + push review.
 
@@ -88,6 +112,7 @@ def render_approved_stories(limit: int | None = None) -> list[int]:
     không tính vào limit.
     """
     limit = limit if limit is not None else config.DRAMA_VIDEOS_PER_RUN
+    _repush_stuck_reviews()
     stories = get_by_status("approved", limit=limit * 3, track="drama")
     created: list[int] = []
     for story in stories:
@@ -221,9 +246,9 @@ def _render_story(story: dict) -> int | None:
 
     from notifier.review_bot import push_review
     if not push_review(video_id):
-        logger.error("Could not push video %d for review — video stays 'ready', "
-                     "re-push by re-running with --step render (resume guard sẽ "
-                     "bỏ qua render, chỉ cần push tay)", video_id)
+        logger.error("Could not push video %d for review — video stays 'ready'; "
+                     "_repush_stuck_reviews() sẽ tự gửi lại ở lần chạy render sau",
+                     video_id)
 
     logger.info("Story %d rendered → video %d (%.0fs audio)", story_id, video_id, duration)
     return video_id

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+"""
+Drama Track Orchestrator (Phase 5 EPIC #5.4) — pipeline end-to-end:
+
+1. Collect  — Reddit RSS+JSON (Phase 2, collectors/reddit_drama_collector.py)
+2. Score    — rubric 6 tiêu chí bằng Haiku (Phase 3, processors/drama_scorer.py)
+3. Rewrite  — Việt hoá bằng Sonnet (Phase 3, processors/drama_rewriter.py)
+4. Render   — TTS + phụ đề + multi-scene composer (Phase 4, video/drama_composer.py)
+5. Review   — push preview + nút ✅/❌/✏️ (Phase 5, notifier/review_bot.py)
+6. Schedule — khi ✅, bot xếp lịch qua scheduler/post_scheduler.py (Phase 5)
+
+Resume-from-crash: mỗi bước đọc trạng thái từ DB thay vì nhớ trong RAM —
+story đi 'pending' → (scored) → 'approved' → 'produced'; video đi 'draft' →
+'ready' → 'pending_approval' → 'approved' → 'published'. Chạy lại sau crash:
+- collector dedupe theo source_id (Phase 2);
+- scorer/rewriter chỉ nhặt story chưa có rubric_score/rewritten_content;
+- render bỏ qua story đã có video row (videos.story_id, migration 006) — một
+  lần crash giữa render không bao giờ tạo 2 video cho 1 story;
+- upload dedupe nằm ở scheduler (claim + platform_video_id).
+
+Chạy: python main_drama.py [--step collect|score|rewrite|render] [--limit N]
+(không có --step = chạy đủ các bước).
+"""
+
+import argparse
+import json
+import logging
+import logging.handlers
+import os
+import sys
+from datetime import date, datetime
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import config
+from storage.database import (
+    init_db, insert_video, update_video_paths, update_video_status,
+    update_video_metadata, get_videos_by_story, set_video_subtitles_burned,
+)
+from storage.stories import get_by_status, update_status
+
+LOGS_DIR = os.path.join(os.path.dirname(__file__), "logs")
+os.makedirs(LOGS_DIR, exist_ok=True)
+
+logging.basicConfig(
+    level=getattr(logging, config.LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.handlers.RotatingFileHandler(
+            os.path.join(LOGS_DIR, "drama_pipeline.log"),
+            maxBytes=5 * 1024 * 1024, backupCount=3, encoding="utf-8",
+        ),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+DRAMA_DESTINATION = "drama_youtube"  # khoá trong channels.py
+
+
+def build_narration(rewrite: dict) -> str:
+    """Ghép text TTS từ output rewriter: hook + script + vn_commentary.
+
+    Prompt rewriter (prompts/drama/rewriter.v1.txt) trả hook/vn_commentary
+    thành FIELD RIÊNG nhưng script cũng có cấu trúc "Hook → ... → Reflection",
+    nên model có thể đã lặp hook/commentary bên trong script. Kiểm tra
+    containment trước khi ghép để không đọc trùng 2 lần.
+    """
+    script = (rewrite.get("script") or "").strip()
+    hook = (rewrite.get("hook") or "").strip()
+    commentary = (rewrite.get("vn_commentary") or "").strip()
+
+    parts = []
+    if hook and hook not in script:
+        parts.append(hook)
+    if script:
+        parts.append(script)
+    if commentary and commentary not in script:
+        parts.append(commentary)
+    return "\n\n".join(parts)
+
+
+def render_approved_stories(limit: int | None = None) -> list[int]:
+    """Render các story 'approved' (đã Việt hoá) thành video + push review.
+
+    Returns list video_id đã tạo. Story đã có video (resume guard) bị bỏ qua
+    không tính vào limit.
+    """
+    limit = limit if limit is not None else config.DRAMA_VIDEOS_PER_RUN
+    stories = get_by_status("approved", limit=limit * 3, track="drama")
+    created: list[int] = []
+    for story in stories:
+        if len(created) >= limit:
+            break
+        # Resume guard: row 'failed' (lỗi transient đã phát hiện — TTS chết,
+        # ffmpeg lỗi) KHÔNG chặn retry; mọi row khác (kể cả 'draft' do crash
+        # giữa render — không biết đã đi tới đâu) chặn auto-render lại, chờ
+        # người xử lý tay.
+        existing = [v for v in get_videos_by_story(story["id"])
+                    if v.get("status") not in ("failed", "rejected")]
+        if existing:
+            logger.info("Story %d already has video %s — skipping (resume guard)",
+                        story["id"], [v["id"] for v in existing])
+            continue
+        video_id = _render_story(story)
+        if video_id:
+            created.append(video_id)
+    logger.info("Rendered %d drama video(s): %s", len(created), created)
+    return created
+
+
+def _render_story(story: dict) -> int | None:
+    """Render 1 story: TTS → subtitle → compose → DB → push review.
+
+    Thứ tự ghi DB cho resume an toàn: insert video row (gắn story_id) TRƯỚC
+    khi render — crash giữa render để lại row 'draft' + story vẫn 'approved',
+    lần chạy sau resume guard thấy row là bỏ qua (người xử lý tay row draft
+    mồ côi, thay vì pipeline tự render trùng). Lỗi transient PHÁT HIỆN ĐƯỢC
+    (TTS/ffmpeg trả lỗi) thì row chuyển 'failed' → lần chạy sau tự retry.
+    Story chỉ chuyển 'produced' sau khi render xong toàn bộ.
+    """
+    def _fail(video_id: int, why: str) -> None:
+        # Lỗi transient đã phát hiện → row 'failed' để lần chạy sau tự retry
+        # (resume guard bỏ qua row failed); khác với crash (row kẹt 'draft').
+        logger.error("%s — video %d marked failed for retry", why, video_id)
+        update_video_status(video_id, "failed")
+
+    story_id = story["id"]
+    try:
+        rewrite = json.loads(story.get("rewritten_content") or "")
+    except (json.JSONDecodeError, TypeError):
+        logger.error("Story %d has malformed rewritten_content — flagging needs_review",
+                     story_id)
+        update_status(story_id, "needs_review")
+        return None
+
+    narration = build_narration(rewrite)
+    if not narration:
+        logger.error("Story %d has empty narration — flagging needs_review", story_id)
+        update_status(story_id, "needs_review")
+        return None
+
+    title = rewrite.get("title", "") or (story.get("title") or "")
+    tags = rewrite.get("tags") or []
+    hashtags = " ".join(f"#{str(t).strip().lstrip('#').replace(' ', '')}"
+                        for t in tags if str(t).strip())
+
+    video_id = insert_video(
+        video_type="short",
+        script_text=narration,
+        youtube_title=title,
+        youtube_description=(rewrite.get("hook", "") or title),
+        tiktok_caption=title,
+        tiktok_hashtags=hashtags,
+        track="drama",
+        destination=DRAMA_DESTINATION,
+        story_id=story_id,
+    )
+
+    base_dir = os.path.join(config.VIDEO_OUTPUT_DIR, "drama", date.today().isoformat())
+    os.makedirs(base_dir, exist_ok=True)
+
+    # TTS với voice riêng của track drama (Phase 4).
+    from video.tts_client import synthesize_for_track, get_audio_duration
+    from video.text_preprocessor import preprocess_for_tts
+    audio_path = os.path.join(base_dir, f"audio_{video_id}.mp3")
+    if not synthesize_for_track(preprocess_for_tts(narration), "drama", audio_path):
+        _fail(video_id, f"TTS failed for story {story_id}")
+        return None
+    duration = get_audio_duration(audio_path)
+    if duration <= 0:
+        _fail(video_id, f"Cannot determine audio duration for story {story_id}")
+        return None
+
+    # Subtitle: whisper-aligned nếu bật, fallback word-count (same as track AI).
+    from video.subtitle_generator import generate_srt, write_entries_srt
+    srt_path = os.path.join(base_dir, f"subtitle_{video_id}.srt")
+    entries = None
+    if config.SUBTITLE_TIMING_MODE == "whisper":
+        try:
+            from video.subtitle_aligner import align
+            entries = align(audio_path, narration)
+        except Exception as e:
+            logger.warning("Whisper alignment error: %s — using word-count", e)
+    result = (write_entries_srt(entries, srt_path) if entries
+              else generate_srt(narration, duration, srt_path))
+    if not result:
+        _fail(video_id, f"Subtitle generation failed for story {story_id}")
+        return None
+
+    # Compose multi-scene (Phase 4). Drama là video short — burn theo policy.
+    burn = config.should_burn_subtitles("short")
+    from video.drama_composer import compose_drama_video
+    video_path = os.path.join(base_dir, f"video_{video_id}.mp4")
+    if not compose_drama_video(
+        audio_path, srt_path if burn else None, video_path,
+        thumbnail_prompt=rewrite.get("thumbnail_prompt"),
+        vn_commentary=rewrite.get("vn_commentary"),
+    ):
+        _fail(video_id, f"Composition failed for story {story_id}")
+        return None
+
+    update_video_paths(video_id, audio_path=audio_path, subtitle_path=srt_path,
+                       video_path=video_path)
+    set_video_subtitles_burned(video_id, burn)
+
+    # Thumbnail (best-effort): tái dùng illustration đã cache cho scene đầu —
+    # cùng (prompt, index=0) nên thường là cache hit, không tốn thêm API call.
+    try:
+        from video.image_generator import generate_illustration
+        thumb = generate_illustration(rewrite.get("thumbnail_prompt", ""), index=0)
+        if thumb:
+            update_video_metadata(video_id, thumbnail_path=thumb)
+    except Exception as e:
+        logger.warning("Thumbnail generation failed (non-fatal): %s", e)
+
+    update_video_status(video_id, "ready")
+    update_status(story_id, "produced",
+                  produced_at=datetime.now().isoformat(sep=" ", timespec="seconds"))
+
+    from notifier.review_bot import push_review
+    if not push_review(video_id):
+        logger.error("Could not push video %d for review — video stays 'ready', "
+                     "re-push by re-running with --step render (resume guard sẽ "
+                     "bỏ qua render, chỉ cần push tay)", video_id)
+
+    logger.info("Story %d rendered → video %d (%.0fs audio)", story_id, video_id, duration)
+    return video_id
+
+
+def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
+    """Chạy pipeline Drama. `steps` None = đủ 4 bước. Returns summary dict."""
+    logger.info("=== Drama pipeline started ===")
+    init_db()
+    steps = steps or ["collect", "score", "rewrite", "render"]
+    summary: dict = {"errors": []}
+
+    if "collect" in steps:
+        try:
+            from collectors.reddit_drama_collector import collect_all_drama
+            summary["collected"] = collect_all_drama()
+        except Exception as e:
+            logger.error("Collect failed: %s", e)
+            summary["errors"].append(f"collect: {e}")
+
+    if "score" in steps:
+        try:
+            from processors.drama_scorer import score_all_pending
+            summary["scored"] = score_all_pending()
+        except Exception as e:
+            logger.error("Score failed: %s", e)
+            summary["errors"].append(f"score: {e}")
+
+    if "rewrite" in steps:
+        try:
+            from processors.drama_rewriter import rewrite_all_scored
+            summary["rewritten"] = rewrite_all_scored()
+        except Exception as e:
+            logger.error("Rewrite failed: %s", e)
+            summary["errors"].append(f"rewrite: {e}")
+
+    if "render" in steps:
+        try:
+            summary["rendered"] = render_approved_stories(limit=limit)
+        except Exception as e:
+            logger.error("Render failed: %s", e)
+            summary["errors"].append(f"render: {e}")
+
+    _send_summary_safe(summary)
+    logger.info("=== Drama pipeline completed: %s ===", summary)
+    return summary
+
+
+def _send_summary_safe(summary: dict) -> None:
+    try:
+        from notifier.telegram_bot import send_alert
+        lines = [f"🎭 DRAMA PIPELINE — {date.today().strftime('%d/%m/%Y')}"]
+        if "collected" in summary:
+            lines.append(f"📥 Thu thập: {summary['collected']} story mới")
+        if "scored" in summary:
+            lines.append(f"🎯 Chấm điểm: {summary['scored']} story")
+        if "rewritten" in summary:
+            lines.append(f"✍️ Việt hoá: {summary['rewritten']} story")
+        if "rendered" in summary:
+            n = len(summary["rendered"])
+            lines.append(f"🎬 Render: {n} video" +
+                         (" (đã gửi duyệt — kiểm tra Telegram)" if n else ""))
+        if summary["errors"]:
+            lines.append(f"⚠️ Lỗi ({len(summary['errors'])}):")
+            lines += [f"  • {e}" for e in summary["errors"][:5]]
+        send_alert("\n".join(lines))
+    except Exception as e:
+        logger.warning("Summary notification failed (non-fatal): %s", e)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Drama track orchestrator (Phase 5)")
+    parser.add_argument("--step", choices=["collect", "score", "rewrite", "render"],
+                        action="append", dest="steps",
+                        help="Chạy riêng 1 bước (lặp lại flag để chạy nhiều bước); "
+                             "bỏ trống = chạy đủ pipeline")
+    parser.add_argument("--limit", type=int, default=None,
+                        help=f"Số video render tối đa (mặc định "
+                             f"DRAMA_VIDEOS_PER_RUN={config.DRAMA_VIDEOS_PER_RUN})")
+    args = parser.parse_args()
+    run_daily(steps=args.steps, limit=args.limit)

--- a/content-pipeline/notifier/review_bot.py
+++ b/content-pipeline/notifier/review_bot.py
@@ -168,23 +168,29 @@ def push_review(video_id: int) -> bool:
     if preview_path:
         msg_id = telegram_bot._send_video_file(
             preview_path, caption, reply_markup=review_keyboard(video_id))
+    keyboard_delivered = bool(msg_id)
     if msg_id:
         from storage.database import update_video_telegram_id
         update_video_telegram_id(video_id, str(msg_id))
     else:
         # Video không gửi được — nút bấm vẫn phải tới tay reviewer.
-        telegram_bot.send_message_with_keyboard(
+        keyboard_delivered = telegram_bot.send_message_with_keyboard(
             caption + "\n\n⚠️ Không gửi được file video qua Telegram — "
                       "duyệt dựa trên script ở trên.",
             review_keyboard(video_id),
         )
 
-    reviewable = script_sent or bool(msg_id)
-    if reviewable:
+    # Reviewability = INLINE KEYBOARD đã tới tay reviewer. Khác tiêu chí cũ
+    # (script HOẶC video, issue #60): với review gate, nút ✅ là actuator duy
+    # nhất route đúng qua scheduler — script suông không duyệt được (finding
+    # Codex review PR #70). Không gửi được keyboard → giữ status để
+    # main_drama._repush_stuck_reviews() thử lại lần chạy sau.
+    if keyboard_delivered:
         update_video_status(video_id, "pending_approval")
-        logger.info("Video %d pushed for review (video_sent=%s)", video_id, bool(msg_id))
+        logger.info("Video %d pushed for review (video_sent=%s, script_sent=%s)",
+                    video_id, bool(msg_id), script_sent)
         return True
-    logger.error("Video %d: could not deliver script nor video — staying put", video_id)
+    logger.error("Video %d: could not deliver review keyboard — staying put", video_id)
     return False
 
 
@@ -243,12 +249,18 @@ def _approve(video_id: int) -> str:
 
     lines = [f"✅ Video {video_id} đã duyệt."]
     for channel_key in _destinations_for(video):
-        channel = get_channel(channel_key)
+        # get_channel nằm TRONG try: destination sai/cũ (không còn trong
+        # registry) chỉ làm hỏng kênh đó và được báo lại kèm lệnh xếp lịch
+        # tay, không nổ cả handler sau khi video đã claim 'approved'.
         try:
+            channel = get_channel(channel_key)
             lines.append(_route_to_channel(video, channel_key, channel))
         except Exception as e:
             logger.exception("Routing video %d to %s failed", video_id, channel_key)
-            lines.append(f"  ❌ {channel_key}: lỗi xếp lịch — {e}")
+            lines.append(
+                f"  ❌ {channel_key}: lỗi xếp lịch — {e}\n"
+                f"     Xếp tay: python -m scheduler.post_scheduler "
+                f"schedule {video_id} <channel_key>")
     if len(lines) == 1:
         lines.append("  ⚠️ Không xác định được kênh đích — xếp lịch tay: "
                      f"python -m scheduler.post_scheduler schedule {video_id} <channel_key>")

--- a/content-pipeline/notifier/review_bot.py
+++ b/content-pipeline/notifier/review_bot.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+"""
+Review Bot (Phase 5 EPIC #5.1 — Telegram Review Gate).
+
+Push video preview (<50MB, tự nén nếu quá cỡ — video/preview.py) kèm inline
+keyboard ✅ Duyệt / ❌ Loại / ✏️ Sửa metadata. Approve → xếp lịch upload qua
+scheduler/post_scheduler.py (KHÔNG publish ngay như flow /approve cũ của
+track AI); TikTok chưa có API token thì export thẳng vào queue tay.
+
+Khác phase-5-detailed.md: doc vẽ review_bot như một bot mới; thực tế đây là
+các HANDLER THUẦN được notifier/telegram_bot.py gọi trong CÙNG vòng
+long-polling đang chạy — cùng lý do với seed_bot Phase 2 (Telegram chỉ cho 1
+getUpdates connection mỗi bot token; process thứ hai sẽ 409 Conflict liên tục).
+
+State hội thoại (đang chờ nhập lý do reject / giá trị metadata mới) lưu ở
+`notifier/.review_state.json`, sống qua restart — giống `.seed_state.json`.
+"""
+
+import json
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from channels import get_channel, channels_for_track
+from storage.database import (
+    get_video, claim_video_status, update_video_status, update_video_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = os.path.join(os.path.dirname(__file__), ".review_state.json")
+
+# Field cho nút ✏️ — key ngắn (callback_data giới hạn 64 byte) → cột DB.
+# Cột DB phải nằm trong database._VIDEO_METADATA_FIELDS.
+EDITABLE_FIELDS = {
+    "title": ("youtube_title", "Tiêu đề YouTube"),
+    "desc": ("youtube_description", "Mô tả YouTube"),
+    "cap": ("tiktok_caption", "Caption TikTok"),
+    "tags": ("tiktok_hashtags", "Hashtags TikTok"),
+}
+
+_CALLBACK_PREFIX = "rv"
+
+
+# --- State (persisted qua restart, như seed_bot) ---
+
+def _get_state() -> dict | None:
+    if not os.path.exists(_STATE_FILE):
+        return None
+    try:
+        with open(_STATE_FILE) as f:
+            return json.load(f) or None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _set_state(state: dict | None) -> None:
+    try:
+        if state is None:
+            if os.path.exists(_STATE_FILE):
+                os.remove(_STATE_FILE)
+            return
+        with open(_STATE_FILE, "w") as f:
+            json.dump(state, f)
+    except OSError as e:
+        logger.warning("Cannot persist review state: %s", e)
+
+
+def skip_awaiting() -> str | None:
+    """Huỷ state đang chờ (lệnh /skip). Returns reply, None nếu không có state."""
+    state = _get_state()
+    if state is None:
+        return None
+    _set_state(None)
+    return "✅ Đã bỏ qua."
+
+
+# --- Push review ---
+
+def review_keyboard(video_id: int) -> dict:
+    return {"inline_keyboard": [
+        [
+            {"text": "✅ Duyệt", "callback_data": f"{_CALLBACK_PREFIX}:a:{video_id}"},
+            {"text": "❌ Loại", "callback_data": f"{_CALLBACK_PREFIX}:r:{video_id}"},
+        ],
+        [
+            {"text": "✏️ Sửa metadata", "callback_data": f"{_CALLBACK_PREFIX}:e:{video_id}"},
+        ],
+    ]}
+
+
+def _story_hook(video: dict) -> str:
+    """Hook từ rewritten_content của story gốc (nếu là video Drama)."""
+    story_id = video.get("story_id")
+    if not story_id:
+        return ""
+    try:
+        from storage.stories import get_story
+        story = get_story(story_id)
+        rewritten = json.loads(story.get("rewritten_content") or "{}") if story else {}
+        return rewritten.get("hook", "")
+    except Exception:
+        return ""
+
+
+def push_review(video_id: int) -> bool:
+    """Gửi preview + inline keyboard cho reviewer, set status pending_approval.
+
+    Giữ nguyên triết lý issue #60: script text là review artifact chính —
+    video preview gửi hỏng/quá cỡ (kể cả sau khi nén) thì reviewer vẫn duyệt
+    được bằng script + nút bấm.
+    """
+    from notifier import telegram_bot
+
+    video = get_video(video_id)
+    if not video:
+        logger.error("push_review: video %d not found", video_id)
+        return False
+    video_path = video.get("video_path")
+    if not video_path or not os.path.exists(video_path):
+        logger.error("push_review: file missing for video %d: %s", video_id, video_path)
+        return False
+
+    destination = video.get("destination") or ""
+    channel_name = ""
+    if destination:
+        try:
+            channel_name = get_channel(destination)["name"]
+        except ValueError:
+            logger.warning("Video %d has unknown destination %r", video_id, destination)
+    hook = _story_hook(video)
+    title = video.get("youtube_title", "") or video.get("tiktok_caption", "")
+
+    # 1. Script = review artifact chính (như send_video_for_approval cũ).
+    script_sent = False
+    script_text = video.get("script_text", "")
+    if script_text:
+        word_count = len(script_text.split())
+        script_sent = telegram_bot._send_text(
+            f"📋 SCRIPT VIDEO #{video_id} — ĐỌC VÀ DUYỆT\n"
+            f"{'=' * 30}\n"
+            f"📝 Tiêu đề: {title}\n"
+            f"📊 Độ dài: {word_count} từ\n"
+            f"{'=' * 30}\n\n"
+            f"{script_text}"
+        )
+
+    # 2. Video preview (nén nếu >50MB) + nút bấm.
+    from video.preview import compress_for_preview
+    preview_path = compress_for_preview(video_path)
+    caption_lines = [f"🎬 VIDEO #{video_id} CHỜ DUYỆT"]
+    if video.get("story_id"):
+        caption_lines.append(f"📖 Story #{video['story_id']}")
+    if destination:
+        caption_lines.append(
+            f"📺 Kênh: {destination}" + (f" ({channel_name})" if channel_name else ""))
+    if hook:
+        caption_lines.append(f"🪝 Hook: {hook}")
+    if title:
+        caption_lines.append(f"📝 Tiêu đề: {title}")
+    if preview_path and preview_path != video_path:
+        caption_lines.append("ℹ️ Bản preview đã nén — file gốc dùng để upload.")
+    caption = "\n".join(caption_lines)
+
+    msg_id = None
+    if preview_path:
+        msg_id = telegram_bot._send_video_file(
+            preview_path, caption, reply_markup=review_keyboard(video_id))
+    if msg_id:
+        from storage.database import update_video_telegram_id
+        update_video_telegram_id(video_id, str(msg_id))
+    else:
+        # Video không gửi được — nút bấm vẫn phải tới tay reviewer.
+        telegram_bot.send_message_with_keyboard(
+            caption + "\n\n⚠️ Không gửi được file video qua Telegram — "
+                      "duyệt dựa trên script ở trên.",
+            review_keyboard(video_id),
+        )
+
+    reviewable = script_sent or bool(msg_id)
+    if reviewable:
+        update_video_status(video_id, "pending_approval")
+        logger.info("Video %d pushed for review (video_sent=%s)", video_id, bool(msg_id))
+        return True
+    logger.error("Video %d: could not deliver script nor video — staying put", video_id)
+    return False
+
+
+# --- Callback handling (nút bấm) ---
+
+def handle_callback(data: str) -> tuple[str, dict | None]:
+    """Xử lý callback_data `rv:*`. Returns (reply_text, keyboard | None).
+
+    Pure DB/state — network (answerCallbackQuery, sendMessage) do
+    telegram_bot lo, nên unit-test không cần mock HTTP.
+    """
+    parts = (data or "").split(":")
+    if len(parts) < 3 or parts[0] != _CALLBACK_PREFIX:
+        return "⚠️ Callback không hợp lệ.", None
+    action = parts[1]
+    try:
+        video_id = int(parts[2])
+    except ValueError:
+        return "⚠️ Callback không hợp lệ.", None
+
+    if action == "a":
+        return _approve(video_id), None
+    if action == "r":
+        return _reject(video_id), None
+    if action == "e":
+        if not get_video(video_id):
+            return f"⚠️ Video {video_id} không tồn tại.", None
+        keyboard = {"inline_keyboard": [[
+            {"text": label, "callback_data": f"{_CALLBACK_PREFIX}:ef:{video_id}:{key}"}
+        ] for key, (_, label) in EDITABLE_FIELDS.items()]}
+        return f"✏️ Video #{video_id} — chọn field cần sửa:", keyboard
+    if action == "ef" and len(parts) >= 4:
+        field_key = parts[3]
+        if field_key not in EDITABLE_FIELDS:
+            return "⚠️ Field không hợp lệ.", None
+        video = get_video(video_id)
+        if not video:
+            return f"⚠️ Video {video_id} không tồn tại.", None
+        column, label = EDITABLE_FIELDS[field_key]
+        current = video.get(column, "") or "(trống)"
+        _set_state({"mode": "edit", "video_id": video_id, "field": field_key})
+        return (f"✏️ {label} hiện tại:\n{current}\n\n"
+                f"Nhập giá trị mới (hoặc /skip để giữ nguyên):"), None
+    return "⚠️ Callback không hợp lệ.", None
+
+
+def _approve(video_id: int) -> str:
+    """✅: claim pending_approval → approved, rồi xếp lịch/queue mọi kênh đích."""
+    video = get_video(video_id)
+    if not video:
+        return f"⚠️ Video {video_id} không tồn tại."
+    if not claim_video_status(video_id, "approved", "pending_approval"):
+        current = get_video(video_id)
+        return (f"⚠️ Video {video_id} không ở trạng thái chờ duyệt "
+                f"(status={current.get('status') if current else '?'}).")
+
+    lines = [f"✅ Video {video_id} đã duyệt."]
+    for channel_key in _destinations_for(video):
+        channel = get_channel(channel_key)
+        try:
+            lines.append(_route_to_channel(video, channel_key, channel))
+        except Exception as e:
+            logger.exception("Routing video %d to %s failed", video_id, channel_key)
+            lines.append(f"  ❌ {channel_key}: lỗi xếp lịch — {e}")
+    if len(lines) == 1:
+        lines.append("  ⚠️ Không xác định được kênh đích — xếp lịch tay: "
+                     f"python -m scheduler.post_scheduler schedule {video_id} <channel_key>")
+    return "\n".join(lines)
+
+
+def _route_to_channel(video: dict, channel_key: str, channel: dict) -> str:
+    """Xếp lịch 1 kênh (YouTube/TikTok-API) hoặc export queue tay (TikTok chưa token)."""
+    import config
+    if channel["platform"] == "tiktok" and not config.TIKTOK_ACCESS_TOKEN:
+        from publisher.tiktok_manual import export_for_manual_upload
+        exported = export_for_manual_upload(video["id"])
+        if exported:
+            return f"  📁 {channel_key}: đã bỏ vào queue upload tay ({exported})"
+        return f"  ❌ {channel_key}: export queue tay thất bại (xem log)"
+
+    from scheduler.post_scheduler import schedule_video
+    post = schedule_video(video["id"], channel_key)
+    if post:
+        return f"  🗓 {channel_key}: đăng lúc {post['scheduled_at']}"
+    return f"  ❌ {channel_key}: không xếp được lịch (xem log)"
+
+
+def _destinations_for(video: dict) -> list[str]:
+    """Các channel key video này sẽ đi tới sau khi duyệt.
+
+    - `destination` (đã set lúc render) luôn được tôn trọng.
+    - Video SHORT còn được nhân bản sang các kênh TikTok nhận track đó
+      (channels.py: tiktok_main là account mixed) — đúng cadence doc:
+      drama shorts → drama_youtube + tiktok.
+    - Không có destination → suy từ track qua channel registry.
+    """
+    track = video.get("track") or "ai"
+    is_short = video.get("video_type") == "short"
+    result = []
+    destination = video.get("destination")
+    if destination:
+        result.append(destination)
+        for key, channel in channels_for_track(track).items():
+            if key != destination and channel["platform"] == "tiktok" \
+                    and is_short and channel["format_shorts"]:
+                result.append(key)
+        return result
+    for key, channel in channels_for_track(track).items():
+        if is_short and channel["format_shorts"]:
+            result.append(key)
+        elif not is_short and channel["format_long"]:
+            result.append(key)
+    return result
+
+
+def _reject(video_id: int) -> str:
+    """❌: đánh dấu rejected rồi chờ 1 message lý do (lưu vào review_note)."""
+    video = get_video(video_id)
+    if not video:
+        return f"⚠️ Video {video_id} không tồn tại."
+    if not claim_video_status(video_id, "rejected", "pending_approval"):
+        current = get_video(video_id)
+        return (f"⚠️ Video {video_id} không ở trạng thái chờ duyệt "
+                f"(status={current.get('status') if current else '?'}).")
+    _set_state({"mode": "reject_reason", "video_id": video_id})
+    return (f"❌ Video {video_id} đã loại.\n"
+            f"Nhập lý do để lưu lại (hoặc /skip để bỏ qua):")
+
+
+# --- Plain-message handling (FSM đang chờ input) ---
+
+def handle_awaiting_message(text: str) -> str | None:
+    """Xử lý message thường khi đang chờ input. None = không có state chờ
+    (telegram_bot sẽ chuyển tiếp cho seed_bot)."""
+    state = _get_state()
+    if state is None:
+        return None
+    video_id = state.get("video_id")
+    mode = state.get("mode")
+
+    if mode == "reject_reason":
+        _set_state(None)
+        try:
+            update_video_metadata(video_id, review_note=text.strip())
+        except Exception as e:
+            logger.error("Cannot save reject reason for video %s: %s", video_id, e)
+            return "⚠️ Không lưu được lý do (xem log)."
+        return f"📝 Đã lưu lý do loại video {video_id}."
+
+    if mode == "edit":
+        field_key = state.get("field", "")
+        if field_key not in EDITABLE_FIELDS:
+            _set_state(None)
+            return "⚠️ State sửa metadata không hợp lệ — đã huỷ."
+        column, label = EDITABLE_FIELDS[field_key]
+        _set_state(None)
+        try:
+            update_video_metadata(video_id, **{column: text.strip()})
+        except Exception as e:
+            logger.error("Cannot update %s for video %s: %s", column, video_id, e)
+            return "⚠️ Không cập nhật được (xem log)."
+        return f"✅ Đã cập nhật {label} cho video {video_id}:\n{text.strip()}"
+
+    _set_state(None)
+    return None
+
+
+def help_text() -> str:
+    return (
+        "🎬 Review gate (Phase 5):\n"
+        "Video mới render sẽ được gửi kèm nút ✅/❌/✏️.\n"
+        "✅ Duyệt → tự xếp lịch đăng theo cadence (không đăng ngay)\n"
+        "❌ Loại → hỏi lý do (lưu vào review_note)\n"
+        "✏️ Sửa metadata → chọn field rồi nhập giá trị mới\n"
+        "/skip — bỏ qua câu hỏi đang chờ trả lời"
+    )

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -374,6 +374,16 @@ def _handle_update(update: dict, publish_callback):
         except (ValueError, IndexError):
             _send_text("⚠️ Lệnh không hợp lệ. Dùng: /approve_<số>")
             return
+        # Video của review gate (Phase 5, có destination trong channel
+        # registry) phải đi qua scheduler routing — kể cả khi reviewer gõ
+        # lệnh cũ thay vì bấm nút ✅. publish_video() cũ nhìn
+        # scheduled_platform (rỗng với video drama) nên sẽ đăng vào hư không
+        # và chặn luôn đường retry vì status đã 'approved'.
+        if _is_review_gate_video(video_id):
+            from notifier import review_bot
+            reply, _ = review_bot.handle_callback(f"rv:a:{video_id}")
+            _send_text(reply)
+            return
         from video.review_service import approve
         # review_service performs the state transition + publish atomically.
         ok, msg = approve(video_id, publish_callback=publish_callback)
@@ -384,6 +394,11 @@ def _handle_update(update: dict, publish_callback):
             video_id = int(text.split("_", 1)[1])
         except (ValueError, IndexError):
             _send_text("⚠️ Lệnh không hợp lệ. Dùng: /reject_<số>")
+            return
+        if _is_review_gate_video(video_id):
+            from notifier import review_bot
+            reply, _ = review_bot.handle_callback(f"rv:r:{video_id}")
+            _send_text(reply)
             return
         from video.review_service import reject
         ok, msg = reject(video_id)
@@ -448,6 +463,25 @@ def _handle_update(update: dict, publish_callback):
             + review_bot.help_text() + "\n\n"
             + seed_bot.help_text()
         )
+
+
+def _is_review_gate_video(video_id: int) -> bool:
+    """Video thuộc flow review gate Phase 5 (route qua scheduler)?
+
+    Phân biệt bằng `destination`: orchestrator mới (main_drama) luôn set
+    destination từ channel registry; flow AI legacy để NULL và dùng
+    scheduled_platform + publish ngay. Sai khác này giữ 2 flow không giẫm
+    chân nhau khi cùng dùng lệnh /approve_<id>.
+
+    Lỗi DB (thiếu bảng/cột trên DB chưa migrate) → False: rơi về flow legacy
+    thay vì làm sập cả vòng xử lý update.
+    """
+    try:
+        video = get_video(video_id)
+    except Exception as e:
+        logger.warning("Cannot check review-gate flag for video %d: %s", video_id, e)
+        return False
+    return bool(video and video.get("destination"))
 
 
 def _handle_callback_query(callback_query: dict):

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -113,7 +113,15 @@ def send_video_for_approval(video_id: int) -> bool:
         f"  ❌ /reject_{video_id}"
     )
 
-    msg_id = _send_video_file(video_path, caption)
+    # Video >50MB: nén 1 bản preview riêng (Phase 5 EPIC #5.1) thay vì bỏ qua
+    # luôn như trước — reviewer được xem hình thật thay vì chỉ script. Nén
+    # thất bại → preview_path=None → giữ nguyên fallback script-only cũ.
+    from video.preview import compress_for_preview
+    preview_path = compress_for_preview(video_path)
+    if preview_path and preview_path != video_path:
+        caption += "\nℹ️ Bản preview đã nén — file gốc dùng để upload."
+
+    msg_id = _send_video_file(preview_path, caption) if preview_path else None
     if msg_id:
         update_video_telegram_id(video_id, str(msg_id))
 
@@ -328,6 +336,12 @@ def run_bot(publish_callback):
 
 def _handle_update(update: dict, publish_callback):
     """Process a single Telegram update."""
+    # Review gate (Phase 5): nút inline ✅/❌/✏️ tới dưới dạng callback_query,
+    # không phải message.
+    if "callback_query" in update:
+        _handle_callback_query(update["callback_query"])
+        return
+
     message = update.get("message", {})
     text = message.get("text", "").strip()
     chat_id = str(message.get("chat", {}).get("id", ""))
@@ -335,14 +349,23 @@ def _handle_update(update: dict, publish_callback):
     if chat_id != config.TELEGRAM_CHAT_ID:
         return
 
-    # Drama seed bot (Phase 2): a plain (non-command) message answers a
-    # pending /seed_vn or /seed_url prompt. Checked first so every command
-    # below still takes priority even in the middle of a seed conversation.
+    # Plain (non-command) messages answer whichever conversation is awaiting
+    # input: review gate FSM (reject reason / edit metadata, Phase 5) first,
+    # then drama seed bot (/seed_vn, /seed_url — Phase 2). Commands below
+    # always take priority even mid-conversation.
     if not text.startswith("/"):
-        from notifier import seed_bot
-        reply = seed_bot.handle_awaiting_message(text)
+        from notifier import review_bot, seed_bot
+        reply = review_bot.handle_awaiting_message(text)
+        if reply is None:
+            reply = seed_bot.handle_awaiting_message(text)
         if reply is not None:
             _send_text(reply)
+        return
+
+    if text == "/skip":
+        from notifier import review_bot
+        reply = review_bot.skip_awaiting()
+        _send_text(reply if reply is not None else "✨ Không có câu hỏi nào đang chờ.")
         return
 
     if text.startswith("/approve_"):
@@ -415,24 +438,56 @@ def _handle_update(update: dict, publish_callback):
         _send_text(seed_bot.list_pending_text())
 
     elif text == "/help":
-        from notifier import seed_bot
+        from notifier import review_bot, seed_bot
         _send_text(
             "📖 Lệnh bot:\n"
             "/approve_<id> — Duyệt và đăng video\n"
             "/reject_<id> — Từ chối video\n"
             "/script_<id> — Xem lại script video\n"
             "/status — Xem video đang chờ duyệt\n\n"
+            + review_bot.help_text() + "\n\n"
             + seed_bot.help_text()
         )
 
 
+def _handle_callback_query(callback_query: dict):
+    """Dispatch một lần bấm nút inline (review gate, Phase 5).
+
+    Luôn answerCallbackQuery (kể cả khi xử lý lỗi) để nút hết xoay vòng chờ
+    trên client Telegram.
+    """
+    chat_id = str(callback_query.get("message", {}).get("chat", {}).get("id", ""))
+    callback_id = callback_query.get("id", "")
+    if chat_id != config.TELEGRAM_CHAT_ID:
+        _answer_callback_query(callback_id)
+        return
+
+    data = callback_query.get("data", "")
+    try:
+        from notifier import review_bot
+        reply, keyboard = review_bot.handle_callback(data)
+    except Exception as e:
+        logger.exception("Callback handling failed for %r", data)
+        reply, keyboard = f"⚠️ Lỗi xử lý: {e}", None
+
+    _answer_callback_query(callback_id)
+    if keyboard:
+        send_message_with_keyboard(reply, keyboard)
+    else:
+        _send_text(reply)
+
+
 # --- Internal helpers ---
 
-def _send_video_file(video_path: str, caption: str) -> str | None:
+def _send_video_file(video_path: str, caption: str,
+                     reply_markup: dict | None = None) -> str | None:
     """Send a video file via Telegram sendVideo API.
 
     Telegram caption limit is 1024 chars. If caption exceeds this,
     truncate at last newline and send the full caption as a follow-up text.
+
+    `reply_markup`: inline keyboard dict (review gate, Phase 5), attached to
+    the video message itself so the buttons sit under the preview.
     """
     url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/sendVideo"
 
@@ -475,6 +530,12 @@ def _send_video_file(video_path: str, caption: str) -> str | None:
     body_parts.append('Content-Disposition: form-data; name="caption"')
     body_parts.append("")
     body_parts.append(caption[:1024])
+
+    if reply_markup:
+        body_parts.append(f"--{boundary}")
+        body_parts.append('Content-Disposition: form-data; name="reply_markup"')
+        body_parts.append("")
+        body_parts.append(json.dumps(reply_markup))
 
     text_body = "\r\n".join(body_parts).encode("utf-8")
 
@@ -542,6 +603,49 @@ def _send_text(text: str) -> bool:
     Auto-splits into multiple messages if text exceeds 4096 chars.
     """
     return _send_text_chunks(text)
+
+
+def send_message_with_keyboard(text: str, keyboard: dict) -> bool:
+    """Send a text message with an inline keyboard (review gate, Phase 5).
+
+    Text quá 4096 ký tự bị cắt (giữ keyboard) — caller của review gate chỉ
+    gửi text ngắn nên thực tế không chạm giới hạn này.
+    """
+    if not config.TELEGRAM_BOT_TOKEN or not config.TELEGRAM_CHAT_ID:
+        return False
+    if len(text) > TELEGRAM_MAX_LENGTH:
+        text = text[:TELEGRAM_MAX_LENGTH - 20] + "\n\n⚠️ (bị cắt ngắn)"
+
+    url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/sendMessage"
+    payload = json.dumps({
+        "chat_id": config.TELEGRAM_CHAT_ID,
+        "text": text,
+        "reply_markup": keyboard,
+    }).encode("utf-8")
+    try:
+        req = Request(url, data=payload,
+                      headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception as e:
+        logger.error("Telegram send (keyboard) failed: %s", e)
+        return False
+
+
+def _answer_callback_query(callback_id: str, text: str = "") -> bool:
+    """Acknowledge một callback_query để nút inline hết trạng thái loading."""
+    if not callback_id or not config.TELEGRAM_BOT_TOKEN:
+        return False
+    url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/answerCallbackQuery"
+    payload = json.dumps({"callback_query_id": callback_id, "text": text}).encode("utf-8")
+    try:
+        req = Request(url, data=payload,
+                      headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception as e:
+        logger.error("answerCallbackQuery failed: %s", e)
+        return False
 
 
 def _send_single_text(text: str) -> bool:

--- a/content-pipeline/publisher/tiktok_manual.py
+++ b/content-pipeline/publisher/tiktok_manual.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""
+TikTok Manual Export Queue (Phase 5 EPIC #5.3 — giai đoạn 1).
+
+Copy video + file .txt chứa caption/hashtag vào `queue_tiktok/YYYY-MM-DD/`
+để Phuong mở thư mục mỗi sáng, upload tay 5-10 phút — không phụ thuộc
+TikTok Content Posting API (approval mất 2-4 tuần). Khi API sẵn sàng
+(TIKTOK_ACCESS_TOKEN có giá trị), scheduler sẽ dùng
+publisher/tiktok_uploader.py thay vì queue này.
+
+Idempotent: export lại cùng video chỉ ghi đè đúng file của nó (tên file có
+video id), không tạo bản sao mới.
+"""
+
+import logging
+import os
+import shutil
+from datetime import date
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from storage.database import get_video
+
+logger = logging.getLogger(__name__)
+
+
+def export_for_manual_upload(video_id: int, queue_dir: str | None = None) -> str | None:
+    """Copy video + caption vào thư mục queue theo ngày. Returns đường dẫn MP4.
+
+    Cấu trúc output:
+        queue_tiktok/2026-07-07/video_12.mp4
+        queue_tiktok/2026-07-07/video_12.txt   (caption + hashtags, copy-paste nhanh)
+    """
+    video = get_video(video_id)
+    if not video:
+        logger.error("export_for_manual_upload: video %d not found", video_id)
+        return None
+    video_path = video.get("video_path")
+    if not video_path or not os.path.exists(video_path):
+        logger.error("export_for_manual_upload: file missing for video %d: %s",
+                     video_id, video_path)
+        return None
+
+    base_dir = queue_dir or config.TIKTOK_QUEUE_DIR
+    day_dir = os.path.join(base_dir, date.today().isoformat())
+    os.makedirs(day_dir, exist_ok=True)
+
+    dest_mp4 = os.path.join(day_dir, f"video_{video_id}.mp4")
+    shutil.copy2(video_path, dest_mp4)
+
+    caption = video.get("tiktok_caption", "") or video.get("youtube_title", "")
+    hashtags = video.get("tiktok_hashtags", "") or ""
+    lines = [caption.strip()]
+    if hashtags.strip():
+        lines += ["", hashtags.strip()]
+    with open(os.path.join(day_dir, f"video_{video_id}.txt"), "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    logger.info("Exported video %d to TikTok manual queue: %s", video_id, dest_mp4)
+    return dest_mp4
+
+
+def list_queue(queue_dir: str | None = None) -> dict[str, list[str]]:
+    """{ 'YYYY-MM-DD': [file, ...] } — các video đang chờ upload tay."""
+    base_dir = queue_dir or config.TIKTOK_QUEUE_DIR
+    if not os.path.isdir(base_dir):
+        return {}
+    result = {}
+    for day in sorted(os.listdir(base_dir)):
+        day_dir = os.path.join(base_dir, day)
+        if os.path.isdir(day_dir):
+            mp4s = sorted(f for f in os.listdir(day_dir) if f.endswith(".mp4"))
+            if mp4s:
+                result[day] = mp4s
+    return result
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    for day, files in list_queue().items():
+        print(f"{day}: {len(files)} video → {', '.join(files)}")

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -12,10 +12,15 @@ Yêu cầu:
 import json
 import logging
 import os
+import time
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import config
+from channels import get_channel
+from storage.quota import (
+    UNITS_VIDEO_INSERT, UNITS_THUMBNAIL_SET, UNITS_CAPTION_INSERT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +29,17 @@ SCOPES = [
     # Required for captions().insert (uploading a caption/subtitle track).
     "https://www.googleapis.com/auth/youtube.force-ssl",
 ]
+
+# categoryId theo track (Phase 5 — multi-channel). Khác phase-5-detailed.md
+# (đề xuất 22 cho AI): track AI giữ nguyên 28 "Science & Technology" mà kênh
+# đang dùng từ trước (đổi category giữa chừng không có lợi ích gì); Drama
+# dùng 24 "Entertainment" như doc.
+_CATEGORY_BY_TRACK = {"ai": "28", "drama": "24"}
+
+# HTTP status coi là transient khi upload resumable — retry với backoff.
+_TRANSIENT_HTTP_STATUS = {429, 500, 502, 503, 504}
+_MAX_CHUNK_RETRIES = 4
+_RETRY_BASE_DELAY = 2  # 2s, 4s, 8s, 16s
 
 
 def _video_id_from_url(url_or_id: str) -> str:
@@ -141,12 +157,8 @@ def upload_video(video_path: str, title: str, description: str,
             body=body,
             media_body=media,
         )
-
-        response = None
-        while response is None:
-            status, response = request.next_chunk()
-            if status:
-                logger.info("Upload progress: %d%%", int(status.progress() * 100))
+        response = _execute_resumable(request)
+        _record_quota_safe(UNITS_VIDEO_INSERT, note="videos.insert (legacy upload_video)")
 
         video_id = response["id"]
         url = f"https://youtu.be/{video_id}"
@@ -158,13 +170,219 @@ def upload_video(video_path: str, title: str, description: str,
         return None
 
 
+def _is_transient_upload_error(exc: Exception) -> bool:
+    """Lỗi tạm thời (đáng retry) khi upload: HTTP 5xx/429 hoặc lỗi mạng."""
+    try:
+        from googleapiclient.errors import HttpError
+        if isinstance(exc, HttpError):
+            return getattr(exc.resp, "status", None) in _TRANSIENT_HTTP_STATUS
+    except ImportError:
+        pass
+    return isinstance(exc, (ConnectionError, TimeoutError, OSError))
+
+
+def _execute_resumable(request):
+    """Run a resumable-upload request to completion, retrying transient errors.
+
+    Backoff 2s → 4s → 8s → 16s (per repo git-push convention); resumable
+    upload giữ tiến độ giữa các lần next_chunk nên retry không upload lại
+    từ đầu. Lỗi không transient (401, 403 quota, 400 metadata) raise ngay.
+    """
+    response = None
+    retries = 0
+    while response is None:
+        try:
+            status, response = request.next_chunk()
+            if status:
+                logger.info("Upload progress: %d%%", int(status.progress() * 100))
+            retries = 0  # tiến độ mới = reset đếm retry
+        except Exception as e:
+            if not _is_transient_upload_error(e) or retries >= _MAX_CHUNK_RETRIES:
+                raise
+            wait = _RETRY_BASE_DELAY * (2 ** retries)
+            retries += 1
+            logger.warning("Transient upload error (retry %d/%d in %ds): %s",
+                           retries, _MAX_CHUNK_RETRIES, wait, e)
+            time.sleep(wait)
+    return response
+
+
+def _record_quota_safe(units: int, note: str | None = None) -> None:
+    """Ghi quota usage; lỗi (DB chưa migrate 006, ...) không làm hỏng upload."""
+    try:
+        from storage.quota import record_youtube_units
+        record_youtube_units(units, note=note)
+    except Exception as e:
+        logger.warning("Quota tracking failed (non-fatal): %s", e)
+
+
+def resolve_token_file(channel_key: str) -> str:
+    """Đường dẫn token OAuth cho 1 kênh trong channels.py.
+
+    Khác phase-5-detailed.md (đề xuất hardcode `tokens/{channel_key}.json`):
+    codebase đã có convention từ Phase 1 — channels.py khai báo tên env var
+    (`oauth_token_env`), .env trỏ env var đó tới file token (xem
+    docs/current/oauth-setup.md §1.4). Dùng đúng convention đó thay vì thêm
+    một chỗ hardcode thứ hai. Env var rỗng → fallback token đơn-kênh cũ
+    (YOUTUBE_TOKEN_FILE) kèm warning, để setup 1-kênh hiện tại vẫn chạy.
+    """
+    channel = get_channel(channel_key)
+    env_name = channel["oauth_token_env"]
+    token_file = getattr(config, env_name, "") or os.getenv(env_name, "")
+    if not token_file:
+        logger.warning(
+            "%s (env %s) chưa cấu hình — dùng token mặc định %s. "
+            "Xem docs/current/oauth-setup.md để cấp token riêng cho kênh.",
+            channel_key, env_name, config.YOUTUBE_TOKEN_FILE,
+        )
+        return config.YOUTUBE_TOKEN_FILE
+    return token_file
+
+
+def _split_hashtags(hashtags: str) -> list[str]:
+    """'#mẹchồng #drama' → ['mẹchồng', 'drama'] (bỏ dấu #, bỏ rỗng)."""
+    return [t.lstrip("#") for t in (hashtags or "").split() if t.lstrip("#")]
+
+
+def _build_video_body(video: dict, channel_key: str) -> dict:
+    """snippet/status body cho videos().insert từ 1 row `videos` + kênh đích."""
+    channel = get_channel(channel_key)
+    track = video.get("track") or channel["track"]
+    is_short = video.get("video_type") == "short"
+
+    title = (video.get("youtube_title")
+             or video.get("tiktok_caption")
+             or f"Video #{video['id']}")
+    if is_short and "#Shorts" not in title:
+        title = f"{title} #Shorts"
+
+    if track == "drama":
+        tags = ["chuyện đời", "drama", "tâm sự", "kể chuyện"]
+    else:
+        tags = ["AI", "AI Việt Nam", "công nghệ", "AI 5 phút"]
+    tags += _split_hashtags(video.get("tiktok_hashtags", ""))
+    if is_short:
+        tags.append("Shorts")
+    # dedupe, giữ thứ tự
+    tags = list(dict.fromkeys(tags))
+
+    return {
+        "snippet": {
+            "title": title[:100],
+            "description": video.get("youtube_description", "") or "",
+            "tags": tags,
+            "categoryId": _CATEGORY_BY_TRACK.get(track, "28"),
+            "defaultLanguage": "vi",
+        },
+        "status": {
+            "privacyStatus": config.YOUTUBE_PRIVACY,
+            "selfDeclaredMadeForKids": False,
+        },
+    }
+
+
+def upload_to_youtube(video_id: int, channel_key: str) -> dict | None:
+    """Upload 1 video trong DB lên đúng kênh YouTube theo channel registry.
+
+    Phase 5 EPIC #5.2. Chọn OAuth token theo `channels.py[channel_key]`,
+    upload resumable có retry, rồi (best-effort) set thumbnail riêng nếu
+    video có `thumbnail_path`. Caption track được upload khi video KHÔNG
+    burn phụ đề (cùng chính sách với main._publish_to_platform).
+
+    Returns:
+        {"youtube_video_id": ..., "url": ...} khi thành công — caller
+        (scheduler) phải lưu id này NGAY để chống upload trùng; None on failure.
+    """
+    from storage.database import get_video
+
+    video = get_video(video_id)
+    if not video:
+        logger.error("upload_to_youtube: video %d not found", video_id)
+        return None
+    video_path = video.get("video_path")
+    if not video_path or not os.path.exists(video_path):
+        logger.error("upload_to_youtube: file missing for video %d: %s",
+                     video_id, video_path)
+        return None
+
+    channel = get_channel(channel_key)
+    if channel["platform"] != "youtube":
+        logger.error("upload_to_youtube: %s is not a YouTube channel", channel_key)
+        return None
+
+    token_file = resolve_token_file(channel_key)
+    service = _get_authenticated_service(token_file)
+    if not service:
+        logger.error("upload_to_youtube: authentication failed for %s (token %s)",
+                     channel_key, token_file)
+        return None
+
+    from googleapiclient.http import MediaFileUpload
+    body = _build_video_body(video, channel_key)
+    media = MediaFileUpload(video_path, mimetype="video/mp4", resumable=True)
+
+    try:
+        request = service.videos().insert(
+            part="snippet,status", body=body, media_body=media,
+        )
+        response = _execute_resumable(request)
+    except Exception as e:
+        logger.error("upload_to_youtube failed for video %d → %s: %s",
+                     video_id, channel_key, e)
+        return None
+    finally:
+        _record_quota_safe(UNITS_VIDEO_INSERT,
+                           note=f"videos.insert video={video_id} channel={channel_key}")
+
+    youtube_video_id = response["id"]
+    url = f"https://youtu.be/{youtube_video_id}"
+    logger.info("Uploaded video %d to %s (%s): %s",
+                video_id, channel_key, channel["name"], url)
+
+    # Thumbnail riêng (EPIC #5.2): best-effort — video đã lên sóng, thumbnail
+    # hỏng chỉ log warning chứ không coi là upload thất bại.
+    thumbnail_path = video.get("thumbnail_path")
+    if thumbnail_path and os.path.exists(thumbnail_path):
+        try:
+            service.thumbnails().set(
+                videoId=youtube_video_id,
+                media_body=MediaFileUpload(thumbnail_path),
+            ).execute()
+            _record_quota_safe(UNITS_THUMBNAIL_SET,
+                               note=f"thumbnails.set video={video_id}")
+            logger.info("Thumbnail set for %s", youtube_video_id)
+        except Exception as e:
+            logger.warning("Thumbnail upload failed for %s (non-fatal): %s",
+                           youtube_video_id, e)
+
+    # Caption track khi phụ đề không burn (cùng chính sách với track AI cũ) —
+    # nhưng KHÔNG fail cả publish ở đây: scheduler đã lưu youtube_video_id,
+    # fail sau điểm này chỉ nên alert chứ không kích hoạt re-upload.
+    burned = video.get("subtitles_burned")
+    if burned is None:
+        burned = config.should_burn_subtitles(video.get("video_type", "short"))
+    srt = video.get("subtitle_path")
+    if not burned and srt and os.path.exists(srt):
+        if upload_caption(url, srt, token_file=token_file):
+            _record_quota_safe(UNITS_CAPTION_INSERT,
+                               note=f"captions.insert video={video_id}")
+        else:
+            logger.warning("Caption upload failed for video %d (%s)", video_id, url)
+
+    return {"youtube_video_id": youtube_video_id, "url": url}
+
+
 def upload_caption(video_url_or_id: str, srt_path: str,
-                   language: str = "vi", name: str = "Tiếng Việt") -> bool:
+                   language: str = "vi", name: str = "Tiếng Việt",
+                   token_file: str | None = None) -> bool:
     """Upload an SRT file as a caption track for an existing YouTube video.
 
     Lets long videos ship accurate, viewer-toggleable captions (the script text
     we control) instead of burning subtitles into the frame. Returns True on
     success.
+
+    `token_file`: token OAuth của kênh sở hữu video (multi-channel, Phase 5);
+    mặc định dùng token đơn-kênh cũ như trước.
     """
     video_id = _video_id_from_url(video_url_or_id)
     if not video_id:
@@ -176,7 +394,7 @@ def upload_caption(video_url_or_id: str, srt_path: str,
 
     from googleapiclient.http import MediaFileUpload
 
-    service = _get_authenticated_service()
+    service = _get_authenticated_service(token_file)
     if not service:
         return False
 

--- a/content-pipeline/publisher/youtube_uploader.py
+++ b/content-pipeline/publisher/youtube_uploader.py
@@ -281,7 +281,8 @@ def _build_video_body(video: dict, channel_key: str) -> dict:
     }
 
 
-def upload_to_youtube(video_id: int, channel_key: str) -> dict | None:
+def upload_to_youtube(video_id: int, channel_key: str,
+                      on_uploaded=None) -> dict | None:
     """Upload 1 video trong DB lên đúng kênh YouTube theo channel registry.
 
     Phase 5 EPIC #5.2. Chọn OAuth token theo `channels.py[channel_key]`,
@@ -289,9 +290,13 @@ def upload_to_youtube(video_id: int, channel_key: str) -> dict | None:
     video có `thumbnail_path`. Caption track được upload khi video KHÔNG
     burn phụ đề (cùng chính sách với main._publish_to_platform).
 
+    `on_uploaded(youtube_video_id, url)`: callback được gọi NGAY khi
+    videos.insert trả về id — TRƯỚC các bước best-effort thumbnail/caption —
+    để caller (scheduler) persist bằng chứng "video đã live" trước khi có cơ
+    hội crash giữa các call mạng sau đó (finding Codex review PR #70).
+
     Returns:
-        {"youtube_video_id": ..., "url": ...} khi thành công — caller
-        (scheduler) phải lưu id này NGAY để chống upload trùng; None on failure.
+        {"youtube_video_id": ..., "url": ...} khi thành công; None on failure.
     """
     from storage.database import get_video
 
@@ -338,6 +343,11 @@ def upload_to_youtube(video_id: int, channel_key: str) -> dict | None:
     url = f"https://youtu.be/{youtube_video_id}"
     logger.info("Uploaded video %d to %s (%s): %s",
                 video_id, channel_key, channel["name"], url)
+    if on_uploaded is not None:
+        try:
+            on_uploaded(youtube_video_id, url)
+        except Exception as e:
+            logger.warning("on_uploaded callback failed (non-fatal): %s", e)
 
     # Thumbnail riêng (EPIC #5.2): best-effort — video đã lên sóng, thumbnail
     # hỏng chỉ log warning chứ không coi là upload thất bại.

--- a/content-pipeline/scheduler/post_scheduler.py
+++ b/content-pipeline/scheduler/post_scheduler.py
@@ -164,14 +164,20 @@ def run_tick(now: datetime | None = None) -> dict:
     stale = scheduled_posts.get_stale_uploading(now=now_str.replace(" ", "T"))
     if stale:
         summary["stale"] = len(stale)
+        details = []
+        for p in stale:
+            line = (f"  • post {p['id']}: video {p['video_id']} → "
+                    f"{p['channel_key']} lúc {p['scheduled_at']}")
+            # platform_video_id đã có = video ĐÃ live, chỉ thiếu mark done.
+            if p.get("platform_video_id"):
+                line += (f"\n    → ĐÃ lên platform ({p['url'] or p['platform_video_id']}), "
+                         f"chỉ cần mark done tay")
+            else:
+                line += "\n    → chưa rõ đã lên chưa — kiểm tra kênh trước"
+            details.append(line)
         _alert_safe(
             "⚠️ %d post kẹt ở trạng thái 'uploading' (crash giữa upload?):\n%s\n"
-            "Kiểm tra kênh xem video ĐÃ lên chưa rồi xử lý tay — không tự "
-            "retry để tránh upload trùng." % (
-                len(stale),
-                "\n".join(f"  • post {p['id']}: video {p['video_id']} → "
-                          f"{p['channel_key']} lúc {p['scheduled_at']}" for p in stale),
-            )
+            "Không tự retry để tránh upload trùng." % (len(stale), "\n".join(details))
         )
 
     for post in scheduled_posts.get_due(now=now_str):
@@ -212,7 +218,15 @@ def _dispatch(post: dict) -> tuple[bool, str | None, str | None]:
 
     if channel["platform"] == "youtube":
         from publisher.youtube_uploader import upload_to_youtube
-        result = upload_to_youtube(post["video_id"], post["channel_key"])
+        # on_uploaded ghi platform_video_id vào post NGAY khi YouTube trả về
+        # id (giữ status 'uploading') — crash trong bước thumbnail/caption
+        # sau đó vẫn để lại bằng chứng video đã live, alert stale bên dưới
+        # nhờ vậy phân biệt được "đã lên sóng" với "chưa biết".
+        result = upload_to_youtube(
+            post["video_id"], post["channel_key"],
+            on_uploaded=lambda vid, url: scheduled_posts.record_platform_id(
+                post["id"], vid, url),
+        )
         if not result:
             return False, "upload_to_youtube failed (see log)", None
         return True, result["url"], result["youtube_video_id"]

--- a/content-pipeline/scheduler/post_scheduler.py
+++ b/content-pipeline/scheduler/post_scheduler.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+"""
+Post Scheduler (Phase 5 EPIC #5.4) — queue video đã duyệt vào slot đăng theo
+cadence chuẩn, và tick mỗi 5 phút để upload các post tới giờ.
+
+Khác phase-5-detailed.md một chi tiết: doc dùng key phẳng kiểu
+"drama_youtube_shorts"/"tiktok_drama" — không tồn tại trong channel registry
+(channels.py chỉ có ai_youtube/drama_youtube/tiktok_main, TikTok là 1 account
+mixed cho cả 2 track). CADENCE ở đây key theo (channel_key, track, video_type)
+để vẫn diễn đạt đủ 6 dòng cadence của doc mà không phải bịa thêm channel key
+ngoài registry.
+
+Chạy:
+    python -m scheduler.post_scheduler tick       # launchd mỗi 5 phút
+    python -m scheduler.post_scheduler list       # xem queue
+    python -m scheduler.post_scheduler schedule <video_id> <channel_key>
+
+Chống upload trùng (resume-from-crash, phase-5-detailed.md §5):
+- tick chỉ nhặt post status='queued' và claim atomic sang 'uploading' trước
+  khi upload — 2 tick chạy chồng nhau không thể cùng upload 1 post.
+- post kẹt ở 'uploading' (crash giữa upload) KHÔNG bị tự retry — video có thể
+  đã lên platform trước khi crash; tick chỉ alert Telegram để người kiểm tra.
+"""
+
+import argparse
+import logging
+import sqlite3
+from datetime import datetime, timedelta
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from channels import get_channel
+from storage import scheduled_posts
+from storage.database import get_video, update_video_status, update_video_publish_url
+
+logger = logging.getLogger(__name__)
+
+# (channel_key, track, video_type) → danh sách slot spec.
+# Slot spec: "HH:MM" (hàng ngày) hoặc "<thứ> HH:MM" (hàng tuần, mon..sun).
+CADENCE: dict[tuple[str, str, str], list[str]] = {
+    ("drama_youtube", "drama", "short"): ["12:00", "21:00"],
+    ("drama_youtube", "drama", "long"):  ["sun 20:00"],
+    ("ai_youtube", "ai", "short"):       ["12:00"],
+    ("ai_youtube", "ai", "long"):        ["tue 19:00", "sat 19:00"],
+    ("tiktok_main", "drama", "short"):   ["12:00", "21:00"],
+    ("tiktok_main", "ai", "short"):      ["19:00"],
+}
+# Combo ngoài CADENCE (vd video long cho tiktok — không nên xảy ra) vẫn được
+# xếp lịch thay vì rơi rụng im lặng.
+DEFAULT_SLOTS = ["12:00"]
+
+_WEEKDAYS = {
+    "mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6,
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3, "friday": 4,
+    "saturday": 5, "sunday": 6,
+}
+
+
+def _parse_slot_spec(spec: str) -> tuple[int | None, int, int]:
+    """'21:00' → (None, 21, 0); 'sun 20:00' → (6, 20, 0).
+
+    Raises ValueError cho spec sai định dạng (bắt ngay lúc dev, không đợi runtime).
+    """
+    parts = spec.strip().lower().split()
+    if len(parts) == 1:
+        weekday = None
+        time_part = parts[0]
+    elif len(parts) == 2:
+        if parts[0] not in _WEEKDAYS:
+            raise ValueError(f"Unknown weekday in slot spec: {spec!r}")
+        weekday = _WEEKDAYS[parts[0]]
+        time_part = parts[1]
+    else:
+        raise ValueError(f"Bad slot spec: {spec!r}")
+    hour_str, _, minute_str = time_part.partition(":")
+    hour, minute = int(hour_str), int(minute_str or 0)
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"Bad time in slot spec: {spec!r}")
+    return weekday, hour, minute
+
+
+def iter_slots(specs: list[str], after: datetime, days: int = 8) -> list[datetime]:
+    """Mọi slot > `after` trong `days` ngày tới, sort tăng dần."""
+    slots = []
+    for spec in specs:
+        weekday, hour, minute = _parse_slot_spec(spec)
+        for offset in range(days + 1):
+            day = after.date() + timedelta(days=offset)
+            if weekday is not None and day.weekday() != weekday:
+                continue
+            candidate = datetime.combine(
+                day, datetime.min.time()).replace(hour=hour, minute=minute)
+            if candidate > after:
+                slots.append(candidate)
+    return sorted(slots)
+
+
+def slots_for_video(video: dict, channel_key: str) -> list[str]:
+    """Tra CADENCE cho (kênh, track, loại video); combo lạ → DEFAULT_SLOTS."""
+    track = video.get("track") or get_channel(channel_key)["track"]
+    video_type = video.get("video_type") or "short"
+    key = (channel_key, track, video_type)
+    specs = CADENCE.get(key)
+    if specs is None:
+        logger.warning("No cadence for %s — using default %s", key, DEFAULT_SLOTS)
+        return DEFAULT_SLOTS
+    return specs
+
+
+def schedule_video(video_id: int, channel_key: str,
+                   now: datetime | None = None) -> dict | None:
+    """Queue video vào slot trống kế tiếp theo CADENCE. Returns post row.
+
+    Idempotent: video đã có post đang hoạt động (queued/uploading/done) cho
+    kênh này thì trả lại post đó thay vì xếp thêm — bấm ✅ approve 2 lần
+    không tạo 2 lịch đăng.
+    """
+    get_channel(channel_key)  # raise ValueError sớm nếu key sai
+    video = get_video(video_id)
+    if not video:
+        logger.error("schedule_video: video %d not found", video_id)
+        return None
+
+    existing = scheduled_posts.find_active(video_id, channel_key)
+    if existing:
+        logger.info("Video %d already scheduled for %s (post %d, %s)",
+                    video_id, channel_key, existing["id"], existing["status"])
+        return existing
+
+    now = now or datetime.now()
+    specs = slots_for_video(video, channel_key)
+    # Slot dày nhất là 1 slot/ngày/dòng cadence — 30 ngày dò là quá đủ; hết 30
+    # ngày mà vẫn kẹt nghĩa là có bug/backlog bất thường, nên báo lỗi thay vì
+    # âm thầm xếp lịch sang tháng sau.
+    for candidate in iter_slots(specs, now, days=30):
+        slot_str = candidate.isoformat(sep=" ", timespec="seconds")
+        if scheduled_posts.slot_taken(channel_key, slot_str):
+            continue
+        try:
+            post_id = scheduled_posts.insert_post(video_id, channel_key, slot_str)
+        except sqlite3.IntegrityError:
+            # Thua race giành slot (unique index) — thử slot kế tiếp; nhưng
+            # nếu là unique (video, channel) thì post active vừa được tạo ở
+            # nơi khác → trả về post đó (idempotent).
+            existing = scheduled_posts.find_active(video_id, channel_key)
+            if existing:
+                return existing
+            continue
+        return scheduled_posts.get_post(post_id)
+
+    logger.error("No free slot within 30 days for video %d → %s", video_id, channel_key)
+    return None
+
+
+def run_tick(now: datetime | None = None) -> dict:
+    """Upload mọi post tới giờ. Returns {'uploaded': n, 'failed': n, 'stale': n}."""
+    now = now or datetime.now()
+    now_str = now.isoformat(sep=" ", timespec="seconds")
+    summary = {"uploaded": 0, "failed": 0, "stale": 0}
+
+    stale = scheduled_posts.get_stale_uploading(now=now_str.replace(" ", "T"))
+    if stale:
+        summary["stale"] = len(stale)
+        _alert_safe(
+            "⚠️ %d post kẹt ở trạng thái 'uploading' (crash giữa upload?):\n%s\n"
+            "Kiểm tra kênh xem video ĐÃ lên chưa rồi xử lý tay — không tự "
+            "retry để tránh upload trùng." % (
+                len(stale),
+                "\n".join(f"  • post {p['id']}: video {p['video_id']} → "
+                          f"{p['channel_key']} lúc {p['scheduled_at']}" for p in stale),
+            )
+        )
+
+    for post in scheduled_posts.get_due(now=now_str):
+        if not scheduled_posts.claim(post["id"]):
+            continue  # tick khác vừa nhận post này
+        try:
+            result = _dispatch(post)
+        except Exception as e:  # không để 1 post hỏng chặn các post còn lại
+            logger.exception("Dispatch error for post %d", post["id"])
+            result = (False, f"{type(e).__name__}: {e}", None)
+
+        ok, url_or_error, platform_video_id = result
+        if ok:
+            scheduled_posts.mark_done(post["id"], platform_video_id=platform_video_id,
+                                      url=url_or_error)
+            update_video_status(post["video_id"], "published")
+            if url_or_error:
+                update_video_publish_url(post["video_id"], url_or_error)
+            _notify_published_safe(post, url_or_error)
+            summary["uploaded"] += 1
+        else:
+            scheduled_posts.mark_failed(post["id"], url_or_error or "unknown error")
+            _alert_safe(f"❌ Upload thất bại: video {post['video_id']} → "
+                        f"{post['channel_key']} (post {post['id']}):\n{url_or_error}")
+            summary["failed"] += 1
+
+    if any(summary.values()):
+        logger.info("Scheduler tick: %s", summary)
+    return summary
+
+
+def _dispatch(post: dict) -> tuple[bool, str | None, str | None]:
+    """Upload 1 post theo platform của kênh. Returns (ok, url|error, platform_id)."""
+    channel = get_channel(post["channel_key"])
+    video = get_video(post["video_id"])
+    if not video:
+        return False, f"video {post['video_id']} not found", None
+
+    if channel["platform"] == "youtube":
+        from publisher.youtube_uploader import upload_to_youtube
+        result = upload_to_youtube(post["video_id"], post["channel_key"])
+        if not result:
+            return False, "upload_to_youtube failed (see log)", None
+        return True, result["url"], result["youtube_video_id"]
+
+    if channel["platform"] == "tiktok":
+        if config.TIKTOK_ACCESS_TOKEN:
+            from publisher.tiktok_uploader import upload_video
+            publish_id = upload_video(
+                video.get("video_path", ""),
+                caption=video.get("tiktok_caption", ""),
+                hashtags=video.get("tiktok_hashtags", ""),
+            )
+            if not publish_id:
+                return False, "TikTok API upload failed (see log)", None
+            return True, f"tiktok://publish/{publish_id}", publish_id
+        # Chưa có API token (approval 2-4 tuần) → rơi về manual queue thay vì
+        # fail: file nằm sẵn trong queue_tiktok/ cho Phuong upload tay.
+        from publisher.tiktok_manual import export_for_manual_upload
+        exported = export_for_manual_upload(post["video_id"])
+        if not exported:
+            return False, "manual export failed (see log)", None
+        return True, f"file://{exported}", None
+
+    return False, f"unknown platform {channel['platform']!r}", None
+
+
+def _notify_published_safe(post: dict, url: str | None) -> None:
+    try:
+        from notifier.telegram_bot import send_publish_notification
+        channel = get_channel(post["channel_key"])
+        label = f"{channel['name']} ({post['channel_key']})"
+        if url and url.startswith("file://"):
+            label += " — QUEUE TAY, chưa lên sóng"
+        send_publish_notification(post["video_id"], label, url or "")
+    except Exception as e:
+        logger.warning("Publish notification failed (non-fatal): %s", e)
+
+
+def _alert_safe(text: str) -> None:
+    try:
+        from notifier.telegram_bot import send_alert
+        send_alert(text)
+    except Exception as e:
+        logger.warning("Alert failed (non-fatal): %s", e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Post scheduler (Phase 5)")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("tick", help="Upload mọi post tới giờ (chạy mỗi 5 phút)")
+    sub.add_parser("list", help="Xem queue")
+    p_sched = sub.add_parser("schedule", help="Xếp lịch 1 video vào slot kế tiếp")
+    p_sched.add_argument("video_id", type=int)
+    p_sched.add_argument("channel_key")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    if args.command == "tick":
+        print(run_tick())
+    elif args.command == "list":
+        for status in ("queued", "uploading", "failed"):
+            for p in scheduled_posts.get_by_status(status):
+                print(f"[{p['status']}] post {p['id']}: video {p['video_id']} → "
+                      f"{p['channel_key']} lúc {p['scheduled_at']}"
+                      + (f" ({p['error']})" if p.get("error") else ""))
+    elif args.command == "schedule":
+        post = schedule_video(args.video_id, args.channel_key)
+        print(post if post else "Không xếp được lịch — xem log.")
+
+
+if __name__ == "__main__":
+    main()

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -316,32 +316,45 @@ def insert_video(video_type: str, script_text: str, youtube_title: str = "",
                  youtube_description: str = "", tiktok_caption: str = "",
                  tiktok_hashtags: str = "", scheduled_date: str = "",
                  scheduled_platform: str = "", track: str = "ai",
-                 destination: Optional[str] = None) -> int:
+                 destination: Optional[str] = None,
+                 story_id: Optional[int] = None) -> int:
     """Insert a new video record. Returns the video id.
 
-    `track`/`destination` require migration 001_multi_track (see
-    storage/migrate.py); on a pre-migration DB the extra columns don't exist
-    and this call falls back to the legacy INSERT below.
+    `track`/`destination` require migration 001_multi_track, `story_id`
+    requires 006_distribution (see storage/migrate.py); on a pre-migration DB
+    the extra columns don't exist and this call falls back to the legacy
+    INSERT below.
     """
     conn = get_connection()
     try:
         try:
             cursor = conn.execute(
                 "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
-                "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform, track, destination) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform, track, destination, story_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (video_type, script_text, youtube_title, youtube_description,
                  tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform,
-                 track, destination),
+                 track, destination, story_id),
             )
         except sqlite3.OperationalError:
-            cursor = conn.execute(
-                "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
-                "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (video_type, script_text, youtube_title, youtube_description,
-                 tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform),
-            )
+            # DB has migration 001 (track/destination) but not 006 (story_id)?
+            try:
+                cursor = conn.execute(
+                    "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
+                    "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform, track, destination) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (video_type, script_text, youtube_title, youtube_description,
+                     tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform,
+                     track, destination),
+                )
+            except sqlite3.OperationalError:
+                cursor = conn.execute(
+                    "INSERT INTO videos (video_type, script_text, youtube_title, youtube_description, "
+                    "tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (video_type, script_text, youtube_title, youtube_description,
+                     tiktok_caption, tiktok_hashtags, scheduled_date, scheduled_platform),
+                )
         conn.commit()
         logger.info("Inserted video id=%d type=%s", cursor.lastrowid, video_type)
         return cursor.lastrowid
@@ -443,6 +456,56 @@ def set_video_subtitles_burned(video_id: int, burned: bool):
         conn.execute("UPDATE videos SET subtitles_burned = ? WHERE id = ?",
                      (1 if burned else 0, video_id))
         conn.commit()
+    finally:
+        conn.close()
+
+
+# Columns update_video_metadata() may touch — same allowlist pattern as
+# storage/stories.update_status(), so a dynamic UPDATE can never be built
+# from arbitrary caller-controlled column names.
+_VIDEO_METADATA_FIELDS = {
+    "youtube_title", "youtube_description", "tiktok_caption",
+    "tiktok_hashtags", "thumbnail_path", "review_note",
+}
+
+
+def update_video_metadata(video_id: int, **fields) -> None:
+    """Update metadata fields on a video (review-gate edits, thumbnail path).
+
+    Raises:
+        ValueError: nếu `fields` chứa cột ngoài allowlist `_VIDEO_METADATA_FIELDS`.
+    """
+    unknown = set(fields) - _VIDEO_METADATA_FIELDS
+    if unknown:
+        raise ValueError(f"update_video_metadata: unknown field(s) {sorted(unknown)}")
+    if not fields:
+        return
+    set_clauses = [f"{key} = ?" for key in fields]
+    params = list(fields.values()) + [video_id]
+    conn = get_connection()
+    try:
+        conn.execute(
+            f"UPDATE videos SET {', '.join(set_clauses)} WHERE id = ?", params
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_videos_by_story(story_id: int) -> list[dict]:
+    """Videos đã tạo từ 1 story (resume guard: không render lại story đã có video).
+
+    Requires migration 006 (`videos.story_id`); trả [] trên DB pre-migration.
+    """
+    conn = get_connection()
+    try:
+        try:
+            rows = conn.execute(
+                "SELECT * FROM videos WHERE story_id = ? ORDER BY id", (story_id,)
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [dict(r) for r in rows]
     finally:
         conn.close()
 

--- a/content-pipeline/storage/migrations/006_distribution.sql
+++ b/content-pipeline/storage/migrations/006_distribution.sql
@@ -1,0 +1,56 @@
+-- Migration 006: distribution layer (Phase 5 — Distribution & Multi-channel Upload).
+--
+-- 1. `scheduled_posts` — hàng đợi upload theo cadence (scheduler/post_scheduler.py).
+--    Mỗi row là "1 video → 1 kênh → 1 giờ đăng". Trạng thái đi 1 chiều:
+--    queued → uploading → done|failed. `platform_video_id` được lưu NGAY khi
+--    upload thành công để chống upload trùng khi pipeline restart giữa chừng
+--    (rủi ro "Upload trùng" trong phase-5-detailed.md mục 5).
+-- 2. `quota_usage` — đếm unit YouTube Data API đã dùng mỗi ngày (upload ~1600
+--    unit, set thumbnail ~50) để alert khi chạm 80% quota (storage/quota.py).
+-- 3. Cột mới trên `videos`:
+--    - story_id: nối video Drama về stories (resume-from-crash: không render
+--      lại story đã có video).
+--    - thumbnail_path: file thumbnail upload riêng qua thumbnails().set().
+--    - review_note: lý do reject từ review gate (notifier/review_bot.py).
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS scheduled_posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  video_id INTEGER NOT NULL,
+  channel_key TEXT NOT NULL,          -- khoá trong channels.py
+  scheduled_at TEXT NOT NULL,         -- 'YYYY-MM-DD HH:MM:SS' giờ local (so sánh lexicographic được)
+  status TEXT NOT NULL DEFAULT 'queued',  -- queued | uploading | done | failed | cancelled
+  platform_video_id TEXT,             -- YouTube video id / TikTok publish_id, lưu ngay khi upload OK
+  url TEXT,
+  error TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_scheduled_posts_due ON scheduled_posts(status, scheduled_at);
+CREATE INDEX IF NOT EXISTS idx_scheduled_posts_video ON scheduled_posts(video_id);
+-- 1 slot (kênh + giờ) chỉ có 1 post đang hoạt động — scheduler tự tìm slot
+-- trống, index này là chốt chặn cuối chống double-book do race/bug.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_scheduled_posts_slot
+  ON scheduled_posts(channel_key, scheduled_at)
+  WHERE status IN ('queued', 'uploading');
+-- 1 video chỉ được xếp lịch 1 lần cho mỗi kênh (trừ khi lần trước failed/cancelled).
+CREATE UNIQUE INDEX IF NOT EXISTS ux_scheduled_posts_video_channel
+  ON scheduled_posts(video_id, channel_key)
+  WHERE status IN ('queued', 'uploading', 'done');
+
+CREATE TABLE IF NOT EXISTS quota_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  service TEXT NOT NULL,              -- 'youtube'
+  date TEXT NOT NULL,                 -- YYYY-MM-DD theo giờ Pacific (YouTube quota reset nửa đêm PT)
+  units INTEGER NOT NULL,
+  note TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_quota_usage_service_date ON quota_usage(service, date);
+
+ALTER TABLE videos ADD COLUMN story_id INTEGER;
+ALTER TABLE videos ADD COLUMN thumbnail_path TEXT;
+ALTER TABLE videos ADD COLUMN review_note TEXT;
+CREATE INDEX IF NOT EXISTS idx_videos_story ON videos(story_id);

--- a/content-pipeline/storage/migrations/006_distribution_down.sql
+++ b/content-pipeline/storage/migrations/006_distribution_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 006_distribution.
+-- SQLite (3.35+) hỗ trợ DROP COLUMN; các index trên bảng bị drop sẽ tự biến mất.
+
+DROP INDEX IF EXISTS idx_videos_story;
+ALTER TABLE videos DROP COLUMN review_note;
+ALTER TABLE videos DROP COLUMN thumbnail_path;
+ALTER TABLE videos DROP COLUMN story_id;
+
+DROP TABLE IF EXISTS quota_usage;
+DROP TABLE IF EXISTS scheduled_posts;

--- a/content-pipeline/storage/quota.py
+++ b/content-pipeline/storage/quota.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+"""
+Quota tracking cho YouTube Data API v3 (Phase 5 EPIC #5.2 — Quota tracking).
+
+Mỗi lần gọi API tốn unit (videos.insert ~1600, thumbnails.set ~50); quota
+mặc định 10.000 unit/ngày/Google Cloud Project và reset lúc NỬA ĐÊM GIỜ
+PACIFIC — nên ngày quota được tính theo America/Los_Angeles chứ không phải
+giờ local, kẻo cảnh báo lệch tới nửa ngày.
+
+`add_units()` trả về flag "vừa vượt ngưỡng cảnh báo" đúng MỘT lần cho mỗi lần
+băng qua ngưỡng (before < threshold <= after) — caller (youtube_uploader)
+gửi Telegram alert dựa trên flag đó, không cần chống spam alert riêng.
+
+Bảng `quota_usage` tạo ở migration 006_distribution.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Chi phí unit các call chính (docs: developers.google.com/youtube/v3/determine_quota_cost)
+UNITS_VIDEO_INSERT = 1600
+UNITS_THUMBNAIL_SET = 50
+UNITS_CAPTION_INSERT = 400
+
+
+def quota_date(now: datetime | None = None) -> str:
+    """Ngày quota hiện tại (YYYY-MM-DD) theo giờ Pacific.
+
+    Nếu tzdata không có (hiếm), fallback về UTC-8 cố định — sai lệch tối đa
+    1 giờ quanh DST, chấp nhận được cho mục đích cảnh báo.
+    """
+    now = now or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    try:
+        from zoneinfo import ZoneInfo
+        pt = now.astimezone(ZoneInfo("America/Los_Angeles"))
+    except Exception:  # tzdata missing
+        from datetime import timedelta
+        pt = now.astimezone(timezone(timedelta(hours=-8)))
+    return pt.date().isoformat()
+
+
+def units_used_today(service: str = "youtube") -> int:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(units), 0) AS total FROM quota_usage "
+            "WHERE service = ? AND date = ?",
+            (service, quota_date()),
+        ).fetchone()
+        return int(row["total"])
+    finally:
+        conn.close()
+
+
+def add_units(units: int, service: str = "youtube",
+              note: str | None = None) -> tuple[int, bool]:
+    """Ghi nhận `units` vừa tiêu. Returns (tổng hôm nay, vừa_vượt_ngưỡng).
+
+    `vừa_vượt_ngưỡng` chỉ True ở đúng lần ghi làm tổng băng qua
+    config.YOUTUBE_DAILY_QUOTA × config.QUOTA_ALERT_RATIO.
+    """
+    date = quota_date()
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(units), 0) AS total FROM quota_usage "
+            "WHERE service = ? AND date = ?",
+            (service, date),
+        ).fetchone()
+        before = int(row["total"])
+        conn.execute(
+            "INSERT INTO quota_usage (service, date, units, note) VALUES (?, ?, ?, ?)",
+            (service, date, units, note),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    after = before + units
+    threshold = config.YOUTUBE_DAILY_QUOTA * config.QUOTA_ALERT_RATIO
+    crossed = before < threshold <= after
+    if crossed:
+        logger.warning("%s quota crossed %.0f%%: %d/%d units used today",
+                       service, config.QUOTA_ALERT_RATIO * 100, after,
+                       config.YOUTUBE_DAILY_QUOTA)
+    return after, crossed
+
+
+def record_youtube_units(units: int, note: str | None = None) -> int:
+    """add_units + gửi Telegram alert nếu vừa vượt ngưỡng. Returns tổng hôm nay.
+
+    Alert lỗi (Telegram down) không được làm hỏng upload — nuốt exception.
+    """
+    total, crossed = add_units(units, service="youtube", note=note)
+    if crossed:
+        try:
+            from notifier.telegram_bot import send_alert
+            pct = 100.0 * total / config.YOUTUBE_DAILY_QUOTA
+            send_alert(
+                f"⚠️ YouTube API quota đã dùng {total}/{config.YOUTUBE_DAILY_QUOTA} "
+                f"unit hôm nay ({pct:.0f}%). Mỗi upload ~{UNITS_VIDEO_INSERT} unit — "
+                f"còn ~{max(0, (config.YOUTUBE_DAILY_QUOTA - total)) // UNITS_VIDEO_INSERT} lượt upload."
+            )
+        except Exception as e:
+            logger.error("Quota alert failed: %s", e)
+    return total
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print(f"YouTube units used today ({quota_date()}):", units_used_today())

--- a/content-pipeline/storage/scheduled_posts.py
+++ b/content-pipeline/storage/scheduled_posts.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `scheduled_posts` — hàng đợi upload theo cadence
+(Phase 5 — Distribution). Bảng được tạo ở migration 006_distribution; chạy
+`python -m storage.migrate up` trước khi dùng module này.
+
+Vòng đời 1 post: queued → uploading → done | failed. Chuyển queued→uploading
+qua `claim()` (UPDATE có điều kiện, atomic) — 2 tick scheduler chạy chồng
+nhau không thể cùng upload 1 post. `platform_video_id` được lưu NGAY khi
+platform trả về id (mark_done) để một lần restart giữa chừng không bao giờ
+tạo video trùng trên YouTube (rủi ro "Upload trùng", phase-5-detailed.md §5).
+"""
+
+import logging
+import sqlite3
+from datetime import datetime
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Trạng thái "đang hoạt động" — chiếm slot và chặn xếp lịch trùng video/kênh.
+ACTIVE_STATUSES = ("queued", "uploading", "done")
+
+
+def _now_str() -> str:
+    return datetime.now().isoformat(sep=" ", timespec="seconds")
+
+
+def insert_post(video_id: int, channel_key: str, scheduled_at: str) -> int:
+    """Queue một video cho một kênh tại một thời điểm. Returns post id.
+
+    Raises:
+        sqlite3.IntegrityError: nếu slot (channel_key, scheduled_at) đã có
+            post đang hoạt động, hoặc video này đã được xếp cho kênh này
+            (unique index từ migration 006). Scheduler bắt lỗi này để dò
+            slot kế tiếp.
+    """
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            "INSERT INTO scheduled_posts (video_id, channel_key, scheduled_at, status, updated_at) "
+            "VALUES (?, ?, ?, 'queued', ?)",
+            (video_id, channel_key, scheduled_at, _now_str()),
+        )
+        conn.commit()
+        logger.info("Queued post id=%d video=%d channel=%s at %s",
+                    cursor.lastrowid, video_id, channel_key, scheduled_at)
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def get_post(post_id: int) -> Optional[dict]:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM scheduled_posts WHERE id = ?", (post_id,)
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_due(now: Optional[str] = None, limit: int = 10) -> list[dict]:
+    """Post status='queued' đã tới giờ đăng (scheduled_at <= now)."""
+    now = now or _now_str()
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM scheduled_posts WHERE status = 'queued' AND scheduled_at <= ? "
+            "ORDER BY scheduled_at, id LIMIT ?",
+            (now, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def claim(post_id: int) -> bool:
+    """Atomically chuyển queued → uploading. True nếu CHÍNH call này chuyển được.
+
+    Cùng cơ chế với database.claim_video_status: chỉ caller thắng race mới
+    tiếp tục upload, không bao giờ 2 tick cùng upload 1 post.
+    """
+    conn = get_connection()
+    try:
+        cur = conn.execute(
+            "UPDATE scheduled_posts SET status = 'uploading', updated_at = ? "
+            "WHERE id = ? AND status = 'queued'",
+            (_now_str(), post_id),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    finally:
+        conn.close()
+
+
+def mark_done(post_id: int, platform_video_id: Optional[str] = None,
+              url: Optional[str] = None) -> None:
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE scheduled_posts SET status = 'done', platform_video_id = ?, "
+            "url = ?, error = NULL, updated_at = ? WHERE id = ?",
+            (platform_video_id, url, _now_str(), post_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_failed(post_id: int, error: str) -> None:
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE scheduled_posts SET status = 'failed', error = ?, updated_at = ? "
+            "WHERE id = ?",
+            (error[:1000], _now_str(), post_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def slot_taken(channel_key: str, scheduled_at: str) -> bool:
+    """True nếu slot này đã có post queued/uploading (done không chặn slot cũ)."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM scheduled_posts WHERE channel_key = ? AND scheduled_at = ? "
+            "AND status IN ('queued', 'uploading')",
+            (channel_key, scheduled_at),
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def find_active(video_id: int, channel_key: str) -> Optional[dict]:
+    """Post đang hoạt động (queued/uploading/done) của video này cho kênh này.
+
+    Dùng để idempotent hoá approve: bấm ✅ hai lần không tạo 2 post.
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM scheduled_posts WHERE video_id = ? AND channel_key = ? "
+            f"AND status IN ({','.join('?' * len(ACTIVE_STATUSES))}) "
+            "ORDER BY id DESC LIMIT 1",
+            (video_id, channel_key, *ACTIVE_STATUSES),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_by_status(status: str, limit: int = 50) -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM scheduled_posts WHERE status = ? "
+            "ORDER BY scheduled_at, id LIMIT ?",
+            (status, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_stale_uploading(older_than_minutes: int = 90,
+                        now: Optional[str] = None) -> list[dict]:
+    """Post kẹt ở 'uploading' quá lâu (crash giữa upload).
+
+    KHÔNG tự retry — video có thể ĐÃ lên YouTube trước khi crash (upload xong
+    nhưng chưa kịp mark_done); tự đăng lại là tạo video trùng. Scheduler chỉ
+    alert để người kiểm tra kênh rồi quyết định mark done/failed thủ công.
+    """
+    now_dt = datetime.fromisoformat(now) if now else datetime.now()
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM scheduled_posts WHERE status = 'uploading'"
+        ).fetchall()
+        stale = []
+        for r in rows:
+            d = dict(r)
+            try:
+                updated = datetime.fromisoformat(d.get("updated_at") or d["created_at"])
+            except (TypeError, ValueError):
+                stale.append(d)
+                continue
+            if (now_dt - updated).total_seconds() > older_than_minutes * 60:
+                stale.append(d)
+        return stale
+    finally:
+        conn.close()
+
+
+def count_by_status() -> dict[str, int]:
+    """{'queued': n, 'done': n, ...} — cho health endpoint / báo cáo."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM scheduled_posts GROUP BY status"
+        ).fetchall()
+        return {r["status"]: r["n"] for r in rows}
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print("Scheduled posts by status:", count_by_status())

--- a/content-pipeline/storage/scheduled_posts.py
+++ b/content-pipeline/storage/scheduled_posts.py
@@ -101,6 +101,26 @@ def claim(post_id: int) -> bool:
         conn.close()
 
 
+def record_platform_id(post_id: int, platform_video_id: str,
+                       url: Optional[str] = None) -> None:
+    """Lưu platform id NGAY khi platform trả về, GIỮ NGUYÊN status 'uploading'.
+
+    Uploader gọi hàm này (qua callback) trước các bước best-effort sau upload
+    (thumbnail/caption) — crash trong các bước đó vẫn để lại bằng chứng "video
+    đã live" trên post row, đúng mục đích chống upload trùng của bảng này.
+    """
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE scheduled_posts SET platform_video_id = ?, url = ?, "
+            "updated_at = ? WHERE id = ?",
+            (platform_video_id, url, _now_str(), post_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def mark_done(post_id: int, platform_video_id: Optional[str] = None,
               url: Optional[str] = None) -> None:
     conn = get_connection()

--- a/content-pipeline/tests/test_health.py
+++ b/content-pipeline/tests/test_health.py
@@ -1,0 +1,65 @@
+"""Tests for webui/health.py (Phase 5 — health endpoint payload)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import webui.health as health
+
+
+class HealthBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestPayloadMigratedDb(HealthBase):
+    def setUp(self):
+        super().setUp()
+        db.init_db()
+        migrate.migrate_up()
+
+    def test_all_sections_present(self):
+        payload = health.build_health_payload()
+        for section in ("videos", "stories", "scheduler", "quota", "collectors"):
+            self.assertIn(section, payload)
+            self.assertNotIn("error", payload[section],
+                             f"section {section} unexpectedly errored")
+
+    def test_counts_reflect_data(self):
+        vid = db.insert_video(video_type="short", script_text="x")
+        db.update_video_status(vid, "pending_approval")
+        import storage.scheduled_posts as sp
+        sp.insert_post(vid, "drama_youtube", "2099-01-01 12:00:00")
+
+        payload = health.build_health_payload()
+        self.assertEqual(payload["videos"].get("pending_approval"), 1)
+        self.assertEqual(payload["scheduler"]["by_status"], {"queued": 1})
+        self.assertEqual(payload["scheduler"]["next_scheduled_at"],
+                         "2099-01-01 12:00:00")
+        self.assertEqual(payload["quota"]["youtube_units_used"], 0)
+
+
+class TestPayloadUnmigratedDb(HealthBase):
+    def test_missing_tables_error_per_section_not_whole_payload(self):
+        db.init_db()  # KHÔNG chạy migrate — stories/scheduled_posts/quota thiếu
+        payload = health.build_health_payload()
+        self.assertNotIn("error", payload["videos"])  # bảng videos luôn có
+        self.assertIn("error", payload["stories"])
+        self.assertIn("error", payload["scheduler"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -171,6 +171,25 @@ class TestRenderHappyPath(RenderBase):
         self.assertEqual(created, [42])
 
 
+class TestRepushStuckReviews(RenderBase):
+    def test_ready_drama_video_gets_repushed(self):
+        # push_review từng fail (Telegram down) → video kẹt 'ready', story đã
+        # 'produced' — render run sau phải tự push lại (finding Codex PR #70).
+        video_id = db.insert_video(video_type="short", script_text="x",
+                                   track="drama", destination="drama_youtube")
+        db.update_video_status(video_id, "ready")
+        with patch("notifier.review_bot.push_review", return_value=True) as push:
+            main_drama.render_approved_stories(limit=0)
+        push.assert_called_once_with(video_id)
+
+    def test_ai_ready_videos_not_touched(self):
+        video_id = db.insert_video(video_type="short", script_text="x")  # track ai
+        db.update_video_status(video_id, "ready")
+        with patch("notifier.review_bot.push_review") as push:
+            main_drama.render_approved_stories(limit=0)
+        push.assert_not_called()
+
+
 class TestRunDaily(RenderBase):
     def test_step_errors_collected_not_raised(self):
         with patch.object(main_drama, "render_approved_stories",

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -1,0 +1,194 @@
+"""Tests for main_drama.py (Phase 5 — Drama orchestrator)."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import main_drama
+
+
+class TestBuildNarration(unittest.TestCase):
+    def test_joins_hook_script_commentary(self):
+        rewrite = {"hook": "Hook sốc!", "script": "Chuyện là thế này...",
+                   "vn_commentary": "Ở Việt Nam mình..."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(
+            narration,
+            "Hook sốc!\n\nChuyện là thế này...\n\nỞ Việt Nam mình...")
+
+    def test_no_duplicate_when_script_contains_hook(self):
+        rewrite = {"hook": "Hook sốc!",
+                   "script": "Hook sốc! Chuyện là thế này...",
+                   "vn_commentary": "Bình luận."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.count("Hook sốc!"), 1)
+
+    def test_no_duplicate_commentary(self):
+        rewrite = {"hook": "H", "script": "Chuyện. Bình luận góc nhìn Việt.",
+                   "vn_commentary": "Bình luận góc nhìn Việt."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.count("Bình luận góc nhìn Việt."), 1)
+
+    def test_empty_rewrite(self):
+        self.assertEqual(main_drama.build_narration({}), "")
+
+
+class RenderBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _make_story(self, rewritten=None, status="approved"):
+        from storage.stories import insert_story, update_status
+        story_id = insert_story("reddit", f"src_{id(self)}_{status}", "raw")
+        rewritten_json = (json.dumps(rewritten, ensure_ascii=False)
+                          if isinstance(rewritten, dict) else rewritten)
+        update_status(story_id, status, rewritten_content=rewritten_json)
+        from storage.stories import get_story
+        return get_story(story_id)
+
+
+class TestRenderGuards(RenderBase):
+    def test_malformed_rewrite_flags_needs_review(self):
+        story = self._make_story(rewritten="not { json")
+        result = main_drama._render_story(story)
+        self.assertIsNone(result)
+        from storage.stories import get_story
+        self.assertEqual(get_story(story["id"])["status"], "needs_review")
+
+    def test_empty_narration_flags_needs_review(self):
+        story = self._make_story(rewritten={"title": "t", "script": ""})
+        self.assertIsNone(main_drama._render_story(story))
+        from storage.stories import get_story
+        self.assertEqual(get_story(story["id"])["status"], "needs_review")
+
+    def test_resume_guard_skips_story_with_existing_video(self):
+        story = self._make_story(rewritten={"title": "t", "script": "s"})
+        db.insert_video(video_type="short", script_text="s", track="drama",
+                        story_id=story["id"])
+        with patch.object(main_drama, "_render_story") as render:
+            created = main_drama.render_approved_stories(limit=5)
+        render.assert_not_called()
+        self.assertEqual(created, [])
+
+    def test_limit_respected(self):
+        for i in range(3):
+            from storage.stories import insert_story, update_status
+            sid = insert_story("reddit", f"limit_{i}", "raw")
+            update_status(sid, "approved",
+                          rewritten_content=json.dumps({"title": "t", "script": "s"}))
+        with patch.object(main_drama, "_render_story",
+                          side_effect=[101, 102, 103]) as render:
+            created = main_drama.render_approved_stories(limit=2)
+        self.assertEqual(len(created), 2)
+        self.assertEqual(render.call_count, 2)
+
+
+class TestRenderHappyPath(RenderBase):
+    def test_full_render_flow(self):
+        rewrite = {
+            "title": "Mẹ chồng gây sốc",
+            "hook": "Không ai ngờ được!",
+            "script": "Chuyện là thế này, tôi tên Mai...",
+            "vn_commentary": "Ở Việt Nam mình chuyện này...",
+            "thumbnail_prompt": "shocked woman",
+            "tags": ["mẹ chồng", "drama"],
+        }
+        story = self._make_story(rewritten=rewrite)
+
+        def fake_tts(text, track, output_path):
+            with open(output_path, "wb") as f:
+                f.write(b"audio")
+            return output_path
+
+        def fake_srt(text, duration, output_path):
+            with open(output_path, "w") as f:
+                f.write("1\n00:00:00,000 --> 00:00:01,000\nx\n")
+            return output_path
+
+        def fake_compose(audio, srt, output_path, **kwargs):
+            with open(output_path, "wb") as f:
+                f.write(b"video")
+            return output_path
+
+        with patch.object(db.config, "VIDEO_OUTPUT_DIR", self.tmp), \
+             patch("video.tts_client.synthesize_for_track", side_effect=fake_tts), \
+             patch("video.tts_client.get_audio_duration", return_value=60.0), \
+             patch("video.subtitle_generator.generate_srt", side_effect=fake_srt), \
+             patch("video.drama_composer.compose_drama_video",
+                   side_effect=fake_compose) as compose, \
+             patch("video.image_generator.generate_illustration", return_value=None), \
+             patch("notifier.review_bot.push_review", return_value=True) as push:
+            video_id = main_drama._render_story(story)
+
+        self.assertIsNotNone(video_id)
+        video = db.get_video(video_id)
+        self.assertEqual(video["story_id"], story["id"])
+        self.assertEqual(video["track"], "drama")
+        self.assertEqual(video["destination"], "drama_youtube")
+        self.assertEqual(video["status"], "ready")
+        self.assertTrue(os.path.exists(video["video_path"]))
+        # narration chứa cả hook lẫn commentary
+        self.assertIn("Không ai ngờ được!", video["script_text"])
+        self.assertIn("Ở Việt Nam mình", video["script_text"])
+        # hashtags sinh từ tags (bỏ dấu cách)
+        self.assertIn("#mẹchồng", video["tiktok_hashtags"])
+        # story chuyển 'produced', vn_commentary được truyền cho composer
+        from storage.stories import get_story
+        self.assertEqual(get_story(story["id"])["status"], "produced")
+        self.assertEqual(compose.call_args.kwargs.get("vn_commentary"),
+                         rewrite["vn_commentary"])
+        push.assert_called_once_with(video_id)
+
+    def test_tts_failure_marks_video_failed_and_story_retryable(self):
+        story = self._make_story(rewritten={"title": "t", "script": "nội dung"})
+        with patch.object(db.config, "VIDEO_OUTPUT_DIR", self.tmp), \
+             patch("video.tts_client.synthesize_for_track", return_value=None):
+            self.assertIsNone(main_drama._render_story(story))
+        from storage.stories import get_story
+        self.assertEqual(get_story(story["id"])["status"], "approved")
+        videos = db.get_videos_by_story(story["id"])
+        self.assertEqual([v["status"] for v in videos], ["failed"])
+        # row 'failed' KHÔNG chặn retry — lần chạy sau story được render lại
+        with patch.object(main_drama, "_render_story", return_value=42) as render:
+            created = main_drama.render_approved_stories(limit=1)
+        render.assert_called_once()
+        self.assertEqual(created, [42])
+
+
+class TestRunDaily(RenderBase):
+    def test_step_errors_collected_not_raised(self):
+        with patch.object(main_drama, "render_approved_stories",
+                          side_effect=RuntimeError("render boom")), \
+             patch.object(main_drama, "_send_summary_safe") as summ:
+            summary = main_drama.run_daily(steps=["render"])
+        self.assertEqual(summary["errors"], ["render: render boom"])
+        summ.assert_called_once()
+
+    def test_only_selected_steps_run(self):
+        with patch.object(main_drama, "render_approved_stories",
+                          return_value=[]) as render, \
+             patch.object(main_drama, "_send_summary_safe"):
+            summary = main_drama.run_daily(steps=["render"])
+        render.assert_called_once()
+        self.assertNotIn("collected", summary)
+        self.assertNotIn("scored", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_post_scheduler.py
+++ b/content-pipeline/tests/test_post_scheduler.py
@@ -1,0 +1,201 @@
+"""Tests for scheduler/post_scheduler.py (Phase 5 — cadence queue + tick)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.scheduled_posts as sp
+import scheduler.post_scheduler as ps
+
+
+def _make_video(**overrides) -> int:
+    fields = dict(video_type="short", script_text="x", track="drama",
+                  destination="drama_youtube")
+    fields.update(overrides)
+    return db.insert_video(**fields)
+
+
+class SchedulerBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestSlotParsing(unittest.TestCase):
+    def test_daily_slot(self):
+        self.assertEqual(ps._parse_slot_spec("21:00"), (None, 21, 0))
+
+    def test_weekly_slot(self):
+        self.assertEqual(ps._parse_slot_spec("sun 20:00"), (6, 20, 0))
+        self.assertEqual(ps._parse_slot_spec("Tuesday 19:30"), (1, 19, 30))
+
+    def test_bad_specs_raise(self):
+        for bad in ("someday 12:00", "12:00 extra stuff", "25:00", "12:99"):
+            with self.assertRaises(ValueError):
+                ps._parse_slot_spec(bad)
+
+    def test_all_cadence_entries_parse(self):
+        # Bắt lỗi typo trong CADENCE ngay ở test thay vì lúc runtime.
+        for specs in ps.CADENCE.values():
+            for spec in specs:
+                ps._parse_slot_spec(spec)
+
+
+class TestIterSlots(unittest.TestCase):
+    def test_daily_slots_strictly_after(self):
+        after = datetime(2026, 7, 7, 12, 0)  # đúng 12:00 → slot 12:00 hôm nay bị loại
+        slots = ps.iter_slots(["12:00", "21:00"], after, days=1)
+        self.assertEqual(slots[0], datetime(2026, 7, 7, 21, 0))
+        self.assertEqual(slots[1], datetime(2026, 7, 8, 12, 0))
+
+    def test_weekly_slot(self):
+        after = datetime(2026, 7, 7, 8, 0)  # thứ 3
+        slots = ps.iter_slots(["sun 20:00"], after, days=8)
+        self.assertEqual(slots[0], datetime(2026, 7, 12, 20, 0))
+
+
+class TestScheduleVideo(SchedulerBase):
+    def test_schedules_next_free_slot(self):
+        vid = _make_video()
+        now = datetime(2026, 7, 7, 9, 0)
+        post = ps.schedule_video(vid, "drama_youtube", now=now)
+        self.assertEqual(post["scheduled_at"], "2026-07-07 12:00:00")
+
+    def test_taken_slot_moves_to_next(self):
+        vid1, vid2 = _make_video(), _make_video()
+        now = datetime(2026, 7, 7, 9, 0)
+        ps.schedule_video(vid1, "drama_youtube", now=now)
+        post2 = ps.schedule_video(vid2, "drama_youtube", now=now)
+        self.assertEqual(post2["scheduled_at"], "2026-07-07 21:00:00")
+
+    def test_idempotent_per_video_channel(self):
+        vid = _make_video()
+        now = datetime(2026, 7, 7, 9, 0)
+        post1 = ps.schedule_video(vid, "drama_youtube", now=now)
+        post2 = ps.schedule_video(vid, "drama_youtube", now=now)
+        self.assertEqual(post1["id"], post2["id"])
+
+    def test_unknown_channel_raises(self):
+        vid = _make_video()
+        with self.assertRaises(ValueError):
+            ps.schedule_video(vid, "nonexistent_channel")
+
+    def test_long_video_weekly_cadence(self):
+        vid = _make_video(video_type="long")
+        now = datetime(2026, 7, 7, 9, 0)  # thứ 3
+        post = ps.schedule_video(vid, "drama_youtube", now=now)
+        self.assertEqual(post["scheduled_at"], "2026-07-12 20:00:00")  # CN 20:00
+
+
+class TestRunTick(SchedulerBase):
+    def _queue_due_post(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        return vid, post_id
+
+    def test_uploads_due_post(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch",
+                          return_value=(True, "https://youtu.be/abc", "abc")) as d, \
+             patch.object(ps, "_notify_published_safe"), \
+             patch.object(ps, "_alert_safe"):
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["uploaded"], 1)
+        d.assert_called_once()
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "done")
+        self.assertEqual(post["platform_video_id"], "abc")
+        self.assertEqual(db.get_video(vid)["status"], "published")
+        self.assertEqual(db.get_video(vid)["publish_url"], "https://youtu.be/abc")
+
+    def test_no_double_upload_on_second_tick(self):
+        self._queue_due_post()
+        with patch.object(ps, "_dispatch",
+                          return_value=(True, "u", "id")) as d, \
+             patch.object(ps, "_notify_published_safe"), \
+             patch.object(ps, "_alert_safe"):
+            ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+            summary2 = ps.run_tick(now=datetime(2026, 7, 7, 12, 7))
+        self.assertEqual(d.call_count, 1)
+        self.assertEqual(summary2["uploaded"], 0)
+
+    def test_failed_dispatch_marks_failed_and_alerts(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch", return_value=(False, "boom", None)), \
+             patch.object(ps, "_alert_safe") as alert:
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(sp.get_post(post_id)["status"], "failed")
+        alert.assert_called_once()
+
+    def test_dispatch_exception_does_not_stop_tick(self):
+        vid1, _ = self._queue_due_post()
+        vid2 = _make_video()
+        sp.insert_post(vid2, "drama_youtube", "2026-07-07 12:30:00")
+        with patch.object(ps, "_dispatch",
+                          side_effect=[RuntimeError("x"), (True, "u", "i")]), \
+             patch.object(ps, "_notify_published_safe"), \
+             patch.object(ps, "_alert_safe"):
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 13, 0))
+        self.assertEqual(summary["uploaded"], 1)
+        self.assertEqual(summary["failed"], 1)
+
+    def test_stale_uploading_alerts_but_never_retries(self):
+        vid, post_id = self._queue_due_post()
+        sp.claim(post_id)
+        conn = db.get_connection()
+        conn.execute("UPDATE scheduled_posts SET updated_at = '2020-01-01 00:00:00' "
+                     "WHERE id = ?", (post_id,))
+        conn.commit()
+        conn.close()
+        with patch.object(ps, "_dispatch") as d, \
+             patch.object(ps, "_alert_safe") as alert:
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["stale"], 1)
+        d.assert_not_called()  # video có thể ĐÃ lên kênh — không tự đăng lại
+        alert.assert_called_once()
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
+
+class TestDispatchTikTok(SchedulerBase):
+    def test_tiktok_without_token_exports_manual_queue(self):
+        vid = _make_video(destination=None)
+        post_id = sp.insert_post(vid, "tiktok_main", "2026-07-07 12:00:00")
+        with patch.object(ps.config, "TIKTOK_ACCESS_TOKEN", ""), \
+             patch("publisher.tiktok_manual.export_for_manual_upload",
+                   return_value="/queue/video_1.mp4") as exp:
+            ok, url, pid = ps._dispatch(sp.get_post(post_id))
+        self.assertTrue(ok)
+        self.assertEqual(url, "file:///queue/video_1.mp4")
+        exp.assert_called_once_with(vid)
+
+    def test_tiktok_with_token_uses_api(self):
+        vid = _make_video(destination=None)
+        db.update_video_paths(vid, video_path="/tmp/v.mp4")
+        post_id = sp.insert_post(vid, "tiktok_main", "2026-07-07 12:00:00")
+        with patch.object(ps.config, "TIKTOK_ACCESS_TOKEN", "tok"), \
+             patch("publisher.tiktok_uploader.upload_video",
+                   return_value="pub42") as up:
+            ok, url, pid = ps._dispatch(sp.get_post(post_id))
+        self.assertTrue(ok)
+        self.assertEqual(pid, "pub42")
+        up.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_post_scheduler.py
+++ b/content-pipeline/tests/test_post_scheduler.py
@@ -172,6 +172,48 @@ class TestRunTick(SchedulerBase):
         self.assertEqual(sp.get_post(post_id)["status"], "uploading")
 
 
+class TestDispatchYouTube(SchedulerBase):
+    def test_on_uploaded_persists_platform_id_before_return(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)
+
+        recorded_during_upload = {}
+
+        def fake_upload(video_id, channel_key, on_uploaded=None):
+            on_uploaded("yt7", "https://youtu.be/yt7")
+            # tại thời điểm này (giữa upload và thumbnail/caption) row đã
+            # phải mang platform_video_id dù vẫn 'uploading'
+            recorded_during_upload.update(sp.get_post(post_id))
+            return {"youtube_video_id": "yt7", "url": "https://youtu.be/yt7"}
+
+        with patch("publisher.youtube_uploader.upload_to_youtube",
+                   side_effect=fake_upload):
+            ok, url, pid = ps._dispatch(sp.get_post(post_id))
+        self.assertTrue(ok)
+        self.assertEqual(recorded_during_upload["platform_video_id"], "yt7")
+        self.assertEqual(recorded_during_upload["status"], "uploading")
+
+    def test_platform_id_survives_late_failure(self):
+        # Upload xong (on_uploaded đã bắn) nhưng bước sau chết → post failed
+        # nhưng vẫn giữ bằng chứng video đã live.
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+
+        def fake_upload(video_id, channel_key, on_uploaded=None):
+            on_uploaded("yt8", "https://youtu.be/yt8")
+            raise RuntimeError("died after upload")
+
+        with patch("publisher.youtube_uploader.upload_to_youtube",
+                   side_effect=fake_upload), \
+             patch.object(ps, "_alert_safe"):
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["failed"], 1)
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "failed")
+        self.assertEqual(post["platform_video_id"], "yt8")
+
+
 class TestDispatchTikTok(SchedulerBase):
     def test_tiktok_without_token_exports_manual_queue(self):
         vid = _make_video(destination=None)

--- a/content-pipeline/tests/test_preview.py
+++ b/content-pipeline/tests/test_preview.py
@@ -1,0 +1,83 @@
+"""Tests for video/preview.py (Phase 5 — Telegram preview compression)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import video.preview as preview
+
+
+class TestBuildPreviewCommand(unittest.TestCase):
+    def test_command_shape(self):
+        cmd = preview.build_preview_command("in.mp4", "out.mp4", 720, 28, "96k")
+        self.assertEqual(cmd[0], "ffmpeg")
+        self.assertIn("in.mp4", cmd)
+        self.assertEqual(cmd[-1], "out.mp4")
+        self.assertIn("-crf", cmd)
+        self.assertEqual(cmd[cmd.index("-crf") + 1], "28")
+        # scale theo chiều ngắn để xử lý được cả video dọc lẫn ngang
+        scale = cmd[cmd.index("-vf") + 1]
+        self.assertIn("720", scale)
+        self.assertIn("gt(iw,ih)", scale)
+
+
+class TestCompressForPreview(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.src = os.path.join(self.tmp, "video.mp4")
+        with open(self.src, "wb") as f:
+            f.write(b"x" * 1000)
+
+    def test_small_file_returned_as_is(self):
+        result = preview.compress_for_preview(self.src, max_bytes=10_000)
+        self.assertEqual(result, self.src)
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(preview.compress_for_preview(
+            os.path.join(self.tmp, "nope.mp4")))
+
+    def test_oversized_compresses_once_when_first_pass_fits(self):
+        def fake_ffmpeg(cmd, out):
+            with open(out, "wb") as f:
+                f.write(b"y" * 100)  # nhỏ hơn max
+            return out
+
+        with patch.object(preview, "_run_ffmpeg", side_effect=fake_ffmpeg) as run:
+            result = preview.compress_for_preview(self.src, max_bytes=500)
+        self.assertEqual(run.call_count, 1)
+        self.assertTrue(result.endswith("_preview.mp4"))
+
+    def test_second_pass_when_still_too_big(self):
+        sizes = iter([800, 100])  # pass 1 vẫn quá 500 bytes, pass 2 lọt
+
+        def fake_ffmpeg(cmd, out):
+            with open(out, "wb") as f:
+                f.write(b"y" * next(sizes))
+            return out
+
+        with patch.object(preview, "_run_ffmpeg", side_effect=fake_ffmpeg) as run:
+            result = preview.compress_for_preview(self.src, max_bytes=500)
+        self.assertEqual(run.call_count, 2)
+        self.assertIsNotNone(result)
+
+    def test_returns_none_when_nothing_fits(self):
+        def fake_ffmpeg(cmd, out):
+            with open(out, "wb") as f:
+                f.write(b"y" * 900)
+            return out
+
+        with patch.object(preview, "_run_ffmpeg", side_effect=fake_ffmpeg):
+            self.assertIsNone(preview.compress_for_preview(self.src, max_bytes=500))
+
+    def test_ffmpeg_failure_returns_none(self):
+        with patch.object(preview, "_run_ffmpeg", return_value=None):
+            self.assertIsNone(preview.compress_for_preview(self.src, max_bytes=500))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_quota.py
+++ b/content-pipeline/tests/test_quota.py
@@ -1,0 +1,77 @@
+"""Tests for storage/quota.py (Phase 5 — YouTube quota tracking)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.quota as quota
+
+
+class QuotaBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patches = [
+            patch.object(db.config, "DB_PATH", self.dbpath),
+            patch.object(quota.config, "YOUTUBE_DAILY_QUOTA", 1000),
+            patch.object(quota.config, "QUOTA_ALERT_RATIO", 0.8),
+        ]
+        for p in self._patches:
+            p.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+
+class TestQuotaDate(unittest.TestCase):
+    def test_pacific_date_rolls_back_from_utc(self):
+        # 05:00 UTC = 21:00/22:00 hôm TRƯỚC theo giờ Pacific
+        now = datetime(2026, 7, 7, 5, 0, tzinfo=timezone.utc)
+        self.assertEqual(quota.quota_date(now), "2026-07-06")
+
+    def test_pacific_same_day_in_utc_evening(self):
+        now = datetime(2026, 7, 7, 20, 0, tzinfo=timezone.utc)
+        self.assertEqual(quota.quota_date(now), "2026-07-07")
+
+
+class TestAddUnits(QuotaBase):
+    def test_accumulates(self):
+        quota.add_units(100)
+        total, _ = quota.add_units(200)
+        self.assertEqual(total, 300)
+        self.assertEqual(quota.units_used_today(), 300)
+
+    def test_crossed_flag_fires_once(self):
+        _, crossed = quota.add_units(700)
+        self.assertFalse(crossed)          # 700 < 800
+        _, crossed = quota.add_units(200)
+        self.assertTrue(crossed)           # 700 → 900 băng qua 800
+        _, crossed = quota.add_units(50)
+        self.assertFalse(crossed)          # đã ở trên ngưỡng — không alert lại
+
+    def test_record_youtube_units_alerts_on_cross(self):
+        with patch("notifier.telegram_bot.send_alert") as alert:
+            quota.record_youtube_units(700)
+            alert.assert_not_called()
+            quota.record_youtube_units(200)
+            alert.assert_called_once()
+
+    def test_alert_failure_does_not_break_recording(self):
+        with patch("notifier.telegram_bot.send_alert", side_effect=RuntimeError("down")):
+            total = quota.record_youtube_units(900)
+        self.assertEqual(total, 900)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_review_bot.py
+++ b/content-pipeline/tests/test_review_bot.py
@@ -1,0 +1,225 @@
+"""Tests for notifier/review_bot.py (Phase 5 — Telegram Review Gate)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import notifier.review_bot as rb
+
+
+class ReviewBotBase(unittest.TestCase):
+    """Temp DB + temp state file cho mỗi test."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patches = [
+            patch.object(db.config, "DB_PATH", self.dbpath),
+            patch.object(rb, "_STATE_FILE", os.path.join(self.tmp, "state.json")),
+        ]
+        for p in self._patches:
+            p.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    def _make_pending_video(self, **overrides):
+        fields = dict(video_type="short", script_text="kịch bản", track="drama",
+                      destination="drama_youtube", youtube_title="Tiêu đề")
+        fields.update(overrides)
+        video_id = db.insert_video(**fields)
+        db.update_video_status(video_id, "pending_approval")
+        return video_id
+
+
+class TestHandleCallbackParsing(ReviewBotBase):
+    def test_garbage_data(self):
+        for bad in ("", "xx:a:1", "rv:a", "rv:a:notanumber", None):
+            reply, kb = rb.handle_callback(bad)
+            self.assertIn("không hợp lệ", reply)
+            self.assertIsNone(kb)
+
+
+class TestApprove(ReviewBotBase):
+    def test_approve_routes_all_destinations(self):
+        video_id = self._make_pending_video()
+        with patch.object(rb, "_route_to_channel",
+                          side_effect=lambda v, k, c: f"  ok {k}") as route:
+            reply, kb = rb.handle_callback(f"rv:a:{video_id}")
+        self.assertIn("đã duyệt", reply)
+        routed = [c.args[1] for c in route.call_args_list]
+        # drama short → kênh đích + TikTok (account mixed nhận track drama)
+        self.assertEqual(routed, ["drama_youtube", "tiktok_main"])
+        self.assertEqual(db.get_video(video_id)["status"], "approved")
+
+    def test_double_approve_blocked(self):
+        video_id = self._make_pending_video()
+        with patch.object(rb, "_route_to_channel", return_value="  ok"):
+            rb.handle_callback(f"rv:a:{video_id}")
+            reply, _ = rb.handle_callback(f"rv:a:{video_id}")
+        self.assertIn("không ở trạng thái chờ duyệt", reply)
+
+    def test_approve_missing_video(self):
+        reply, _ = rb.handle_callback("rv:a:999")
+        self.assertIn("không tồn tại", reply)
+
+    def test_routing_error_reported_not_raised(self):
+        video_id = self._make_pending_video()
+        with patch.object(rb, "_route_to_channel", side_effect=RuntimeError("db down")):
+            reply, _ = rb.handle_callback(f"rv:a:{video_id}")
+        self.assertIn("lỗi xếp lịch", reply)
+
+
+class TestRouteToChannel(ReviewBotBase):
+    def test_tiktok_without_token_exports_manual(self):
+        video_id = self._make_pending_video()
+        video = db.get_video(video_id)
+        from channels import get_channel
+        with patch("config.TIKTOK_ACCESS_TOKEN", ""), \
+             patch("publisher.tiktok_manual.export_for_manual_upload",
+                   return_value="/q/v.mp4") as exp:
+            line = rb._route_to_channel(video, "tiktok_main", get_channel("tiktok_main"))
+        self.assertIn("queue upload tay", line)
+        exp.assert_called_once_with(video_id)
+
+    def test_youtube_schedules(self):
+        video_id = self._make_pending_video()
+        video = db.get_video(video_id)
+        from channels import get_channel
+        with patch("scheduler.post_scheduler.schedule_video",
+                   return_value={"scheduled_at": "2026-07-08 12:00:00"}) as sched:
+            line = rb._route_to_channel(video, "drama_youtube", get_channel("drama_youtube"))
+        self.assertIn("2026-07-08 12:00:00", line)
+        sched.assert_called_once_with(video_id, "drama_youtube")
+
+
+class TestReject(ReviewBotBase):
+    def test_reject_sets_status_and_awaits_reason(self):
+        video_id = self._make_pending_video()
+        reply, _ = rb.handle_callback(f"rv:r:{video_id}")
+        self.assertIn("đã loại", reply)
+        self.assertEqual(db.get_video(video_id)["status"], "rejected")
+        # lý do được lưu vào review_note
+        followup = rb.handle_awaiting_message("hook quá yếu")
+        self.assertIn("Đã lưu lý do", followup)
+        self.assertEqual(db.get_video(video_id)["review_note"], "hook quá yếu")
+
+    def test_skip_clears_awaiting(self):
+        video_id = self._make_pending_video()
+        rb.handle_callback(f"rv:r:{video_id}")
+        self.assertIsNotNone(rb.skip_awaiting())
+        # sau skip, message thường không còn bị nuốt bởi review FSM
+        self.assertIsNone(rb.handle_awaiting_message("tin nhắn khác"))
+
+    def test_skip_without_state(self):
+        self.assertIsNone(rb.skip_awaiting())
+
+
+class TestEditMetadata(ReviewBotBase):
+    def test_edit_menu_lists_fields(self):
+        video_id = self._make_pending_video()
+        reply, kb = rb.handle_callback(f"rv:e:{video_id}")
+        self.assertIsNotNone(kb)
+        datas = [btn["callback_data"] for row in kb["inline_keyboard"] for btn in row]
+        self.assertIn(f"rv:ef:{video_id}:title", datas)
+
+    def test_edit_field_flow_updates_db(self):
+        video_id = self._make_pending_video()
+        reply, _ = rb.handle_callback(f"rv:ef:{video_id}:title")
+        self.assertIn("Tiêu đề", reply)
+        followup = rb.handle_awaiting_message("Tiêu đề mới hay hơn")
+        self.assertIn("Đã cập nhật", followup)
+        self.assertEqual(db.get_video(video_id)["youtube_title"], "Tiêu đề mới hay hơn")
+
+    def test_unknown_field_rejected(self):
+        video_id = self._make_pending_video()
+        reply, _ = rb.handle_callback(f"rv:ef:{video_id}:status")
+        self.assertIn("không hợp lệ", reply)
+
+    def test_state_survives_restart(self):
+        # State ghi ra file — module "restart" (đọc lại file) vẫn thấy.
+        video_id = self._make_pending_video()
+        rb.handle_callback(f"rv:ef:{video_id}:cap")
+        followup = rb.handle_awaiting_message("caption mới")
+        self.assertIn("Đã cập nhật", followup)
+        self.assertEqual(db.get_video(video_id)["tiktok_caption"], "caption mới")
+
+
+class TestDestinationsFor(ReviewBotBase):
+    def test_drama_short_gets_youtube_and_tiktok(self):
+        video = {"track": "drama", "video_type": "short",
+                 "destination": "drama_youtube"}
+        self.assertEqual(rb._destinations_for(video),
+                         ["drama_youtube", "tiktok_main"])
+
+    def test_long_video_not_duplicated_to_tiktok(self):
+        video = {"track": "drama", "video_type": "long",
+                 "destination": "drama_youtube"}
+        self.assertEqual(rb._destinations_for(video), ["drama_youtube"])
+
+    def test_no_destination_falls_back_to_track(self):
+        video = {"track": "ai", "video_type": "short", "destination": None}
+        dests = rb._destinations_for(video)
+        self.assertIn("ai_youtube", dests)
+        self.assertIn("tiktok_main", dests)
+        self.assertNotIn("drama_youtube", dests)
+
+
+class TestAwaitingMessageNoState(ReviewBotBase):
+    def test_returns_none_so_seed_bot_can_handle(self):
+        self.assertIsNone(rb.handle_awaiting_message("text bất kỳ"))
+
+
+class TestTelegramCallbackDispatch(ReviewBotBase):
+    """_handle_callback_query trong telegram_bot phải answer + gửi reply."""
+
+    def test_dispatch_answers_and_replies(self):
+        import notifier.telegram_bot as tb
+        cq = {"id": "cb1", "data": "rv:a:1",
+              "message": {"chat": {"id": 123}}}
+        with patch.object(tb.config, "TELEGRAM_CHAT_ID", "123"), \
+             patch.object(tb, "_answer_callback_query") as ans, \
+             patch.object(tb, "_send_text") as send, \
+             patch("notifier.review_bot.handle_callback",
+                   return_value=("done", None)):
+            tb._handle_callback_query(cq)
+        ans.assert_called_once_with("cb1")
+        send.assert_called_once_with("done")
+
+    def test_wrong_chat_ignored(self):
+        import notifier.telegram_bot as tb
+        cq = {"id": "cb1", "data": "rv:a:1",
+              "message": {"chat": {"id": 666}}}
+        with patch.object(tb.config, "TELEGRAM_CHAT_ID", "123"), \
+             patch.object(tb, "_answer_callback_query") as ans, \
+             patch.object(tb, "_send_text") as send:
+            tb._handle_callback_query(cq)
+        ans.assert_called_once()
+        send.assert_not_called()
+
+    def test_keyboard_reply_uses_keyboard_sender(self):
+        import notifier.telegram_bot as tb
+        kb = {"inline_keyboard": []}
+        cq = {"id": "cb1", "data": "rv:e:1",
+              "message": {"chat": {"id": 123}}}
+        with patch.object(tb.config, "TELEGRAM_CHAT_ID", "123"), \
+             patch.object(tb, "_answer_callback_query"), \
+             patch.object(tb, "send_message_with_keyboard") as send_kb, \
+             patch("notifier.review_bot.handle_callback",
+                   return_value=("chọn field", kb)):
+            tb._handle_callback_query(cq)
+        send_kb.assert_called_once_with("chọn field", kb)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_review_bot.py
+++ b/content-pipeline/tests/test_review_bot.py
@@ -175,6 +175,104 @@ class TestDestinationsFor(ReviewBotBase):
         self.assertNotIn("drama_youtube", dests)
 
 
+class TestApproveBadDestination(ReviewBotBase):
+    def test_stale_destination_reports_error_and_routes_rest(self):
+        # destination không còn trong registry — không được nổ cả handler
+        # sau khi đã claim 'approved' (finding Codex PR #70).
+        video_id = self._make_pending_video(destination="ghost_channel")
+        with patch.object(rb, "_route_to_channel",
+                          side_effect=lambda v, k, c: f"  ok {k}") as route:
+            reply, _ = rb.handle_callback(f"rv:a:{video_id}")
+        self.assertIn("đã duyệt", reply)
+        self.assertIn("ghost_channel: lỗi xếp lịch", reply)
+        self.assertIn("Xếp tay:", reply)
+        # kênh còn lại (tiktok_main cho track drama) vẫn được route
+        routed = [c.args[1] for c in route.call_args_list]
+        self.assertEqual(routed, ["tiktok_main"])
+
+
+class TestPushReview(ReviewBotBase):
+    def _make_ready_video_with_file(self):
+        video_id = self._make_pending_video()
+        db.update_video_status(video_id, "ready")
+        src = os.path.join(self.tmp, f"v_{video_id}.mp4")
+        with open(src, "wb") as f:
+            f.write(b"mp4")
+        db.update_video_paths(video_id, video_path=src)
+        return video_id
+
+    def test_video_sent_sets_pending(self):
+        video_id = self._make_ready_video_with_file()
+        import notifier.telegram_bot as tb
+        with patch.object(tb, "_send_text", return_value=True), \
+             patch.object(tb, "_send_video_file", return_value="55"), \
+             patch("video.preview.compress_for_preview", side_effect=lambda p: p):
+            self.assertTrue(rb.push_review(video_id))
+        self.assertEqual(db.get_video(video_id)["status"], "pending_approval")
+
+    def test_fallback_keyboard_delivered_sets_pending(self):
+        video_id = self._make_ready_video_with_file()
+        import notifier.telegram_bot as tb
+        with patch.object(tb, "_send_text", return_value=True), \
+             patch.object(tb, "_send_video_file", return_value=None), \
+             patch.object(tb, "send_message_with_keyboard", return_value=True) as kb, \
+             patch("video.preview.compress_for_preview", side_effect=lambda p: p):
+            self.assertTrue(rb.push_review(video_id))
+        kb.assert_called_once()
+        self.assertEqual(db.get_video(video_id)["status"], "pending_approval")
+
+    def test_no_keyboard_delivered_stays_ready(self):
+        # Script tới nhưng KHÔNG có keyboard nào tới tay reviewer → không được
+        # đánh dấu pending_approval (script suông không bấm ✅ được) — giữ
+        # 'ready' để _repush_stuck_reviews thử lại (finding Codex PR #70).
+        video_id = self._make_ready_video_with_file()
+        import notifier.telegram_bot as tb
+        with patch.object(tb, "_send_text", return_value=True), \
+             patch.object(tb, "_send_video_file", return_value=None), \
+             patch.object(tb, "send_message_with_keyboard", return_value=False), \
+             patch("video.preview.compress_for_preview", side_effect=lambda p: p):
+            self.assertFalse(rb.push_review(video_id))
+        self.assertEqual(db.get_video(video_id)["status"], "ready")
+
+
+class TestLegacyCommandRouting(ReviewBotBase):
+    """Lệnh /approve_<id> cũ trên video review-gate phải đi qua scheduler
+    routing thay vì publish ngay (finding Codex PR #70)."""
+
+    def _dispatch(self, text, publish_callback=None):
+        import notifier.telegram_bot as tb
+        from unittest.mock import MagicMock
+        update = {"message": {"text": text, "chat": {"id": 123}}}
+        with patch.object(tb.config, "TELEGRAM_CHAT_ID", "123"), \
+             patch.object(tb, "_send_text") as send:
+            tb._handle_update(update, publish_callback or MagicMock())
+        return send
+
+    def test_legacy_approve_on_gated_video_routes_to_review_bot(self):
+        video_id = self._make_pending_video()  # destination=drama_youtube
+        with patch("notifier.review_bot.handle_callback",
+                   return_value=("routed!", None)) as cb:
+            send = self._dispatch(f"/approve_{video_id}")
+        cb.assert_called_once_with(f"rv:a:{video_id}")
+        send.assert_called_once_with("routed!")
+
+    def test_legacy_reject_on_gated_video_routes_to_review_bot(self):
+        video_id = self._make_pending_video()
+        with patch("notifier.review_bot.handle_callback",
+                   return_value=("rejected!", None)) as cb:
+            self._dispatch(f"/reject_{video_id}")
+        cb.assert_called_once_with(f"rv:r:{video_id}")
+
+    def test_legacy_approve_on_ai_video_keeps_old_publish_flow(self):
+        video_id = db.insert_video(video_type="short", script_text="x")  # no destination
+        db.update_video_status(video_id, "pending_approval")
+        publish = MagicMock()
+        with patch("notifier.review_bot.handle_callback") as cb:
+            self._dispatch(f"/approve_{video_id}", publish_callback=publish)
+        cb.assert_not_called()
+        publish.assert_called_once_with(video_id)
+
+
 class TestAwaitingMessageNoState(ReviewBotBase):
     def test_returns_none_so_seed_bot_can_handle(self):
         self.assertIsNone(rb.handle_awaiting_message("text bất kỳ"))

--- a/content-pipeline/tests/test_scheduled_posts.py
+++ b/content-pipeline/tests/test_scheduled_posts.py
@@ -72,6 +72,25 @@ class TestClaim(ScheduledPostsBase):
         self.assertEqual(post["status"], "done")
         self.assertEqual(post["platform_video_id"], "yt123")
 
+    def test_record_platform_id_keeps_uploading_status(self):
+        # Bằng chứng "đã live" phải ghi được TRƯỚC khi mark_done (chống mất
+        # dấu khi crash giữa thumbnail/caption — finding Codex PR #70).
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "yt9", url="https://youtu.be/yt9")
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "uploading")
+        self.assertEqual(post["platform_video_id"], "yt9")
+
+    def test_mark_failed_keeps_platform_id(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "yt9")
+        sp.mark_failed(post_id, "thumbnail step died")
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "failed")
+        self.assertEqual(post["platform_video_id"], "yt9")
+
     def test_mark_failed_records_error(self):
         post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
         sp.mark_failed(post_id, "quota exceeded")

--- a/content-pipeline/tests/test_scheduled_posts.py
+++ b/content-pipeline/tests/test_scheduled_posts.py
@@ -1,0 +1,131 @@
+"""Tests for storage/scheduled_posts.py (Phase 5 — Distribution)."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.scheduled_posts as sp
+
+
+class ScheduledPostsBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestInsertAndGet(ScheduledPostsBase):
+    def test_insert_returns_id(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        self.assertIsInstance(post_id, int)
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "queued")
+        self.assertEqual(post["channel_key"], "drama_youtube")
+
+    def test_slot_unique_for_active_posts(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        with self.assertRaises(sqlite3.IntegrityError):
+            sp.insert_post(2, "drama_youtube", "2026-07-08 12:00:00")
+
+    def test_same_slot_ok_after_failed(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.mark_failed(post_id, "boom")
+        # slot giải phóng khi post trước failed
+        sp.insert_post(2, "drama_youtube", "2026-07-08 12:00:00")
+
+    def test_video_channel_unique_while_active(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        with self.assertRaises(sqlite3.IntegrityError):
+            sp.insert_post(1, "drama_youtube", "2026-07-08 21:00:00")
+
+    def test_same_video_other_channel_ok(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.insert_post(1, "tiktok_main", "2026-07-08 12:00:00")
+
+
+class TestClaim(ScheduledPostsBase):
+    def test_claim_once(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        self.assertTrue(sp.claim(post_id))
+        self.assertFalse(sp.claim(post_id))  # đã uploading — lần 2 thua
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
+    def test_mark_done_records_platform_id(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.mark_done(post_id, platform_video_id="yt123", url="https://youtu.be/yt123")
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "done")
+        self.assertEqual(post["platform_video_id"], "yt123")
+
+    def test_mark_failed_records_error(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.mark_failed(post_id, "quota exceeded")
+        self.assertEqual(sp.get_post(post_id)["error"], "quota exceeded")
+
+
+class TestQueries(ScheduledPostsBase):
+    def test_get_due_only_past_queued(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.insert_post(2, "drama_youtube", "2099-01-01 12:00:00")
+        due = sp.get_due(now="2026-07-08 12:03:00")
+        self.assertEqual([p["video_id"] for p in due], [1])
+
+    def test_slot_taken(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        self.assertTrue(sp.slot_taken("drama_youtube", "2026-07-08 12:00:00"))
+        self.assertFalse(sp.slot_taken("drama_youtube", "2026-07-08 21:00:00"))
+        self.assertFalse(sp.slot_taken("ai_youtube", "2026-07-08 12:00:00"))
+
+    def test_find_active(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        found = sp.find_active(1, "drama_youtube")
+        self.assertEqual(found["id"], post_id)
+        self.assertIsNone(sp.find_active(1, "ai_youtube"))
+        sp.mark_failed(post_id, "x")
+        self.assertIsNone(sp.find_active(1, "drama_youtube"))
+
+    def test_find_active_includes_done(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.mark_done(post_id, "yt1", "https://youtu.be/yt1")
+        # done vẫn "active" — video đã lên kênh, không được xếp lịch lại
+        self.assertIsNotNone(sp.find_active(1, "drama_youtube"))
+
+    def test_stale_uploading(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        # tươi mới → chưa stale
+        self.assertEqual(sp.get_stale_uploading(older_than_minutes=90), [])
+        # già hoá updated_at trực tiếp
+        conn = db.get_connection()
+        conn.execute("UPDATE scheduled_posts SET updated_at = '2020-01-01 00:00:00' "
+                     "WHERE id = ?", (post_id,))
+        conn.commit()
+        conn.close()
+        stale = sp.get_stale_uploading(older_than_minutes=90)
+        self.assertEqual([p["id"] for p in stale], [post_id])
+
+    def test_count_by_status(self):
+        sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        p2 = sp.insert_post(2, "drama_youtube", "2026-07-08 21:00:00")
+        sp.mark_failed(p2, "x")
+        self.assertEqual(sp.count_by_status(), {"queued": 1, "failed": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_telegram_approval.py
+++ b/content-pipeline/tests/test_telegram_approval.py
@@ -49,6 +49,13 @@ class TestSendVideoForApproval(unittest.TestCase):
         self.p_tgid.start()
         self.addCleanup(self.p_tgid.stop)
 
+        # Phase 5: preview compression chạy trước khi gửi — pass-through để
+        # các test này tiếp tục pin hành vi reviewability, không test nén.
+        self.p_prev = patch("video.preview.compress_for_preview",
+                            side_effect=lambda p: p)
+        self.p_prev.start()
+        self.addCleanup(self.p_prev.stop)
+
     def test_video_upload_fails_but_script_sent_sets_pending(self):
         """Core issue #60: video upload fails, script ok -> pending_approval."""
         with patch.object(tb, "get_video", return_value=_video()), \

--- a/content-pipeline/tests/test_tiktok_manual.py
+++ b/content-pipeline/tests/test_tiktok_manual.py
@@ -1,0 +1,91 @@
+"""Tests for publisher/tiktok_manual.py (Phase 5 — manual export queue)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import publisher.tiktok_manual as tm
+
+
+class TikTokManualBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self.queue = os.path.join(self.tmp, "queue")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _make_video_with_file(self, caption="Chuyện mẹ chồng", hashtags="#drama #mechong"):
+        video_id = db.insert_video(video_type="short", script_text="x",
+                                   tiktok_caption=caption, tiktok_hashtags=hashtags)
+        src = os.path.join(self.tmp, f"src_{video_id}.mp4")
+        with open(src, "wb") as f:
+            f.write(b"fake mp4 bytes")
+        db.update_video_paths(video_id, video_path=src)
+        return video_id
+
+
+class TestExport(TikTokManualBase):
+    def test_exports_mp4_and_caption_txt(self):
+        video_id = self._make_video_with_file()
+        dest = tm.export_for_manual_upload(video_id, queue_dir=self.queue)
+        self.assertTrue(os.path.exists(dest))
+        txt = dest.replace(".mp4", ".txt")
+        with open(txt, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("Chuyện mẹ chồng", content)
+        self.assertIn("#drama #mechong", content)
+
+    def test_export_is_idempotent(self):
+        video_id = self._make_video_with_file()
+        first = tm.export_for_manual_upload(video_id, queue_dir=self.queue)
+        second = tm.export_for_manual_upload(video_id, queue_dir=self.queue)
+        self.assertEqual(first, second)
+        day_dir = os.path.dirname(first)
+        mp4s = [f for f in os.listdir(day_dir) if f.endswith(".mp4")]
+        self.assertEqual(len(mp4s), 1)
+
+    def test_missing_video_returns_none(self):
+        self.assertIsNone(tm.export_for_manual_upload(999, queue_dir=self.queue))
+
+    def test_missing_file_returns_none(self):
+        video_id = db.insert_video(video_type="short", script_text="x")
+        self.assertIsNone(tm.export_for_manual_upload(video_id, queue_dir=self.queue))
+
+    def test_caption_falls_back_to_youtube_title(self):
+        video_id = db.insert_video(video_type="short", script_text="x",
+                                   youtube_title="Tiêu đề YT")
+        src = os.path.join(self.tmp, "s.mp4")
+        with open(src, "wb") as f:
+            f.write(b"x")
+        db.update_video_paths(video_id, video_path=src)
+        dest = tm.export_for_manual_upload(video_id, queue_dir=self.queue)
+        with open(dest.replace(".mp4", ".txt"), encoding="utf-8") as f:
+            self.assertIn("Tiêu đề YT", f.read())
+
+
+class TestListQueue(TikTokManualBase):
+    def test_empty_queue(self):
+        self.assertEqual(tm.list_queue(queue_dir=self.queue), {})
+
+    def test_lists_by_day(self):
+        video_id = self._make_video_with_file()
+        tm.export_for_manual_upload(video_id, queue_dir=self.queue)
+        result = tm.list_queue(queue_dir=self.queue)
+        self.assertEqual(len(result), 1)
+        (day, files), = result.items()
+        self.assertEqual(files, [f"video_{video_id}.mp4"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_youtube_multichannel.py
+++ b/content-pipeline/tests/test_youtube_multichannel.py
@@ -1,0 +1,131 @@
+"""Tests for publisher/youtube_uploader.py multi-channel additions (Phase 5)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import publisher.youtube_uploader as yu
+
+
+class TestResolveTokenFile(unittest.TestCase):
+    def test_reads_channel_env_from_config(self):
+        with patch.object(yu.config, "YOUTUBE_DRAMA_TOKEN",
+                          "publisher/.youtube_token_drama.json"):
+            path = yu.resolve_token_file("drama_youtube")
+        self.assertEqual(path, "publisher/.youtube_token_drama.json")
+
+    def test_empty_env_falls_back_to_legacy_token(self):
+        with patch.object(yu.config, "YOUTUBE_AI_TOKEN", ""), \
+             patch.dict(os.environ, {"YOUTUBE_AI_TOKEN": ""}):
+            path = yu.resolve_token_file("ai_youtube")
+        self.assertEqual(path, yu.config.YOUTUBE_TOKEN_FILE)
+
+    def test_unknown_channel_raises(self):
+        with self.assertRaises(ValueError):
+            yu.resolve_token_file("nonexistent")
+
+
+class TestBuildVideoBody(unittest.TestCase):
+    def _video(self, **overrides):
+        video = {"id": 5, "video_type": "short", "track": "drama",
+                 "youtube_title": "Mẹ chồng làm loạn",
+                 "youtube_description": "desc",
+                 "tiktok_hashtags": "#mechong #drama"}
+        video.update(overrides)
+        return video
+
+    def test_drama_uses_entertainment_category(self):
+        body = yu._build_video_body(self._video(), "drama_youtube")
+        self.assertEqual(body["snippet"]["categoryId"], "24")
+
+    def test_ai_keeps_existing_category_28(self):
+        body = yu._build_video_body(self._video(track="ai"), "ai_youtube")
+        self.assertEqual(body["snippet"]["categoryId"], "28")
+
+    def test_short_gets_shorts_tag_in_title(self):
+        body = yu._build_video_body(self._video(), "drama_youtube")
+        self.assertIn("#Shorts", body["snippet"]["title"])
+
+    def test_long_has_no_shorts_tag(self):
+        body = yu._build_video_body(self._video(video_type="long"), "drama_youtube")
+        self.assertNotIn("#Shorts", body["snippet"]["title"])
+
+    def test_hashtags_merged_into_tags(self):
+        body = yu._build_video_body(self._video(), "drama_youtube")
+        self.assertIn("mechong", body["snippet"]["tags"])
+
+    def test_privacy_from_config(self):
+        with patch.object(yu.config, "YOUTUBE_PRIVACY", "unlisted"):
+            body = yu._build_video_body(self._video(), "drama_youtube")
+        self.assertEqual(body["status"]["privacyStatus"], "unlisted")
+
+    def test_title_fallback_when_missing(self):
+        body = yu._build_video_body(
+            self._video(youtube_title="", tiktok_caption=""), "drama_youtube")
+        self.assertTrue(body["snippet"]["title"])
+
+
+class TestSplitHashtags(unittest.TestCase):
+    def test_strips_hash_and_empties(self):
+        self.assertEqual(yu._split_hashtags("#a #b c  # "), ["a", "b", "c"])
+        self.assertEqual(yu._split_hashtags(""), [])
+        self.assertEqual(yu._split_hashtags(None), [])
+
+
+class TestExecuteResumable(unittest.TestCase):
+    def test_retries_transient_then_succeeds(self):
+        request = MagicMock()
+        request.next_chunk.side_effect = [
+            ConnectionError("reset"),
+            TimeoutError("slow"),
+            (None, {"id": "abc"}),
+        ]
+        with patch.object(yu.time, "sleep") as sleep:
+            response = yu._execute_resumable(request)
+        self.assertEqual(response, {"id": "abc"})
+        self.assertEqual(sleep.call_count, 2)
+        # exponential: 2s rồi 4s
+        self.assertEqual([c.args[0] for c in sleep.call_args_list], [2, 4])
+
+    def test_non_transient_raises_immediately(self):
+        request = MagicMock()
+        request.next_chunk.side_effect = ValueError("bad metadata")
+        with patch.object(yu.time, "sleep") as sleep:
+            with self.assertRaises(ValueError):
+                yu._execute_resumable(request)
+        sleep.assert_not_called()
+
+    def test_gives_up_after_max_retries(self):
+        request = MagicMock()
+        request.next_chunk.side_effect = ConnectionError("dead")
+        with patch.object(yu.time, "sleep"):
+            with self.assertRaises(ConnectionError):
+                yu._execute_resumable(request)
+        # 1 lần đầu + _MAX_CHUNK_RETRIES lần retry
+        self.assertEqual(request.next_chunk.call_count, yu._MAX_CHUNK_RETRIES + 1)
+
+
+class TestUploadToYoutubeGuards(unittest.TestCase):
+    def test_missing_video_returns_none(self):
+        with patch("storage.database.get_video", return_value=None):
+            self.assertIsNone(yu.upload_to_youtube(999, "drama_youtube"))
+
+    def test_missing_file_returns_none(self):
+        video = {"id": 1, "video_path": "/nonexistent/v.mp4"}
+        with patch("storage.database.get_video", return_value=video):
+            self.assertIsNone(yu.upload_to_youtube(1, "drama_youtube"))
+
+    def test_non_youtube_channel_returns_none(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as f:
+            video = {"id": 1, "video_path": f.name}
+            with patch("storage.database.get_video", return_value=video):
+                self.assertIsNone(yu.upload_to_youtube(1, "tiktok_main"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/video/preview.py
+++ b/content-pipeline/video/preview.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""
+Preview compression (Phase 5 EPIC #5.1 — Video compress <50MB).
+
+Telegram Bot API từ chối file >50MB; trước đây video quá cỡ bị BỎ QUA và
+reviewer chỉ duyệt qua script (issue #60). Module này nén một bản PREVIEW
+riêng (hạ resolution + CRF cao) chỉ để gửi Telegram — file gốc dùng để upload
+không bị đụng tới.
+
+Nén 2 nấc: 720p/CRF28 trước; vẫn quá 50MB (video rất dài) thì 480p/CRF32.
+Vẫn không lọt → trả None, caller giữ hành vi cũ (script-only review).
+"""
+
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from video.video_composer import _run_ffmpeg
+
+logger = logging.getLogger(__name__)
+
+# Trần của Telegram Bot API — đồng bộ với notifier.telegram_bot.TELEGRAM_MAX_FILE_BYTES.
+DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+
+# (max chiều-ngắn, CRF, audio bitrate) — thử lần lượt tới khi lọt size.
+_PASSES = [
+    (720, 28, "96k"),
+    (480, 32, "64k"),
+]
+
+
+def build_preview_command(src: str, dst: str, short_side: int, crf: int,
+                          audio_bitrate: str) -> list[str]:
+    """ffmpeg command nén preview (pure, unit-testable).
+
+    Scale theo chiều NGẮN (min(w,h) → short_side) để cả video dọc 1080x1920
+    lẫn ngang 1920x1080 đều co về cùng cỡ; -2 giữ chẵn để libx264 không kêu.
+    """
+    scale = (f"scale='if(gt(iw,ih),-2,{short_side})'"
+             f":'if(gt(iw,ih),{short_side},-2)'")
+    return [
+        "ffmpeg", "-y", "-i", src,
+        "-vf", scale,
+        "-c:v", "libx264", "-preset", "fast", "-crf", str(crf),
+        "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", audio_bitrate,
+        "-movflags", "+faststart",
+        dst,
+    ]
+
+
+def compress_for_preview(video_path: str, preview_path: str | None = None,
+                         max_bytes: int = DEFAULT_MAX_BYTES) -> str | None:
+    """Trả về đường dẫn file gửi được qua Telegram (<= max_bytes).
+
+    - File gốc đã đủ nhỏ → trả chính nó, không tốn ffmpeg.
+    - Quá cỡ → nén ra `preview_path` (mặc định `<tên>_preview.mp4` cạnh file
+      gốc) qua các nấc _PASSES. Không nấc nào lọt → None.
+    """
+    try:
+        size = os.path.getsize(video_path)
+    except OSError as e:
+        logger.error("compress_for_preview: cannot stat %s: %s", video_path, e)
+        return None
+    if size <= max_bytes:
+        return video_path
+
+    if preview_path is None:
+        base, _ = os.path.splitext(video_path)
+        preview_path = f"{base}_preview.mp4"
+
+    for short_side, crf, audio_bitrate in _PASSES:
+        cmd = build_preview_command(video_path, preview_path, short_side, crf,
+                                    audio_bitrate)
+        if _run_ffmpeg(cmd, preview_path) is None:
+            logger.error("Preview compression failed at %dp", short_side)
+            return None
+        new_size = os.path.getsize(preview_path)
+        logger.info("Preview %dp/crf%d: %.1f MB → %.1f MB",
+                    short_side, crf, size / 1024 / 1024, new_size / 1024 / 1024)
+        if new_size <= max_bytes:
+            return preview_path
+
+    logger.error("Preview still over %d MB after all passes — giving up",
+                 max_bytes // 1024 // 1024)
+    return None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) > 1:
+        print(compress_for_preview(sys.argv[1]))
+    else:
+        print("Usage: python -m video.preview <video.mp4>")

--- a/content-pipeline/webui/health.py
+++ b/content-pipeline/webui/health.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+"""
+Health endpoint (Phase 5 EPIC #5.4) — mini HTTP server local trả `/health`
+với trạng thái từng module: video/story theo status, queue scheduler, quota
+YouTube hôm nay, last_success của collectors.
+
+Chạy: python -m webui.health   (bind 127.0.0.1 ONLY — như webui/app.py,
+không bao giờ expose public; Telegram daily report có thể kéo JSON từ đây).
+
+`build_health_payload()` là pure DB nên unit-test được; mỗi section bọc
+try/except riêng — DB chưa migrate đủ (thiếu bảng) chỉ làm section đó báo
+lỗi chứ không 500 cả endpoint.
+"""
+
+import json
+import logging
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def _count_by_status(table: str) -> dict:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            f"SELECT status, COUNT(*) AS n FROM {table} GROUP BY status"
+        ).fetchall()
+        return {r["status"]: r["n"] for r in rows}
+    finally:
+        conn.close()
+
+
+def _section(fn):
+    """Chạy 1 section, lỗi → {'error': ...} thay vì sập cả payload."""
+    try:
+        return fn()
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
+def build_health_payload() -> dict:
+    def videos():
+        return _count_by_status("videos")
+
+    def stories():
+        return _count_by_status("stories")
+
+    def scheduler():
+        from storage import scheduled_posts
+        counts = scheduled_posts.count_by_status()
+        queued = scheduled_posts.get_by_status("queued", limit=1)
+        return {
+            "by_status": counts,
+            "next_scheduled_at": queued[0]["scheduled_at"] if queued else None,
+            "stale_uploading": len(scheduled_posts.get_stale_uploading()),
+        }
+
+    def quota():
+        from storage.quota import units_used_today, quota_date
+        used = units_used_today("youtube")
+        return {
+            "date_pt": quota_date(),
+            "youtube_units_used": used,
+            "youtube_units_limit": config.YOUTUBE_DAILY_QUOTA,
+            "used_ratio": round(used / config.YOUTUBE_DAILY_QUOTA, 3),
+        }
+
+    def collectors():
+        conn = get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT name, last_success FROM collector_health"
+            ).fetchall()
+            return {r["name"]: r["last_success"] for r in rows}
+        finally:
+            conn.close()
+
+    return {
+        "generated_at": datetime.now().isoformat(sep=" ", timespec="seconds"),
+        "videos": _section(videos),
+        "stories": _section(stories),
+        "scheduler": _section(scheduler),
+        "quota": _section(quota),
+        "collectors": _section(collectors),
+    }
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+        if self.path.split("?")[0].rstrip("/") not in ("", "/health"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = json.dumps(build_health_payload(), ensure_ascii=False,
+                          indent=2).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        logger.debug("health: " + fmt, *args)
+
+
+def run(port: int | None = None):
+    port = port or config.HEALTH_PORT
+    server = HTTPServer(("127.0.0.1", port), _HealthHandler)
+    logger.info("Health endpoint on http://127.0.0.1:%d/health", port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run()

--- a/docs/current/oauth-setup.md
+++ b/docs/current/oauth-setup.md
@@ -88,9 +88,11 @@ nào* lúc chạy flow. Vì vậy nếu đã setup OAuth2 xong cho kênh 1 (`AI 
 4. Kiểm tra dòng in ra `Authenticated as channel: ...` đúng là
    `[2P] Chuyện Đời` (không phải `[2P] AI Hôm Nay`) trước khi coi như xong.
 5. Điền `YOUTUBE_DRAMA_TOKEN=publisher/.youtube_token_drama.json` vào `.env`
-   (đường dẫn tới file token vừa tạo). Việc đọc đúng biến này theo từng kênh
-   khi upload thật sẽ được nối dây ở Phase 5 — Phase 1 chỉ cần token đã sẵn
-   sàng.
+   (đường dẫn tới file token vừa tạo). Từ Phase 5,
+   `publisher/youtube_uploader.upload_to_youtube(video_id, channel_key)` đọc
+   đúng biến này theo từng kênh (qua `channels.py[key]["oauth_token_env"]`)
+   khi upload thật — biến rỗng sẽ fallback về token đơn-kênh cũ
+   (`YOUTUBE_TOKEN_FILE`) kèm warning.
 
 ---
 


### PR DESCRIPTION
## Tóm tắt

Implement Phase 5 (Distribution & Multi-channel Upload) theo `docs/current/phase-5-detailed.md` / `phase-5-issues.md`: video render xong giờ đi qua review gate (nút bấm Telegram) → duyệt → tự xếp lịch đăng theo cadence → upload đúng kênh. Track Drama chạy end-to-end qua `main_drama.py` (Reddit RSS → render → upload, chỉ còn gate duyệt tay).

## EPIC #5.1 — Telegram Review Gate

- **`notifier/review_bot.py`**: preview + inline keyboard ✅ Duyệt / ❌ Loại / ✏️ Sửa metadata. Approve → xếp lịch qua scheduler (không publish ngay như flow `/approve_<id>` cũ — flow cũ giữ nguyên cho track AI); Reject → hỏi lý do, lưu `videos.review_note`; Edit → FSM chọn field (allowlist) → nhập giá trị, state persisted qua restart (`.review_state.json`, `/skip` để huỷ).
- **Khác doc**: review_bot là handler thuần chạy trong vòng long-polling hiện có, không phải process bot mới — Telegram chỉ cho 1 `getUpdates`/token (cùng lý do seed_bot Phase 2, tránh 409 Conflict).
- **`video/preview.py`**: video >50MB được nén preview 2 nấc (720p/CRF28 → 480p/CRF32) thay vì bỏ qua; file gốc không đụng. Nối vào cả flow duyệt cũ của track AI (issue #60 trước đây chỉ fallback script-only).

## EPIC #5.2 — YouTube Multi-channel

- **`upload_to_youtube(video_id, channel_key)`**: token tra qua `channels.py[key]["oauth_token_env"]` → env var (convention Phase 1/`oauth-setup.md`, không hardcode `tokens/{key}.json` như doc); resumable upload retry transient 2/4/8/16s; thumbnail (`videos.thumbnail_path`) + caption track best-effort **sau** khi đã có `youtube_video_id` (fail điểm đó không kích re-upload). `YOUTUBE_PRIVACY=unlisted` cho E2E test.
- **Khác doc**: category track AI giữ 28 Science & Tech (hành vi cũ) thay vì 22; Drama = 24 Entertainment như doc.
- **`storage/quota.py`**: đếm unit theo ngày **Pacific** (quota Google reset nửa đêm PT, không phải giờ VN); alert Telegram đúng 1 lần khi băng 80%.

## EPIC #5.3 — TikTok

- **`publisher/tiktok_manual.py`**: export `queue_tiktok/YYYY-MM-DD/` (MP4 + `.txt` caption/hashtags), idempotent. Approve/scheduler tự rơi về queue tay khi chưa có `TIKTOK_ACCESS_TOKEN`; API uploader (đã có sẵn từ trước) dùng khi token sẵn sàng.

## EPIC #5.4 — Scheduler & Orchestrator

- **`scheduler/post_scheduler.py`** + bảng `scheduled_posts` (migration 006): `CADENCE` key theo `(channel_key, track, video_type)` — key phẳng của doc (`drama_youtube_shorts`, `tiktok_drama`) không tồn tại trong channel registry. Schedule idempotent + partial unique index chống double-book; tick 5 phút (launchd) claim atomic `queued→uploading`.
- **Chống upload trùng** (rủi ro §5 của doc): `platform_video_id` lưu ngay khi upload OK; post kẹt `uploading` sau crash **không tự retry** (video có thể đã lên kênh) — chỉ alert Telegram để xử lý tay.
- **`main_drama.py`**: collect→score→rewrite→render→review, resume hoàn toàn từ DB. Lỗi transient (TTS/ffmpeg trả lỗi) → video `failed` tự retry lần sau; crash thật (row kẹt `draft`) chặn render trùng. `--step`/`--limit` cho chạy tay từng bước.
- **`webui/health.py`**: `GET /health` (127.0.0.1) — video/story/queue/quota/collector, mỗi section chịu lỗi độc lập.

## Migration & Test

- Migration `006_distribution` (+down, roundtrip đã verify): `scheduled_posts`, `quota_usage`, cột `videos.story_id/thumbnail_path/review_note` — chạy `python -m storage.migrate up` sau khi pull.
- 106 test mới (603 tổng): `python3 -m unittest discover -s tests` pass — trừ `test_reddit_drama_collector` lỗi import `feedparser` **pre-existing** trong sandbox (không build được wheel `sgmllib3k`), không liên quan diff này.

## Việc còn lại ngoài code (thủ công)

- Lấy OAuth token cho kênh 2 theo `docs/current/oauth-setup.md` §1.4, điền `YOUTUBE_DRAMA_TOKEN` vào `.env`.
- E2E upload test 2 kênh với `YOUTUBE_PRIVACY=unlisted` (acceptance #5.2) — cần credential thật, không chạy được trong CI.
- Đăng ký TikTok Developer App (task external, 2-4 tuần) — pipeline không block nhờ queue tay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrAiARHeG48JQHNYuuLj4f