### PR TITLE
Phase 6 — Analytics & Iteration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,22 @@ content-pipeline/
 │   ├── twitter_collector.py     # Twitter API v2
 │   ├── reddit_collector.py      # Reddit API (r/ChatGPT, r/artificial) — track AI
 │   └── reddit_drama_collector.py # Reddit RSS+JSON (AITA, ProRevenge, ...) — track Drama (Phase 2)
+├── analytics/
+│   ├── youtube_puller.py       # Pull metric YouTube Analytics API v2 → video_metrics/channel_metrics (Phase 6)
+│   ├── tiktok_csv.py           # Parse CSV TikTok Studio → video_metrics (Phase 6)
+│   ├── experiment_compare.py   # compare_arms() A/B video theo metric thật + Welch t-test (Phase 6)
+│   ├── stats.py                # Welch t-test + p-value, KHÔNG cần scipy (Phase 6)
+│   ├── pricing.py              # Overlay token → USD (đổi giá không đụng dữ liệu) (Phase 6)
+│   └── weekly_retro.py         # Báo cáo tuần Telegram: top/bottom/sub growth/cost/action (Phase 6)
+├── dashboard/
+│   ├── data.py                 # Tầng dữ liệu KPI thuần (test được, không cần streamlit) (Phase 6)
+│   └── app.py                  # Streamlit dashboard 4 tab (Overview/Top/Format/Cost) (Phase 6)
 ├── processors/
 │   ├── rule_filter.py          # Lọc keyword, không dùng AI
 │   ├── ai_scorer.py            # Chấm điểm 1-10 bằng Claude Haiku (rẻ) — track AI
 │   ├── ai_analyzer.py          # Phân tích sâu bằng Claude Sonnet (bài tốt) — track AI
 │   ├── prompt_loader.py        # load_prompt()/render() — đọc prompts/{module}/{name}.{version}.txt (Phase 3)
-│   ├── ai_usage.py             # Log token usage mỗi call Anthropic (Phase 3)
+│   ├── ai_usage.py             # Log + persist token usage mỗi call Anthropic vào cost_logs (Phase 3/6)
 │   ├── ab_harness.py           # A/B test prompt version (deterministic theo story_id, Phase 3)
 │   ├── drama_scorer.py         # Rubric 6 tiêu chí bằng Haiku — track Drama (Phase 3)
 │   ├── drama_rewriter.py       # Việt hoá story bằng Sonnet + validate_rewrite() — track Drama (Phase 3)
@@ -48,12 +58,16 @@ content-pipeline/
 │   ├── collector_health.py     # Theo dõi last_success/alert nếu collector im lặng (Phase 2)
 │   ├── scheduled_posts.py      # CRUD queue upload theo cadence + atomic claim (Phase 5)
 │   ├── quota.py                # Track unit YouTube API/ngày (reset giờ Pacific) + alert 80% (Phase 5)
+│   ├── video_metrics.py        # CRUD snapshot số liệu video (upsert theo ngày) (Phase 6)
+│   ├── channel_metrics.py      # CRUD snapshot cấp kênh (sub growth cho retro) (Phase 6)
+│   ├── cost_logs.py            # CRUD token/chi phí mỗi call AI (Phase 6)
 │   ├── migrate.py              # Migration runner (up/down/status)
 │   └── migrations/             # File SQL versioned, vd 001_multi_track.sql
 ├── notifier/
 │   ├── telegram_bot.py         # Bot chính: báo cáo sáng + approve/reject + dispatch seed/review bot
 │   ├── seed_bot.py             # Command handlers /seed_vn, /seed_url, /list_pending (Phase 2)
-│   └── review_bot.py           # Review gate: nút ✅/❌/✏️ + FSM edit metadata (Phase 5)
+│   ├── review_bot.py           # Review gate: nút ✅/❌/✏️ + FSM edit metadata (Phase 5)
+│   └── analytics_bot.py        # Command /import_tiktok_csv + handler nạp CSV (Phase 6)
 ├── publisher/
 │   ├── youtube_uploader.py     # Upload YouTube; upload_to_youtube(video_id, channel_key) multi-channel (Phase 5)
 │   ├── tiktok_uploader.py      # TikTok Content Posting API
@@ -304,6 +318,62 @@ multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
 - TikTok Content Posting API uploader (`publisher/tiktok_uploader.py`) có từ
   trước, giữ nguyên — phần "3-step upload" của doc đã được cover; approval
   app TikTok là task external (2-4 tuần), pipeline không block nhờ queue tay.
+
+---
+
+## Analytics Layer (Phase 6)
+
+Xem `docs/current/phase-6-detailed.md`/`phase-6-issues.md`. Đo lường để học:
+pull metric YouTube/TikTok → snapshot theo ngày → dashboard KPI + A/B compare +
+báo cáo tuần Telegram. Ngoài phạm vi: predictive model, auto-tune prompt.
+
+- **`storage/video_metrics.py` + `channel_metrics.py`** — snapshot số liệu
+  video / kênh. **Khác `phase-6-detailed.md`:** `video_metrics.video_id` để
+  NULLABLE (doc ghi NOT NULL) và khoá upsert là `(platform, external_id,
+  snapshot_date)` thay vì `(video_id, snapshot_at)` — vì metric TikTok giai
+  đoạn manual (CSV) không có đường map đáng tin về `videos.id`, ép NOT NULL =
+  vứt hết số liệu TikTok. `video_id` là FK best-effort, điền khi map được qua
+  `scheduled_posts.platform_video_id`. Upsert idempotent trong ngày (pull lại
+  chỉ ghi đè — metric YouTube trễ 24-48h).
+- **`storage/cost_logs.py` + `analytics/pricing.py`** — hiện thực hoá bảng
+  `cost_logs` mà `phase-6-detailed.md` GIẢ ĐỊNH "đã ghi từ Phase 3/4" (thực tế
+  `ai_usage.py` xưa chỉ log ra Python logging, KHÔNG persist). Nay
+  `ai_usage.log_token_usage()` persist token thô vào `cost_logs` (best-effort,
+  non-fatal), và `ai_scorer`/`ai_analyzer` cũng gọi vào đó. Lưu **token thô**
+  (không phải $); quy đổi USD là overlay ở `pricing.py`, đổi giá qua env
+  `PRICE_<MODEL>_IN/_OUT` không cần migrate dữ liệu — đúng tinh thần `ai_usage`
+  cố ý không nhét pricing vào hot path (giá stale âm thầm).
+- **`analytics/youtube_puller.py`** — pull qua YouTube Analytics API v2
+  (`ids=channel==MINE`), cả per-video lẫn per-channel (sub growth). `retention
+  _50_pct` lấy từ report `audienceRetention` tại mốc 0.5 (best-effort, video
+  thiếu dữ liệu → None). Scope OAuth chỉ-đọc KHÁC token upload → dùng token
+  riêng `<upload_token>.analytics.json`; cấp: `python -m analytics.youtube_
+  puller auth <channel_key>`. Cron 23h (`com.ai5phut.metrics-pull.plist`).
+- **`analytics/tiktok_csv.py` + `notifier/analytics_bot.py`** — giai đoạn 1
+  (chưa có TikTok API): `/import_tiktok_csv` → đính kèm CSV từ TikTok Studio →
+  `telegram_bot._download_file()` tải file → parse (khoan dung header Anh/Việt,
+  số "1.2K"/"45%"/"0:12") → upsert. Handler THUẦN gọi trong cùng vòng
+  long-polling (như seed_bot/review_bot — 1 token/1 poll).
+- **`analytics/experiment_compare.py` + `stats.py`** — tag video qua
+  `database.set_video_experiment(id, experiment_id, arm)` (cột mới
+  `videos.experiment_id/experiment_arm`), so 2 arm theo metric thật bằng
+  Welch's t-test (p-value qua incomplete-beta, KHÔNG cần scipy). Chặn kết luận
+  non non mẫu: `enough_samples` (≥5/arm) vs `recommended_samples_met` (≥10/arm,
+  quy tắc cứng §5). Khác `ab_harness.py` (A/B prompt tầng story) — cái này tầng
+  video sau khi đăng. 3 thí nghiệm đầu: `docs/current/experiments-log.md`.
+- **`analytics/weekly_retro.py`** — báo cáo tuần ≤1500 ký tự (vừa 1 message
+  Telegram): top 3 view, bottom 3 retention, sub growth từng kênh, chi phí AI,
+  action items (chỉ nêu tín hiệu, KHÔNG tự cắt format — để `experiment_compare`
+  quyết). Cron CN 19h (`com.ai5phut.weekly-retro.plist`). `generate_retro_
+  report()` pure (test được), `send_weekly_retro()` mới gọi Telegram.
+- **`dashboard/data.py` (thuần) + `dashboard/app.py` (Streamlit)** — 4 tab
+  Overview/Top videos/Format/Cost. Toàn bộ logic dữ liệu ở `data.py` (test
+  không cần streamlit); `app.py` lazy-import streamlit, thiếu thì báo cài.
+  `webui/health.py` thêm section `analytics` (snapshot 7 ngày + cost 7 ngày).
+- Migration 007 (`video_metrics`, `channel_metrics`, `cost_logs`, cột
+  `videos.experiment_id/experiment_arm`) — chạy `python -m storage.migrate up`
+  sau khi pull. **Khác `phase-6-issues.md`** (đặt tên `002_metrics_schema.sql`):
+  tiếp dãy số liên tục tới 007, không reset về 002 (đụng 002 đã tồn tại).
 
 ---
 

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -83,3 +83,17 @@ BURN_SUBTITLES=all
 # SECURITY: set to 1 ONLY for a trusted self-signed TTS endpoint. Default 0
 # keeps TLS certificate verification ON. Enabling it exposes the call to MITM.
 TTS_ALLOW_INSECURE_SSL=0
+
+# --- Analytics (Phase 6) ---
+# YouTube Analytics puller dùng token OAuth RIÊNG cho mỗi kênh (scope chỉ-đọc,
+# khác token upload). File token lưu tại <upload_token>.analytics.json — cấp 1
+# lần: python -m analytics.youtube_puller auth <channel_key>. Không cần env var
+# mới cho token (suy ra từ YOUTUBE_AI_TOKEN / YOUTUBE_DRAMA_TOKEN).
+#
+# Pricing overlay (analytics/pricing.py) quy đổi token → USD. Mặc định đã có giá
+# Haiku/Sonnet/Opus; override khi Anthropic đổi giá (USD trên 1 TRIỆU token).
+# Tên biến: PRICE_<MODEL_ID_HOA_GẠCH_DƯỚI>_IN / _OUT. Ví dụ:
+# PRICE_CLAUDE_HAIKU_4_5_IN=1.0
+# PRICE_CLAUDE_HAIKU_4_5_OUT=5.0
+# PRICE_CLAUDE_SONNET_4_5_IN=3.0
+# PRICE_CLAUDE_SONNET_4_5_OUT=15.0

--- a/content-pipeline/.gitignore
+++ b/content-pipeline/.gitignore
@@ -14,5 +14,6 @@ publisher/.youtube_token*.json
 notifier/.telegram_offset
 notifier/.seed_state.json
 notifier/.review_state.json
+notifier/.analytics_state.json
 video/assets/backgrounds/*.mp4
 video/assets/fonts/*.ttf

--- a/content-pipeline/analytics/__init__.py
+++ b/content-pipeline/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics & Iteration layer (Phase 6).
+
+Pull số liệu từ YouTube/TikTok, quy đổi chi phí, so sánh A/B, và sinh báo cáo
+tuần. Xem docs/current/phase-6-detailed.md.
+"""

--- a/content-pipeline/analytics/experiment_compare.py
+++ b/content-pipeline/analytics/experiment_compare.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+"""
+A/B experiment helper (Phase 6 EPIC #6.3) — so sánh các nhánh (arm) của 1 thí
+nghiệm gắn trên video (thumbnail style / hook variant / độ dài) theo số liệu
+thực từ `video_metrics`.
+
+Khác processors/ab_harness.py (A/B prompt version ở tầng story, so mean
+heuristic_score) — module này ở tầng VIDEO, so metric platform thật (views,
+retention...) sau khi đăng.
+
+Nguyên tắc cứng (phase-6-detailed.md §5): đừng kết luận khi mẫu nhỏ. Hàm trả
+`enough_samples` theo `min_samples` (mặc định 5/arm cho acceptance criteria,
+nhưng khuyến nghị ≥10 trước khi thực sự cắt format). p-value chỉ là tham khảo
+bổ sung, không thay quy tắc mẫu.
+"""
+
+import logging
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_videos_by_experiment
+from storage import video_metrics
+from analytics.stats import welch_ttest, mean
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MIN_SAMPLES = 5
+# Ngưỡng khuyến nghị để thật sự ra quyết định cắt/nhân format.
+RECOMMENDED_MIN_SAMPLES = 10
+
+
+def _metric_by_video_id(metric: str) -> dict[int, float]:
+    """{video_id: giá trị metric mới nhất} cho mọi video có snapshot."""
+    out: dict[int, float] = {}
+    for row in video_metrics.latest_per_video():
+        vid = row.get("video_id")
+        val = row.get(metric)
+        if vid is not None and val is not None:
+            # Nếu 1 video có nhiều platform, cộng dồn (vd views YouTube+TikTok).
+            out[vid] = out.get(vid, 0) + val
+    return out
+
+
+def compare_arms(experiment_id: str, metric: str = "views",
+                 min_samples: int = DEFAULT_MIN_SAMPLES) -> dict:
+    """So sánh các arm của `experiment_id` theo `metric`.
+
+    Returns:
+        {
+          "experiment_id", "metric",
+          "arms": {arm: {"n": int, "mean": float, "values": [...]}},
+          "better": arm|"tie"|None,
+          "delta": float|None,             # mean(better) - mean(other), chỉ khi 2 arm
+          "p_value": float|None, "t": ..., "df": ...,   # chỉ khi đúng 2 arm đủ mẫu
+          "enough_samples": bool,          # mọi arm >= min_samples
+          "recommended_samples_met": bool, # mọi arm >= RECOMMENDED_MIN_SAMPLES
+          "note": str,
+        }
+    """
+    videos = get_videos_by_experiment(experiment_id)
+    metric_map = _metric_by_video_id(metric)
+
+    arms: dict[str, list[float]] = {}
+    for v in videos:
+        arm = v.get("experiment_arm")
+        if not arm:
+            continue
+        val = metric_map.get(v["id"])
+        if val is None:
+            continue  # video chưa có số liệu — chưa đưa vào so sánh
+        arms.setdefault(arm, []).append(val)
+
+    arm_summary = {
+        arm: {"n": len(vals), "mean": mean(vals) if vals else None, "values": vals}
+        for arm, vals in arms.items()
+    }
+    result: dict = {
+        "experiment_id": experiment_id,
+        "metric": metric,
+        "arms": arm_summary,
+        "better": None,
+        "delta": None,
+        "p_value": None, "t": None, "df": None,
+        "enough_samples": bool(arms) and all(len(v) >= min_samples for v in arms.values()),
+        "recommended_samples_met": bool(arms) and all(
+            len(v) >= RECOMMENDED_MIN_SAMPLES for v in arms.values()),
+    }
+
+    if not arms:
+        result["note"] = "Chưa có video nào có số liệu cho thí nghiệm này."
+        return result
+
+    means = {arm: mean(vals) for arm, vals in arms.items() if vals}
+    result["better"] = (max(means, key=means.get)
+                        if len(set(means.values())) > 1 else "tie")
+
+    if len(arms) == 2:
+        (arm_a, vals_a), (arm_b, vals_b) = sorted(arms.items())
+        tt = welch_ttest(vals_a, vals_b)
+        result.update({"t": tt["t"], "df": tt["df"], "p_value": tt["p_value"]})
+        if result["better"] not in (None, "tie"):
+            other = arm_b if result["better"] == arm_a else arm_a
+            result["delta"] = means[result["better"]] - means[other]
+
+    if not result["enough_samples"]:
+        result["note"] = (
+            f"Chưa đủ mẫu (cần ≥{min_samples}/arm; khuyến nghị "
+            f"≥{RECOMMENDED_MIN_SAMPLES} trước khi quyết định).")
+    elif not result["recommended_samples_met"]:
+        result["note"] = (
+            f"Đủ {min_samples}/arm để xem xu hướng, nhưng nên chờ "
+            f"≥{RECOMMENDED_MIN_SAMPLES}/arm trước khi cắt/nhân format.")
+    else:
+        result["note"] = "Đủ mẫu khuyến nghị — có thể ra quyết định."
+    return result
+
+
+def format_comparison(result: dict) -> str:
+    """Render kết quả compare_arms thành text ngắn (Telegram / CLI)."""
+    lines = [f"🧪 {result['experiment_id']} — metric: {result['metric']}"]
+    for arm, s in sorted(result["arms"].items()):
+        m = f"{s['mean']:.1f}" if s["mean"] is not None else "—"
+        lines.append(f"  Arm {arm}: n={s['n']}, mean={m}")
+    if result.get("better") and result["better"] != "tie":
+        delta = result.get("delta")
+        d = f" (Δ {delta:+.1f})" if delta is not None else ""
+        lines.append(f"  → Nhỉnh hơn: {result['better']}{d}")
+    elif result.get("better") == "tie":
+        lines.append("  → Hoà")
+    if result.get("p_value") is not None:
+        lines.append(f"  p-value: {result['p_value']:.3f}")
+    lines.append(f"  {result.get('note', '')}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import argparse
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="So sánh A/B experiment (Phase 6)")
+    parser.add_argument("experiment_id")
+    parser.add_argument("--metric", default="views")
+    parser.add_argument("--min-samples", type=int, default=DEFAULT_MIN_SAMPLES)
+    args = parser.parse_args()
+    print(format_comparison(compare_arms(args.experiment_id, args.metric, args.min_samples)))

--- a/content-pipeline/analytics/experiment_compare.py
+++ b/content-pipeline/analytics/experiment_compare.py
@@ -32,16 +32,28 @@ DEFAULT_MIN_SAMPLES = 5
 RECOMMENDED_MIN_SAMPLES = 10
 
 
+# Metric cộng dồn được giữa các platform (đếm tuyệt đối). Các metric còn lại là
+# TỶ LỆ / thời lượng — cộng chúng lại là sai (55% YT + 40% TikTok ≠ 95%), nên
+# lấy trung bình giữa các platform.
+_ADDITIVE_METRICS = {"views", "likes", "comments", "shares", "watch_time_minutes"}
+
+
 def _metric_by_video_id(metric: str) -> dict[int, float]:
-    """{video_id: giá trị metric mới nhất} cho mọi video có snapshot."""
-    out: dict[int, float] = {}
+    """{video_id: giá trị metric mới nhất} cho mọi video có snapshot.
+
+    Một video có thể có snapshot ở nhiều platform (YouTube + TikTok). Với metric
+    đếm (views...) cộng dồn; với metric tỷ lệ/thời lượng (retention...) lấy
+    trung bình — cộng tỷ lệ giữa 2 platform sẽ bóp méo mean của arm.
+    """
+    collected: dict[int, list[float]] = {}
     for row in video_metrics.latest_per_video():
         vid = row.get("video_id")
         val = row.get(metric)
         if vid is not None and val is not None:
-            # Nếu 1 video có nhiều platform, cộng dồn (vd views YouTube+TikTok).
-            out[vid] = out.get(vid, 0) + val
-    return out
+            collected.setdefault(vid, []).append(val)
+    if metric in _ADDITIVE_METRICS:
+        return {vid: sum(vals) for vid, vals in collected.items()}
+    return {vid: sum(vals) / len(vals) for vid, vals in collected.items()}
 
 
 def compare_arms(experiment_id: str, metric: str = "views",
@@ -84,8 +96,11 @@ def compare_arms(experiment_id: str, metric: str = "views",
         "better": None,
         "delta": None,
         "p_value": None, "t": None, "df": None,
-        "enough_samples": bool(arms) and all(len(v) >= min_samples for v in arms.values()),
-        "recommended_samples_met": bool(arms) and all(
+        # Cần ≥2 arm mới có gì để so — 1 arm dù nhiều mẫu vẫn KHÔNG "đủ mẫu"
+        # (không có nhánh đối chứng), tránh format_comparison báo "đủ dữ liệu"
+        # nhầm khi arm B chưa đăng.
+        "enough_samples": len(arms) >= 2 and all(len(v) >= min_samples for v in arms.values()),
+        "recommended_samples_met": len(arms) >= 2 and all(
             len(v) >= RECOMMENDED_MIN_SAMPLES for v in arms.values()),
     }
 

--- a/content-pipeline/analytics/pricing.py
+++ b/content-pipeline/analytics/pricing.py
@@ -35,16 +35,9 @@ def _env_key(model: str) -> str:
     return model.upper().replace("-", "_").replace(".", "_")
 
 
-def rates_for(model: str) -> tuple[float, float] | None:
-    """(giá_input, giá_output) USD/1M token cho `model`, hoặc None nếu chưa biết.
-
-    Ưu tiên env override `PRICE_<MODEL>_IN` / `PRICE_<MODEL>_OUT`, rồi bảng
-    mặc định. Match cả prefix (vd 'claude-haiku-4-5-20251001' khớp
-    'claude-haiku-4-5') để id có hậu tố ngày vẫn tra được.
-    """
-    if not model:
-        return None
-    base = _env_key(model)
+def _env_override(model_key_source: str) -> tuple[float, float] | None:
+    """Đọc PRICE_<MODEL>_IN/_OUT cho 1 tên model, hoặc None nếu chưa đặt/không hợp lệ."""
+    base = _env_key(model_key_source)
     env_in = os.getenv(f"PRICE_{base}_IN")
     env_out = os.getenv(f"PRICE_{base}_OUT")
     if env_in and env_out:
@@ -52,13 +45,31 @@ def rates_for(model: str) -> tuple[float, float] | None:
             return float(env_in), float(env_out)
         except ValueError:
             logger.warning("Bad PRICE_%s_* env value, ignoring", base)
+    return None
 
+
+def rates_for(model: str) -> tuple[float, float] | None:
+    """(giá_input, giá_output) USD/1M token cho `model`, hoặc None nếu chưa biết.
+
+    Ưu tiên env override `PRICE_<MODEL>_IN` / `PRICE_<MODEL>_OUT`, rồi bảng
+    mặc định. Match cả prefix (vd 'claude-haiku-4-5-20251001' khớp
+    'claude-haiku-4-5') — và ở nhánh prefix vẫn ưu tiên env override CỦA BASE
+    (`PRICE_CLAUDE_HAIKU_4_5_*`) trước khi rơi về giá hardcode, để operator đặt
+    override theo tên base vẫn áp được cho id có hậu tố ngày.
+    """
+    if not model:
+        return None
+    # 1. Override khớp chính xác id (kể cả id có hậu tố ngày).
+    exact = _env_override(model)
+    if exact:
+        return exact
+    # 2. Giá mặc định theo id chính xác.
     if model in _DEFAULT_PRICING:
         return _DEFAULT_PRICING[model]
-    # prefix match cho id có hậu tố (vd -20251001)
+    # 3. Prefix match cho id có hậu tố: env override của base > giá hardcode.
     for known, rate in _DEFAULT_PRICING.items():
         if model.startswith(known):
-            return rate
+            return _env_override(known) or rate
     return None
 
 

--- a/content-pipeline/analytics/pricing.py
+++ b/content-pipeline/analytics/pricing.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+"""
+Pricing overlay (Phase 6) — quy đổi token thô trong `cost_logs` ra USD.
+
+Tách khỏi chỗ GHI log (storage/cost_logs.py, processors/ai_usage.py) một cách
+có chủ đích: dữ liệu lịch sử lưu token thô (không bao giờ stale); tiền chỉ được
+tính khi HIỂN THỊ, dùng bảng giá ở đây. Đổi giá = sửa 1 chỗ (hoặc override qua
+env var `PRICE_<MODEL>_IN` / `_OUT` theo USD trên 1 TRIỆU token) và mọi báo cáo
+tự tính lại — không cần migrate dữ liệu.
+
+Đây cũng là lý do processors/ai_usage.py xưa nay từ chối nhét pricing vào chỗ
+log token: giá thay đổi âm thầm, hardcode ở hot path sẽ lệch hoá đơn mà không
+ai biết. Ở đây giá là 1 lớp overlay tường minh, dễ cập nhật.
+
+Giá mặc định (USD / 1 triệu token) — CẬP NHẬT theo trang giá Anthropic khi giá
+đổi. Kiểm tra: https://www.anthropic.com/pricing  (hoặc override bằng env var).
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# USD trên 1 TRIỆU token (input, output). Chỉ là mặc định — override qua env.
+_DEFAULT_PRICING: dict[str, tuple[float, float]] = {
+    "claude-haiku-4-5": (1.0, 5.0),
+    "claude-sonnet-4-5": (3.0, 15.0),
+    "claude-opus-4-5": (5.0, 25.0),
+}
+
+
+def _env_key(model: str) -> str:
+    """Chuẩn hoá tên model thành hậu tố env var: claude-haiku-4-5 → CLAUDE_HAIKU_4_5."""
+    return model.upper().replace("-", "_").replace(".", "_")
+
+
+def rates_for(model: str) -> tuple[float, float] | None:
+    """(giá_input, giá_output) USD/1M token cho `model`, hoặc None nếu chưa biết.
+
+    Ưu tiên env override `PRICE_<MODEL>_IN` / `PRICE_<MODEL>_OUT`, rồi bảng
+    mặc định. Match cả prefix (vd 'claude-haiku-4-5-20251001' khớp
+    'claude-haiku-4-5') để id có hậu tố ngày vẫn tra được.
+    """
+    if not model:
+        return None
+    base = _env_key(model)
+    env_in = os.getenv(f"PRICE_{base}_IN")
+    env_out = os.getenv(f"PRICE_{base}_OUT")
+    if env_in and env_out:
+        try:
+            return float(env_in), float(env_out)
+        except ValueError:
+            logger.warning("Bad PRICE_%s_* env value, ignoring", base)
+
+    if model in _DEFAULT_PRICING:
+        return _DEFAULT_PRICING[model]
+    # prefix match cho id có hậu tố (vd -20251001)
+    for known, rate in _DEFAULT_PRICING.items():
+        if model.startswith(known):
+            return rate
+    return None
+
+
+def cost_usd(model: str, input_tokens: int | None,
+             output_tokens: int | None) -> float | None:
+    """Chi phí USD cho 1 call. None nếu model chưa có giá (đừng đoán = 0)."""
+    rates = rates_for(model)
+    if rates is None:
+        return None
+    in_rate, out_rate = rates
+    ti = input_tokens or 0
+    to = output_tokens or 0
+    return (ti * in_rate + to * out_rate) / 1_000_000
+
+
+def summarize_costs(rows: list[dict]) -> dict:
+    """Tổng hợp $ từ các dòng cost_logs thô (storage.cost_logs.rows_since()).
+
+    Returns {
+        "total_usd": float,
+        "by_model": {model: {"calls", "input_tokens", "output_tokens", "usd"}},
+        "by_service": {service: usd},
+        "unpriced_models": [model, ...],   # có token nhưng chưa có giá
+    }
+    """
+    by_model: dict[str, dict] = {}
+    by_service: dict[str, float] = {}
+    unpriced: set[str] = set()
+    total = 0.0
+
+    for row in rows:
+        model = row.get("model") or "(unknown)"
+        service = row.get("service") or "(unknown)"
+        ti = row.get("input_tokens") or 0
+        to = row.get("output_tokens") or 0
+
+        entry = by_model.setdefault(
+            model, {"calls": 0, "input_tokens": 0, "output_tokens": 0, "usd": 0.0}
+        )
+        entry["calls"] += 1
+        entry["input_tokens"] += ti
+        entry["output_tokens"] += to
+
+        usd = cost_usd(model, ti, to)
+        if usd is None:
+            if ti or to:
+                unpriced.add(model)
+            usd = 0.0
+        entry["usd"] += usd
+        by_service[service] = by_service.get(service, 0.0) + usd
+        total += usd
+
+    return {
+        "total_usd": round(total, 4),
+        "by_model": by_model,
+        "by_service": {k: round(v, 4) for k, v in by_service.items()},
+        "unpriced_models": sorted(unpriced),
+    }
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    for model in _DEFAULT_PRICING:
+        print(model, "→", rates_for(model),
+              "| 1M in + 100k out =",
+              cost_usd(model, 1_000_000, 100_000), "USD")

--- a/content-pipeline/analytics/stats.py
+++ b/content-pipeline/analytics/stats.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+"""
+Thống kê tối thiểu, KHÔNG phụ thuộc scipy/numpy (Phase 6).
+
+Chỉ cần cho experiment_compare: Welch's t-test 2 mẫu (phương sai không bằng
+nhau) + p-value 2 phía. p-value tính qua hàm beta không hoàn chỉnh
+(regularized incomplete beta, continued fraction — Numerical Recipes) để ra
+CDF phân phối Student-t chính xác, thay vì kéo cả scipy vào chỉ để chạy 1 test.
+
+Cảnh báo diễn giải (phase-6-detailed.md §5): p-value KHÔNG thay cho quy tắc
+"≥10 sample/arm mới quyết định". Mẫu nhỏ → p dễ ra tín hiệu giả. Hàm trả cả
+n để caller tự chặn.
+"""
+
+import math
+from typing import Sequence
+
+
+def mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs)
+
+
+def _variance(xs: Sequence[float]) -> float:
+    """Phương sai mẫu (chia n-1). 0 nếu < 2 phần tử."""
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = mean(xs)
+    return sum((x - m) ** 2 for x in xs) / (n - 1)
+
+
+def _betacf(a: float, b: float, x: float) -> float:
+    """Continued fraction cho hàm beta không hoàn chỉnh (Numerical Recipes)."""
+    MAXIT, EPS, FPMIN = 200, 3.0e-12, 1.0e-30
+    qab, qap, qam = a + b, a + 1.0, a - 1.0
+    c = 1.0
+    d = 1.0 - qab * x / qap
+    if abs(d) < FPMIN:
+        d = FPMIN
+    d = 1.0 / d
+    h = d
+    for m_i in range(1, MAXIT + 1):
+        m2 = 2 * m_i
+        aa = m_i * (b - m_i) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if abs(d) < FPMIN:
+            d = FPMIN
+        c = 1.0 + aa / c
+        if abs(c) < FPMIN:
+            c = FPMIN
+        d = 1.0 / d
+        h *= d * c
+        aa = -(a + m_i) * (qab + m_i) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if abs(d) < FPMIN:
+            d = FPMIN
+        c = 1.0 + aa / c
+        if abs(c) < FPMIN:
+            c = FPMIN
+        d = 1.0 / d
+        delta = d * c
+        h *= delta
+        if abs(delta - 1.0) < EPS:
+            break
+    return h
+
+
+def _betai(a: float, b: float, x: float) -> float:
+    """Regularized incomplete beta I_x(a, b)."""
+    if x <= 0.0:
+        return 0.0
+    if x >= 1.0:
+        return 1.0
+    lbeta = math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+    bt = math.exp(lbeta + a * math.log(x) + b * math.log(1.0 - x))
+    if x < (a + 1.0) / (a + b + 2.0):
+        return bt * _betacf(a, b, x) / a
+    return 1.0 - bt * _betacf(b, a, 1.0 - x) / b
+
+
+def _t_sf_two_sided(t: float, df: float) -> float:
+    """p-value 2 phía cho thống kê t với `df` bậc tự do."""
+    if df <= 0:
+        return float("nan")
+    x = df / (df + t * t)
+    return _betai(df / 2.0, 0.5, x)
+
+
+def welch_ttest(a: Sequence[float], b: Sequence[float]) -> dict:
+    """Welch's t-test 2 mẫu độc lập.
+
+    Returns {"t": float|None, "df": float|None, "p_value": float|None,
+             "mean_a", "mean_b", "n_a", "n_b"}. t/df/p = None nếu không đủ dữ
+             liệu (mỗi nhóm cần ≥2, và tổng phương sai > 0).
+    """
+    na, nb = len(a), len(b)
+    out = {
+        "mean_a": mean(a) if na else None,
+        "mean_b": mean(b) if nb else None,
+        "n_a": na, "n_b": nb,
+        "t": None, "df": None, "p_value": None,
+    }
+    if na < 2 or nb < 2:
+        return out
+    va, vb = _variance(a), _variance(b)
+    sa, sb = va / na, vb / nb
+    denom = sa + sb
+    if denom <= 0:
+        return out  # cả 2 nhóm không phương sai → t vô định
+    t = (mean(a) - mean(b)) / math.sqrt(denom)
+    df = denom * denom / ((sa * sa) / (na - 1) + (sb * sb) / (nb - 1))
+    out.update({"t": t, "df": df, "p_value": _t_sf_two_sided(t, df)})
+    return out

--- a/content-pipeline/analytics/tiktok_csv.py
+++ b/content-pipeline/analytics/tiktok_csv.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+"""
+TikTok CSV parser (Phase 6 EPIC #6.1, giai đoạn 1 — trước khi có TikTok API).
+
+TikTok Studio cho export CSV số liệu video. Phuong tải file, gửi qua Telegram
+(lệnh /import_tiktok_csv → đính kèm file), bot parse vào `video_metrics`
+(platform='tiktok'). Giai đoạn 2 (Display/Insights API) để sau khi app TikTok
+được duyệt (task external từ Phase 5).
+
+Parser cố ý KHOAN DUNG với header: TikTok Studio đổi tên cột giữa các phiên bản
+/ ngôn ngữ (Anh/Việt), và số có thể ở dạng "1.2K", "1,234", "45%". Cột không
+nhận diện được → bỏ qua (không làm hỏng cả file). Không map được external_id →
+skip dòng đó và báo trong summary.
+"""
+
+import csv
+import io
+import logging
+import re
+from datetime import datetime
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage import video_metrics
+
+logger = logging.getLogger(__name__)
+
+# Alias header (đã chuẩn hoá lowercase, bỏ khoảng trắng thừa) → field nội bộ.
+_HEADER_ALIASES: dict[str, str] = {
+    # views
+    "views": "views", "video views": "views", "total views": "views",
+    "play count": "views", "lượt xem": "views", "số lượt xem": "views",
+    # likes
+    "likes": "likes", "total likes": "likes", "lượt thích": "likes",
+    # comments
+    "comments": "comments", "total comments": "comments", "bình luận": "comments",
+    "lượt bình luận": "comments",
+    # shares
+    "shares": "shares", "total shares": "shares", "lượt chia sẻ": "shares",
+    # avg watch time (seconds)
+    "average watch time": "avg_view_duration_seconds",
+    "avg watch time": "avg_view_duration_seconds",
+    "thời gian xem trung bình": "avg_view_duration_seconds",
+    # retention proxy: % xem hết video
+    "watched full video": "retention_50_pct",
+    "completion rate": "retention_50_pct",
+    "tỷ lệ xem hết": "retention_50_pct",
+}
+
+_ID_HEADERS = {"video id", "id", "video link", "video url", "link", "url",
+               "liên kết video", "đường dẫn"}
+_TITLE_HEADERS = {"video title", "title", "tiêu đề", "tên video"}
+_DATE_HEADERS = {"post time", "date", "posted", "ngày đăng", "thời gian đăng"}
+
+_TIKTOK_ID_RE = re.compile(r"/video/(\d+)")
+_TRAILING_ID_RE = re.compile(r"(\d{6,})")
+
+
+def _norm_header(h: str) -> str:
+    return (h or "").strip().lower().lstrip("﻿")
+
+
+def _num(value) -> Optional[float]:
+    """Parse '1.2K', '1,234', '45%', '12' → float. None nếu không parse được."""
+    if value is None:
+        return None
+    s = str(value).strip().replace(",", "").replace("%", "")
+    if not s:
+        return None
+    mult = 1.0
+    if s[-1:].upper() == "K":
+        mult, s = 1_000.0, s[:-1]
+    elif s[-1:].upper() == "M":
+        mult, s = 1_000_000.0, s[:-1]
+    try:
+        return float(s) * mult
+    except ValueError:
+        return None
+
+
+def _duration_seconds(value) -> Optional[float]:
+    """Parse thời lượng: '0:12' / '1:05' (mm:ss) hoặc '12' / '12.3s' → giây."""
+    if value is None:
+        return None
+    s = str(value).strip().lower().rstrip("s").strip()
+    if not s:
+        return None
+    if ":" in s:
+        parts = s.split(":")
+        try:
+            nums = [float(p) for p in parts]
+        except ValueError:
+            return None
+        secs = 0.0
+        for n in nums:
+            secs = secs * 60 + n
+        return secs
+    return _num(s)
+
+
+def _extract_external_id(row: dict) -> Optional[str]:
+    """Rút external_id ổn định từ 1 dòng: ưu tiên id số trong link TikTok."""
+    for key, val in row.items():
+        if _norm_header(key) in _ID_HEADERS and val:
+            v = str(val).strip()
+            m = _TIKTOK_ID_RE.search(v) or _TRAILING_ID_RE.search(v)
+            if m:
+                return m.group(1)
+            if v:
+                return v  # dùng nguyên link/id nếu không tách được số
+    # Fallback: title (không lý tưởng nhưng còn hơn bỏ dòng).
+    for key, val in row.items():
+        if _norm_header(key) in _TITLE_HEADERS and val:
+            return str(val).strip()[:80]
+    return None
+
+
+def _extract_date(row: dict) -> Optional[str]:
+    for key, val in row.items():
+        if _norm_header(key) in _DATE_HEADERS and val:
+            raw = str(val).strip()
+            for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%d/%m/%Y", "%m/%d/%Y"):
+                try:
+                    return datetime.strptime(raw[:len(fmt) + 4].strip(), fmt).date().isoformat()
+                except ValueError:
+                    continue
+    return None
+
+
+def parse_csv_text(text: str) -> list[dict]:
+    """Parse CSV → list record chuẩn hoá {external_id, snapshot_date?, <metrics>}.
+
+    Dòng không rút được external_id bị bỏ (kèm cảnh báo debug).
+    """
+    reader = csv.DictReader(io.StringIO(text))
+    records = []
+    for raw_row in reader:
+        external_id = _extract_external_id(raw_row)
+        if not external_id:
+            logger.debug("Bỏ 1 dòng CSV không có video id/link: %s", raw_row)
+            continue
+        record: dict = {"external_id": external_id}
+        d = _extract_date(raw_row)
+        if d:
+            record["snapshot_date"] = d
+        for key, val in raw_row.items():
+            field = _HEADER_ALIASES.get(_norm_header(key))
+            if not field:
+                continue
+            if field == "avg_view_duration_seconds":
+                parsed = _duration_seconds(val)
+            else:
+                parsed = _num(val)
+            if parsed is not None:
+                # views/likes/... là số nguyên; retention/duration để float.
+                if field in ("views", "likes", "comments", "shares"):
+                    record[field] = int(round(parsed))
+                else:
+                    record[field] = parsed
+        records.append(record)
+    return records
+
+
+def import_csv_text(text: str, snapshot_date: Optional[str] = None) -> dict:
+    """Parse + upsert vào video_metrics. Returns summary.
+
+    `snapshot_date`: ép ngày snapshot cho mọi dòng (nếu CSV không có cột ngày,
+    hoặc muốn gộp cả file vào 1 ngày). Ưu tiên hơn ngày rút từ từng dòng.
+    """
+    records = parse_csv_text(text)
+    imported = 0
+    metric_fields = {"views", "likes", "comments", "shares",
+                     "avg_view_duration_seconds", "retention_50_pct"}
+    for rec in records:
+        metrics = {k: v for k, v in rec.items() if k in metric_fields}
+        if not metrics:
+            continue  # dòng chỉ có id, không có số liệu — bỏ
+        video_metrics.upsert_metric(
+            platform="tiktok", external_id=rec["external_id"],
+            snapshot_date=snapshot_date or rec.get("snapshot_date"),
+            **metrics,
+        )
+        imported += 1
+    summary = {"rows": len(records), "imported": imported,
+               "skipped": len(records) - imported}
+    logger.info("TikTok CSV import: %s", summary)
+    return summary
+
+
+def import_csv_file(path: str, snapshot_date: Optional[str] = None) -> dict:
+    with open(path, encoding="utf-8-sig") as f:
+        return import_csv_text(f.read(), snapshot_date=snapshot_date)
+
+
+if __name__ == "__main__":
+    import argparse
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Import TikTok Studio CSV (Phase 6)")
+    parser.add_argument("csv_path")
+    parser.add_argument("--date", help="Ép snapshot_date YYYY-MM-DD cho mọi dòng")
+    args = parser.parse_args()
+    print(import_csv_file(args.csv_path, snapshot_date=args.date))

--- a/content-pipeline/analytics/weekly_retro.py
+++ b/content-pipeline/analytics/weekly_retro.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+"""
+Weekly retro (Phase 6 EPIC #6.4) — báo cáo tuần tự động qua Telegram.
+
+Cron Chủ nhật 19h (launchd com.ai5phut.weekly-retro.plist): Phuong đọc tối CN,
+sáng thứ 2 đã có quyết định. 5 mục (phase-6-detailed.md §3.6): top 3, bottom 3,
+sub growth từng kênh, chi phí tuần, action items. Gói gọn ≤1500 ký tự để vừa 1
+message Telegram + kèm link deep-dive tới dashboard.
+
+`generate_retro_report()` là pure (đọc DB, trả str) nên unit-test được;
+`send_weekly_retro()` mới gọi Telegram.
+"""
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from channels import channels_for_platform, get_channel
+from storage import video_metrics, channel_metrics, cost_logs
+from storage.database import get_video
+from analytics import pricing
+
+logger = logging.getLogger(__name__)
+
+MAX_REPORT_CHARS = 1500
+
+
+def _week_ago(now: Optional[date] = None) -> str:
+    now = now or date.today()
+    return (now - timedelta(days=7)).isoformat()
+
+
+def _label_for(row: dict) -> str:
+    """Nhãn ngắn cho 1 metric row: tên video nếu map được, không thì external_id."""
+    vid = row.get("video_id")
+    if vid:
+        v = get_video(vid)
+        if v:
+            title = (v.get("youtube_title") or v.get("tiktok_caption")
+                     or v.get("script_text", "")[:40])
+            if title:
+                return title[:45]
+    return f"{row.get('platform', '?')}:{row.get('external_id', '?')}"
+
+
+def _fmt_int(v) -> str:
+    return f"{int(v):,}" if v is not None else "—"
+
+
+def generate_retro_report(since: Optional[str] = None,
+                          now: Optional[date] = None) -> str:
+    """Sinh báo cáo tuần (str ≤ MAX_REPORT_CHARS)."""
+    since = since or _week_ago(now)
+    today = (now or date.today()).isoformat()
+    lines = [f"🗓️ RETRO TUẦN — {today}", ""]
+
+    # 1. Top 3 theo views.
+    top = video_metrics.top_videos(metric="views", limit=3, since=since)
+    if top:
+        lines.append("🔥 TOP 3 (views):")
+        for r in top:
+            ret = r.get("retention_50_pct")
+            ret_s = f", ret50 {ret:.0f}%" if ret is not None else ""
+            lines.append(f"  • {_label_for(r)} — {_fmt_int(r.get('views'))} view{ret_s}")
+    else:
+        lines.append("🔥 TOP 3: chưa có số liệu tuần này.")
+
+    # 2. Bottom 3 theo retention (video cần phân tích) — chỉ xét video có retention.
+    bottom = video_metrics.top_videos(metric="retention_50_pct", limit=3,
+                                      since=since, ascending=True)
+    if bottom:
+        lines.append("")
+        lines.append("🧊 CẦN XEM LẠI (retention thấp):")
+        for r in bottom:
+            lines.append(
+                f"  • {_label_for(r)} — ret50 {r.get('retention_50_pct'):.0f}%, "
+                f"{_fmt_int(r.get('views'))} view")
+
+    # 3. Sub growth từng kênh YouTube.
+    lines.append("")
+    lines.append("📈 SUB GROWTH (7 ngày):")
+    for channel_key in channels_for_platform("youtube"):
+        gained = channel_metrics.subs_gained(channel_key, since)
+        name = get_channel(channel_key)["name"]
+        sign = "+" if gained >= 0 else ""
+        lines.append(f"  • {name}: {sign}{gained} sub")
+
+    # 4. Chi phí tuần.
+    summary = pricing.summarize_costs(cost_logs.rows_since(since))
+    lines.append("")
+    lines.append(f"💸 CHI PHÍ AI: ${summary['total_usd']:.2f}")
+    if summary["unpriced_models"]:
+        lines.append(f"  (chưa có giá: {', '.join(summary['unpriced_models'])})")
+
+    # 5. Action items — gợi ý dựa trên dữ liệu, không phán bằng cảm tính.
+    lines.append("")
+    lines.append("🎯 ĐỀ XUẤT:")
+    for item in _action_items(top, bottom, summary):
+        lines.append(f"  • {item}")
+
+    lines.append("")
+    lines.append("🔍 Chi tiết: streamlit run dashboard/app.py")
+
+    report = "\n".join(lines)
+    if len(report) > MAX_REPORT_CHARS:
+        report = report[:MAX_REPORT_CHARS - 20].rstrip() + "\n… (xem dashboard)"
+    return report
+
+
+def _action_items(top: list[dict], bottom: list[dict], cost_summary: dict) -> list[str]:
+    """Gợi ý hành động — có dữ liệu thì cụ thể, thiếu thì nhắc thu thập thêm.
+
+    Cố ý KHÔNG đề xuất cắt format ở đây (quy tắc ≥10 sample/arm — dùng
+    analytics/experiment_compare.py cho quyết định đó); retro chỉ nêu tín hiệu.
+    """
+    items: list[str] = []
+    if top:
+        best = top[0]
+        items.append(f"Nhân motif của '{_label_for(best)}' (top view tuần).")
+    if bottom and bottom[0].get("retention_50_pct") is not None:
+        worst = bottom[0]
+        if worst["retention_50_pct"] < 40:
+            items.append(
+                f"Xem lại hook của '{_label_for(worst)}' (retention "
+                f"{worst['retention_50_pct']:.0f}% < 40%).")
+    if cost_summary["total_usd"] > 0:
+        items.append("Đối chiếu chi phí với hoá đơn Anthropic cuối tháng.")
+    if not items:
+        items.append("Chưa đủ dữ liệu — tiếp tục thu thập, chưa quyết định cắt format.")
+    return items
+
+
+def send_weekly_retro(since: Optional[str] = None) -> bool:
+    """Sinh + gửi báo cáo tuần qua Telegram. Returns True nếu gửi thành công."""
+    report = generate_retro_report(since=since)
+    try:
+        from notifier.telegram_bot import send_alert
+        return send_alert(report)
+    except Exception as e:
+        logger.error("send_weekly_retro failed: %s", e)
+        return False
+
+
+if __name__ == "__main__":
+    import argparse
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Weekly retro report (Phase 6)")
+    parser.add_argument("--print", action="store_true",
+                        help="In ra stdout thay vì gửi Telegram")
+    args = parser.parse_args()
+    if args.print:
+        print(generate_retro_report())
+    else:
+        print("sent" if send_weekly_retro() else "failed")

--- a/content-pipeline/analytics/youtube_puller.py
+++ b/content-pipeline/analytics/youtube_puller.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+"""
+YouTube Analytics puller (Phase 6 EPIC #6.1) — kéo số liệu per-video + per-channel
+qua YouTube Analytics API v2, upsert vào `video_metrics` / `channel_metrics`.
+
+Chạy mỗi đêm 23h (launchd com.ai5phut.metrics-pull.plist). Metric YouTube trễ
+24-48h (phase-6-detailed.md §5) nên snapshot mỗi ngày ghi đè trong ngày là bình
+thường — upsert idempotent lo việc đó.
+
+## Scope OAuth
+Analytics cần `yt-analytics.readonly` + `youtube.readonly` — KHÁC token upload
+(`youtube.upload` + `force-ssl`, publisher/youtube_uploader.py). Nên puller
+dùng file token RIÊNG cho mỗi kênh, suy ra từ token upload:
+    <upload_token>.analytics.json
+Một OAuth2 client (Google Cloud) mint được nhiều token với scope khác nhau.
+Chạy `python -m analytics.youtube_puller auth <channel_key>` một lần để cấp
+token analytics cho từng kênh (mở browser, giống youtube_uploader.py __main__).
+
+## Mapping video → videos.id
+Analytics trả về YouTube video id; nối về `videos.id` qua
+scheduled_posts.platform_video_id (storage.video_metrics.resolve_video_id).
+Không map được (vd video đăng tay) → vẫn lưu metric với video_id=NULL.
+"""
+
+import logging
+import os
+from datetime import date, timedelta
+from typing import Optional
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from channels import get_channel, channels_for_platform
+from storage import video_metrics, channel_metrics
+
+logger = logging.getLogger(__name__)
+
+# Scope chỉ-đọc cho Analytics + Data API (khác scope upload).
+SCOPES = [
+    "https://www.googleapis.com/auth/yt-analytics.readonly",
+    "https://www.googleapis.com/auth/youtube.readonly",
+]
+
+# Metric per-video hợp lệ với dimension=video ở Analytics API v2. CTR
+# (impressions) KHÔNG lấy được ổn định qua endpoint này nên để NULL — có thể
+# bổ sung sau bằng report "impressions" riêng.
+_VIDEO_METRICS_QUERY = (
+    "views,likes,comments,shares,estimatedMinutesWatched,averageViewDuration"
+)
+
+
+def _analytics_token_file(channel_key: str) -> str:
+    """File token analytics riêng cho kênh (suy ra từ token upload)."""
+    from publisher.youtube_uploader import resolve_token_file
+    upload_token = resolve_token_file(channel_key)
+    return upload_token + ".analytics.json"
+
+
+def _load_credentials(token_file: str, interactive: bool = False):
+    """Load OAuth creds với SCOPES analytics; refresh nếu hết hạn.
+
+    `interactive=True` (chỉ dùng ở CLI auth) sẽ mở browser cấp quyền lần đầu.
+    Non-interactive mà token thiếu/không đủ scope → trả None kèm hướng dẫn.
+    """
+    from google.oauth2.credentials import Credentials
+    from google.auth.transport.requests import Request
+
+    creds = None
+    if os.path.exists(token_file):
+        creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+        granted = set(getattr(creds, "scopes", None) or [])
+        if not set(SCOPES).issubset(granted):
+            logger.warning("Token %s thiếu scope analytics — cần auth lại.", token_file)
+            creds = None
+
+    if creds and creds.valid:
+        return creds
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        return creds
+
+    if not interactive:
+        logger.error(
+            "Chưa có token analytics hợp lệ (%s). Chạy: "
+            "python -m analytics.youtube_puller auth <channel_key>", token_file,
+        )
+        return None
+
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    if not config.YOUTUBE_CLIENT_SECRETS or not os.path.exists(config.YOUTUBE_CLIENT_SECRETS):
+        logger.error("YOUTUBE_CLIENT_SECRETS không tồn tại: %s", config.YOUTUBE_CLIENT_SECRETS)
+        return None
+    flow = InstalledAppFlow.from_client_secrets_file(config.YOUTUBE_CLIENT_SECRETS, SCOPES)
+    creds = flow.run_local_server(port=0)
+    os.makedirs(os.path.dirname(token_file) or ".", exist_ok=True)
+    with open(token_file, "w") as f:
+        f.write(creds.to_json())
+    return creds
+
+
+def _build_services(channel_key: str, interactive: bool = False):
+    """(analytics_service, data_service) đã xác thực cho 1 kênh, hoặc (None, None)."""
+    creds = _load_credentials(_analytics_token_file(channel_key), interactive=interactive)
+    if not creds:
+        return None, None
+    from googleapiclient.discovery import build
+    analytics = build("youtubeAnalytics", "v2", credentials=creds)
+    data = build("youtube", "v3", credentials=creds)
+    return analytics, data
+
+
+def _date_range(days_back: int) -> tuple[str, str]:
+    end = date.today()
+    start = end - timedelta(days=max(1, days_back))
+    return start.isoformat(), end.isoformat()
+
+
+def _rows_to_records(response: dict) -> list[dict]:
+    """Chuyển response Analytics (columnHeaders + rows) thành list dict theo tên cột."""
+    headers = [h["name"] for h in response.get("columnHeaders", [])]
+    records = []
+    for row in response.get("rows", []) or []:
+        records.append(dict(zip(headers, row)))
+    return records
+
+
+def _retention_50(analytics, external_id: str, start: str, end: str) -> Optional[float]:
+    """% khán giả còn xem ở mốc 50% video (report audienceRetention), best-effort.
+
+    Đây là metric chiến lược ưu tiên (phase-6-detailed.md §5: đừng chỉ nhìn
+    views). Report riêng theo từng video; video mới/không đủ dữ liệu → trả None
+    chứ không làm hỏng cả lần pull.
+    """
+    try:
+        resp = analytics.reports().query(
+            ids="channel==MINE",
+            startDate=start, endDate=end,
+            metrics="audienceWatchRatio",
+            dimensions="elapsedVideoTimeRatio",
+            filters=f"video=={external_id};audienceType==ORGANIC",
+        ).execute()
+    except Exception as e:
+        logger.debug("retention_50 unavailable for %s: %s", external_id, e)
+        return None
+    records = _rows_to_records(resp)
+    if not records:
+        return None
+    # Lấy điểm có elapsedVideoTimeRatio gần 0.5 nhất.
+    best = min(records, key=lambda r: abs((r.get("elapsedVideoTimeRatio") or 0) - 0.5))
+    ratio = best.get("audienceWatchRatio")
+    return round(ratio * 100, 2) if ratio is not None else None
+
+
+def pull_metrics_for_channel(channel_key: str, days_back: int = 7,
+                             with_retention: bool = True,
+                             analytics=None, data=None,
+                             snapshot_date: Optional[str] = None) -> int:
+    """Kéo + upsert số liệu 1 kênh YouTube. Returns số video snapshot được ghi.
+
+    `analytics`/`data`: inject service (cho test); mặc định tự xác thực.
+    """
+    channel = get_channel(channel_key)
+    if channel["platform"] != "youtube":
+        logger.error("%s không phải kênh YouTube", channel_key)
+        return 0
+
+    if analytics is None or data is None:
+        analytics, data = _build_services(channel_key)
+        if not analytics:
+            return 0
+
+    start, end = _date_range(days_back)
+
+    # 1. Per-video.
+    try:
+        resp = analytics.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics=_VIDEO_METRICS_QUERY, dimensions="video",
+            sort="-views", maxResults=200,
+        ).execute()
+    except Exception as e:
+        logger.error("pull per-video failed for %s: %s", channel_key, e)
+        return 0
+
+    count = 0
+    for rec in _rows_to_records(resp):
+        external_id = rec.get("video")
+        if not external_id:
+            continue
+        retention = (_retention_50(analytics, external_id, start, end)
+                     if with_retention else None)
+        video_metrics.upsert_metric(
+            platform="youtube", external_id=external_id, channel_key=channel_key,
+            snapshot_date=snapshot_date,
+            views=_int(rec.get("views")), likes=_int(rec.get("likes")),
+            comments=_int(rec.get("comments")), shares=_int(rec.get("shares")),
+            watch_time_minutes=_float(rec.get("estimatedMinutesWatched")),
+            avg_view_duration_seconds=_float(rec.get("averageViewDuration")),
+            retention_50_pct=retention,
+        )
+        count += 1
+
+    # 2. Per-channel (sub growth + view cho weekly retro).
+    _pull_channel_totals(channel_key, start, end, analytics, data, snapshot_date)
+
+    logger.info("Pulled %d video snapshots for %s", count, channel_key)
+    return count
+
+
+def _pull_channel_totals(channel_key: str, start: str, end: str,
+                         analytics, data, snapshot_date: Optional[str]) -> None:
+    subs_gained = channel_views = None
+    try:
+        resp = analytics.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics="subscribersGained,subscribersLost,views",
+        ).execute()
+        recs = _rows_to_records(resp)
+        if recs:
+            r = recs[0]
+            gained = _int(r.get("subscribersGained")) or 0
+            lost = _int(r.get("subscribersLost")) or 0
+            subs_gained = gained - lost
+            channel_views = _int(r.get("views"))
+    except Exception as e:
+        logger.debug("channel totals unavailable for %s: %s", channel_key, e)
+
+    # Tổng subscriber tuyệt đối (Data API statistics).
+    subscribers = None
+    try:
+        ch = data.channels().list(part="statistics", mine=True).execute()
+        items = ch.get("items", [])
+        if items:
+            subscribers = _int(items[0]["statistics"].get("subscriberCount"))
+    except Exception as e:
+        logger.debug("subscriberCount unavailable for %s: %s", channel_key, e)
+
+    if any(v is not None for v in (subs_gained, channel_views, subscribers)):
+        channel_metrics.upsert_channel_metric(
+            channel_key=channel_key, platform="youtube",
+            snapshot_date=snapshot_date, subscribers=subscribers,
+            subscribers_gained=subs_gained, views=channel_views,
+        )
+
+
+def pull_all(days_back: int = 7) -> dict[str, int]:
+    """Pull mọi kênh YouTube trong registry. Returns {channel_key: n_videos}."""
+    result = {}
+    for channel_key in channels_for_platform("youtube"):
+        try:
+            result[channel_key] = pull_metrics_for_channel(channel_key, days_back)
+        except Exception as e:
+            logger.error("pull_all: %s failed: %s", channel_key, e)
+            result[channel_key] = 0
+    return result
+
+
+def _int(v):
+    try:
+        return int(round(float(v))) if v is not None else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _float(v):
+    try:
+        return float(v) if v is not None else None
+    except (ValueError, TypeError):
+        return None
+
+
+if __name__ == "__main__":
+    import argparse
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description="YouTube Analytics puller (Phase 6)")
+    sub = parser.add_subparsers(dest="command")
+
+    p_auth = sub.add_parser("auth", help="Cấp token analytics cho 1 kênh (mở browser)")
+    p_auth.add_argument("channel_key")
+
+    p_pull = sub.add_parser("pull", help="Pull số liệu")
+    p_pull.add_argument("channel_key", nargs="?", help="Bỏ trống = mọi kênh YouTube")
+    p_pull.add_argument("--days-back", type=int, default=7)
+
+    args = parser.parse_args()
+    if args.command == "auth":
+        creds = _load_credentials(_analytics_token_file(args.channel_key), interactive=True)
+        print("✅ Token analytics đã lưu." if creds else "❌ Auth thất bại.")
+    elif args.command == "pull" and args.channel_key:
+        print(pull_metrics_for_channel(args.channel_key, days_back=args.days_back), "video")
+    else:
+        print(pull_all(days_back=getattr(args, "days_back", 7)))

--- a/content-pipeline/analytics/youtube_puller.py
+++ b/content-pipeline/analytics/youtube_puller.py
@@ -172,19 +172,15 @@ def pull_metrics_for_channel(channel_key: str, days_back: int = 7,
 
     start, end = _date_range(days_back)
 
-    # 1. Per-video.
+    # 1. Per-video (phân trang: kênh >200 video vẫn lấy hết, không rớt long-tail).
     try:
-        resp = analytics.reports().query(
-            ids="channel==MINE", startDate=start, endDate=end,
-            metrics=_VIDEO_METRICS_QUERY, dimensions="video",
-            sort="-views", maxResults=200,
-        ).execute()
+        records = _query_all_video_rows(analytics, start, end)
     except Exception as e:
         logger.error("pull per-video failed for %s: %s", channel_key, e)
         return 0
 
     count = 0
-    for rec in _rows_to_records(resp):
+    for rec in records:
         external_id = rec.get("video")
         if not external_id:
             continue
@@ -208,12 +204,45 @@ def pull_metrics_for_channel(channel_key: str, days_back: int = 7,
     return count
 
 
+_VIDEO_PAGE_SIZE = 200
+
+
+def _query_all_video_rows(analytics, start: str, end: str) -> list[dict]:
+    """Query per-video, phân trang qua startIndex tới khi hết dòng.
+
+    YouTube Analytics API mặc định trả tối đa 200 dòng/lần; kênh có >200 video
+    hoạt động sẽ mất long-tail (và rớt mẫu arm khỏi compare_arms) nếu chỉ lấy
+    trang đầu (finding review PR #71).
+    """
+    records: list[dict] = []
+    start_index = 1
+    while True:
+        resp = analytics.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics=_VIDEO_METRICS_QUERY, dimensions="video",
+            sort="-views", maxResults=_VIDEO_PAGE_SIZE, startIndex=start_index,
+        ).execute()
+        page = _rows_to_records(resp)
+        records.extend(page)
+        if len(page) < _VIDEO_PAGE_SIZE:
+            break
+        start_index += _VIDEO_PAGE_SIZE
+    return records
+
+
 def _pull_channel_totals(channel_key: str, start: str, end: str,
                          analytics, data, snapshot_date: Optional[str]) -> None:
+    # subscribersGained/views là delta tích luỹ theo cửa sổ. Puller chạy mỗi đêm
+    # với days_back=7 → các cửa sổ CHỒNG NHAU; nếu lưu delta 7-ngày cho mỗi
+    # snapshot thì retro/dashboard cộng lại đếm trùng tới ~7x. Dùng cửa sổ 1
+    # NGÀY (end-1 → end) để mỗi snapshot_date giữ delta KHÔNG chồng, cộng các
+    # ngày lại mới ra tăng trưởng đúng (finding review PR #71).
+    from datetime import date as _date, timedelta as _td
+    daily_start = (_date.fromisoformat(end) - _td(days=1)).isoformat()
     subs_gained = channel_views = None
     try:
         resp = analytics.reports().query(
-            ids="channel==MINE", startDate=start, endDate=end,
+            ids="channel==MINE", startDate=daily_start, endDate=end,
             metrics="subscribersGained,subscribersLost,views",
         ).execute()
         recs = _rows_to_records(resp)

--- a/content-pipeline/dashboard/__init__.py
+++ b/content-pipeline/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""KPI dashboard (Phase 6 EPIC #6.2).
+
+`data.py` là tầng dữ liệu THUẦN (test được, không cần streamlit); `app.py` chỉ
+render Streamlit gọi vào đó. Chạy: streamlit run dashboard/app.py
+"""

--- a/content-pipeline/dashboard/app.py
+++ b/content-pipeline/dashboard/app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""
+KPI dashboard Streamlit (Phase 6 EPIC #6.2).
+
+Chạy local trên Mac Mini:  streamlit run dashboard/app.py
+(streamlit là optional dependency — xem requirements.txt; cài: pip install streamlit)
+
+Toàn bộ logic dữ liệu nằm ở dashboard/data.py (test được không cần streamlit);
+file này chỉ render. 4 tab: Overview, Top videos, Format analysis, Cost.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    import streamlit as st
+except ImportError:  # pragma: no cover - chỉ chạy khi thiếu streamlit
+    sys.stderr.write(
+        "streamlit chưa được cài. Chạy: pip install streamlit\n"
+        "rồi: streamlit run dashboard/app.py\n"
+    )
+    sys.exit(1)
+
+from channels import channels_for_platform
+from dashboard import data
+
+
+def _sidebar():
+    st.sidebar.title("📊 AI 5 Phút — KPI")
+    days = st.sidebar.selectbox("Khoảng thời gian", [7, 14, 30, 90], index=2,
+                                format_func=lambda d: f"{d} ngày gần nhất")
+    platforms = ["Tất cả", "youtube", "tiktok"]
+    platform = st.sidebar.selectbox("Platform", platforms)
+    return {
+        "since": data.default_since(days),
+        "platform": None if platform == "Tất cả" else platform,
+    }
+
+
+def _tab_overview(cfg):
+    ov = data.overview(since=cfg["since"], platform=cfg["platform"])
+    cols = st.columns(4)
+    cols[0].metric("Video có số liệu", ov["n_videos"])
+    cols[1].metric("Tổng views", f"{ov['views']:,}")
+    cols[2].metric("Tổng likes", f"{ov['likes']:,}")
+    cols[3].metric("Retention 50% TB",
+                   f"{ov['avg_retention_50']}%" if ov["avg_retention_50"] is not None else "—")
+
+    st.subheader("Views theo ngày")
+    ts = data.views_timeseries(since=cfg["since"], platform=cfg["platform"])
+    if ts:
+        st.line_chart({"views": list(ts.values())}, x=None)
+        st.caption("Trục X: " + ", ".join(ts.keys()))
+    else:
+        st.info("Chưa có snapshot nào trong khoảng này.")
+
+    st.subheader("Sub growth từng kênh")
+    st.table(data.sub_growth(since=cfg["since"]))
+
+
+def _tab_top_videos(cfg):
+    metric = st.selectbox("Xếp theo", ["views", "retention_50_pct",
+                                       "avg_view_duration_seconds", "likes"])
+    st.subheader(f"Top 10 — {metric}")
+    st.table(data.top_videos_table(metric=metric, limit=10, since=cfg["since"]))
+    st.subheader("Bottom 5 (cần phân tích)")
+    st.table(data.top_videos_table(metric="retention_50_pct", limit=5,
+                                   since=cfg["since"], ascending=True))
+
+
+def _tab_format(cfg):
+    st.subheader("Retention / views theo format")
+    rows = data.format_breakdown(since=cfg["since"])
+    if rows:
+        st.table(rows)
+    else:
+        st.info("Chưa có dữ liệu format.")
+
+
+def _tab_cost(cfg):
+    cb = data.cost_breakdown(since=cfg["since"])
+    summary = cb["summary"]
+    st.metric("Tổng chi phí AI (USD)", f"${summary['total_usd']:.2f}")
+    if summary["unpriced_models"]:
+        st.warning("Model chưa có giá: " + ", ".join(summary["unpriced_models"]))
+    st.subheader("Theo model")
+    st.table([
+        {"model": m, **v} for m, v in summary["by_model"].items()
+    ])
+    st.subheader("Theo ngày")
+    st.table(cb["daily"])
+
+
+def main():
+    st.set_page_config(page_title="AI 5 Phút — KPI", layout="wide")
+    cfg = _sidebar()
+    st.title("KPI Dashboard")
+    tabs = st.tabs(["Overview", "Top videos", "Format analysis", "Cost"])
+    with tabs[0]:
+        _tab_overview(cfg)
+    with tabs[1]:
+        _tab_top_videos(cfg)
+    with tabs[2]:
+        _tab_format(cfg)
+    with tabs[3]:
+        _tab_cost(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/content-pipeline/dashboard/data.py
+++ b/content-pipeline/dashboard/data.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+"""
+Tầng dữ liệu cho dashboard (Phase 6) — pure DB, KHÔNG import streamlit nên
+unit-test được. app.py chỉ render các dict/list mà module này trả về.
+"""
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from channels import channels_for_platform, get_channel
+from storage import video_metrics, channel_metrics, cost_logs
+from storage.database import get_connection, get_video
+from analytics import pricing
+
+logger = logging.getLogger(__name__)
+
+_KPI_METRICS = ("views", "likes", "comments", "shares")
+
+
+def default_since(days: int = 30) -> str:
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+def overview(since: Optional[str] = None, platform: Optional[str] = None) -> dict:
+    """KPI tổng: cộng metric snapshot MỚI NHẤT của mỗi video (tránh cộng trùng
+    nhiều snapshot cùng 1 video). Returns {n_videos, views, likes, ...,
+    avg_retention_50}."""
+    rows = video_metrics.latest_per_video(platform=platform, since=since)
+    totals = {m: 0 for m in _KPI_METRICS}
+    retentions = []
+    for r in rows:
+        for m in _KPI_METRICS:
+            if r.get(m) is not None:
+                totals[m] += r[m]
+        if r.get("retention_50_pct") is not None:
+            retentions.append(r["retention_50_pct"])
+    totals["n_videos"] = len(rows)
+    totals["avg_retention_50"] = round(sum(retentions) / len(retentions), 1) if retentions else None
+    return totals
+
+
+def _label_for(row: dict) -> str:
+    vid = row.get("video_id")
+    if vid:
+        v = get_video(vid)
+        if v:
+            title = (v.get("youtube_title") or v.get("tiktok_caption")
+                     or v.get("script_text", "")[:40])
+            if title:
+                return title[:50]
+    return f"{row.get('platform', '?')}:{row.get('external_id', '?')}"
+
+
+def top_videos_table(metric: str = "views", limit: int = 10,
+                     since: Optional[str] = None, ascending: bool = False) -> list[dict]:
+    """Bảng top/bottom video: [{label, platform, metric_value, views, retention_50_pct}]."""
+    rows = video_metrics.top_videos(metric=metric, limit=limit, since=since,
+                                    ascending=ascending)
+    return [
+        {
+            "label": _label_for(r),
+            "platform": r.get("platform"),
+            metric: r.get(metric),
+            "views": r.get("views"),
+            "retention_50_pct": r.get("retention_50_pct"),
+        }
+        for r in rows
+    ]
+
+
+def views_timeseries(since: Optional[str] = None,
+                     platform: Optional[str] = None) -> dict[str, int]:
+    """{snapshot_date: tổng views} — cho line chart 30 ngày."""
+    where = []
+    params: list = []
+    if since:
+        where.append("snapshot_date >= ?")
+        params.append(since)
+    if platform:
+        where.append("platform = ?")
+        params.append(platform)
+    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            f"SELECT snapshot_date, COALESCE(SUM(views), 0) AS v FROM video_metrics "
+            f"{where_sql} GROUP BY snapshot_date ORDER BY snapshot_date",
+            params,
+        ).fetchall()
+        return {r["snapshot_date"]: int(r["v"]) for r in rows}
+    finally:
+        conn.close()
+
+
+def format_breakdown(since: Optional[str] = None) -> list[dict]:
+    """Retention/views trung bình theo (track, video_type) — 'format' của video.
+
+    Join snapshot mới nhất với bảng videos để biết track/loại. Video chưa map
+    (video_id NULL) gộp vào nhóm 'unmapped'.
+    """
+    latest = video_metrics.latest_per_video(since=since)
+    groups: dict[tuple, dict] = {}
+    for r in latest:
+        vid = r.get("video_id")
+        track = video_type = None
+        if vid:
+            v = get_video(vid)
+            if v:
+                track = v.get("track")
+                video_type = v.get("video_type")
+        key = (track or "unmapped", video_type or "?")
+        g = groups.setdefault(key, {"track": key[0], "video_type": key[1],
+                                    "n": 0, "views": 0, "_ret": []})
+        g["n"] += 1
+        if r.get("views") is not None:
+            g["views"] += r["views"]
+        if r.get("retention_50_pct") is not None:
+            g["_ret"].append(r["retention_50_pct"])
+    out = []
+    for g in groups.values():
+        rets = g.pop("_ret")
+        g["avg_retention_50"] = round(sum(rets) / len(rets), 1) if rets else None
+        out.append(g)
+    out.sort(key=lambda g: g["views"], reverse=True)
+    return out
+
+
+def sub_growth(since: Optional[str] = None) -> list[dict]:
+    """[{channel_key, name, subs_gained, subscribers}] cho mỗi kênh YouTube."""
+    since = since or default_since()
+    out = []
+    for channel_key in channels_for_platform("youtube"):
+        rng = channel_metrics.get_range(channel_key, since=since)
+        latest_subs = rng[-1]["subscribers"] if rng else None
+        out.append({
+            "channel_key": channel_key,
+            "name": get_channel(channel_key)["name"],
+            "subs_gained": channel_metrics.subs_gained(channel_key, since),
+            "subscribers": latest_subs,
+        })
+    return out
+
+
+def cost_breakdown(since: Optional[str] = None) -> dict:
+    """{'summary': summarize_costs(...), 'daily': [{date, service, ...}]}."""
+    since = since or default_since()
+    return {
+        "summary": pricing.summarize_costs(cost_logs.rows_since(since)),
+        "daily": cost_logs.daily_totals(since=since),
+    }

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -17,6 +17,8 @@ cp com.ai5phut.reddit-drama.plist ~/Library/LaunchAgents/
 cp com.ai5phut.drama-health.plist ~/Library/LaunchAgents/
 cp com.ai5phut.drama-pipeline.plist ~/Library/LaunchAgents/
 cp com.ai5phut.post-scheduler.plist ~/Library/LaunchAgents/
+cp com.ai5phut.metrics-pull.plist ~/Library/LaunchAgents/
+cp com.ai5phut.weekly-retro.plist ~/Library/LaunchAgents/
 ```
 
 ## Bước 3: Load services
@@ -40,6 +42,12 @@ launchctl load ~/Library/LaunchAgents/com.ai5phut.drama-pipeline.plist
 
 # Load post scheduler (tick mỗi 5 phút — upload video đã duyệt đúng giờ cadence, Phase 5)
 launchctl load ~/Library/LaunchAgents/com.ai5phut.post-scheduler.plist
+
+# Load metrics puller (23h mỗi đêm — kéo số liệu YouTube Analytics, Phase 6)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.metrics-pull.plist
+
+# Load weekly retro (Chủ nhật 19h — báo cáo tuần qua Telegram, Phase 6)
+launchctl load ~/Library/LaunchAgents/com.ai5phut.weekly-retro.plist
 ```
 
 ## Bước 4: Kiểm tra
@@ -79,4 +87,15 @@ cd ~/ContentCreator/content-pipeline && python3 main_drama.py
 # Xem/kick queue upload thủ công (Phase 5)
 cd ~/ContentCreator/content-pipeline && python3 -m scheduler.post_scheduler list
 cd ~/ContentCreator/content-pipeline && python3 -m scheduler.post_scheduler tick
+
+# Analytics (Phase 6)
+# Cấp token analytics cho từng kênh (1 lần, mở browser — scope chỉ-đọc)
+cd ~/ContentCreator/content-pipeline && python3 -m analytics.youtube_puller auth ai_youtube
+cd ~/ContentCreator/content-pipeline && python3 -m analytics.youtube_puller auth drama_youtube
+# Pull số liệu thủ công
+cd ~/ContentCreator/content-pipeline && python3 -m analytics.youtube_puller pull
+# In thử báo cáo tuần (không gửi Telegram)
+cd ~/ContentCreator/content-pipeline && python3 -m analytics.weekly_retro --print
+# Dashboard KPI (cần: pip install streamlit)
+cd ~/ContentCreator/content-pipeline && streamlit run dashboard/app.py
 ```

--- a/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
+++ b/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.metrics-pull</string>
+
+    <!-- Use the venv Python directly.
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>-m</string>
+        <string>analytics.youtube_puller</string>
+        <string>pull</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- 23:00 mỗi đêm — kéo số liệu YouTube Analytics vào video_metrics /
+         channel_metrics (Phase 6 — Analytics). Metric YouTube trễ 24-48h nên
+         snapshot đêm là đủ; chạy lại cùng ngày chỉ ghi đè (upsert). -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>23</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/metrics_pull_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/metrics_pull_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
+++ b/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.weekly-retro</string>
+
+    <!-- Use the venv Python directly.
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>-m</string>
+        <string>analytics.weekly_retro</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline</string>
+
+    <!-- Chủ nhật 19:00 — đẩy báo cáo tuần qua Telegram để tối CN đọc, sáng T2
+         đã có quyết định (Phase 6 — Weekly retro). Weekday: 0=CN trong launchd. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>19</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/weekly_retro_stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/ContentCreator/content-pipeline/logs/weekly_retro_stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/notifier/analytics_bot.py
+++ b/content-pipeline/notifier/analytics_bot.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""
+Analytics bot handlers (Phase 6 EPIC #6.1) — lệnh Telegram để nạp CSV số liệu
+TikTok từ TikTok Studio.
+
+Giống seed_bot.py / review_bot.py: đây là các hàm xử lý THUẦN, được
+notifier/telegram_bot.py dispatch vào CÙNG vòng long-polling / 1 bot token (2
+process cùng token → 409 Conflict). Trạng thái "đang chờ file CSV" lưu ở
+notifier/.analytics_state.json (persisted qua restart).
+
+Luồng:
+  /import_tiktok_csv → bot chờ → user đính kèm file .csv → telegram_bot tải file
+  về rồi gọi handle_csv_document(text) → parse + upsert → trả summary.
+"""
+
+import json
+import logging
+import os
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from analytics.tiktok_csv import import_csv_text
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = os.path.join(os.path.dirname(__file__), ".analytics_state.json")
+
+
+def _get_awaiting() -> str | None:
+    if not os.path.exists(_STATE_FILE):
+        return None
+    try:
+        with open(_STATE_FILE) as f:
+            return json.load(f).get("awaiting")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _set_awaiting(value: str | None):
+    try:
+        with open(_STATE_FILE, "w") as f:
+            json.dump({"awaiting": value}, f)
+    except OSError as e:
+        logger.warning("Could not persist analytics bot state: %s", e)
+
+
+def start_import_tiktok_csv() -> str:
+    """Handle /import_tiktok_csv — chờ file CSV đính kèm tiếp theo."""
+    _set_awaiting("tiktok_csv")
+    return (
+        "📎 Hãy đính kèm file CSV export từ TikTok Studio "
+        "(Analytics → Export). File tiếp theo bạn gửi sẽ được nạp vào DB.\n"
+        "Gõ /skip để huỷ."
+    )
+
+
+def is_awaiting_csv() -> bool:
+    return _get_awaiting() == "tiktok_csv"
+
+
+def skip_awaiting() -> str | None:
+    """Huỷ trạng thái chờ (dùng chung cơ chế /skip). None nếu không có gì chờ."""
+    if _get_awaiting() is None:
+        return None
+    _set_awaiting(None)
+    return "✨ Đã huỷ nạp CSV TikTok."
+
+
+def handle_csv_document(text: str, file_name: str = "") -> str:
+    """Nạp nội dung CSV (đã tải về) nếu đang chờ. Returns reply, luôn clear state.
+
+    Chỉ được gọi khi is_awaiting_csv() True (telegram_bot kiểm tra trước khi
+    tải file — tránh tải nhầm mọi document người dùng gửi).
+    """
+    _set_awaiting(None)
+    if file_name and not file_name.lower().endswith(".csv"):
+        return (f"⚠️ File '{file_name}' không phải .csv. "
+                f"Gõ /import_tiktok_csv để thử lại.")
+    try:
+        summary = import_csv_text(text)
+    except Exception as e:
+        logger.exception("TikTok CSV import failed")
+        return f"⚠️ Lỗi nạp CSV: {e}"
+    return (
+        f"✅ Đã nạp CSV TikTok:\n"
+        f"  • {summary['imported']} video có số liệu\n"
+        f"  • {summary['skipped']} dòng bỏ qua (thiếu id/số liệu)\n"
+        f"Tổng {summary['rows']} dòng."
+    )
+
+
+def help_text() -> str:
+    return (
+        "📊 Analytics bot:\n"
+        "/import_tiktok_csv — Nạp CSV số liệu từ TikTok Studio"
+    )

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -349,6 +349,20 @@ def _handle_update(update: dict, publish_callback):
     if chat_id != config.TELEGRAM_CHAT_ID:
         return
 
+    # File đính kèm (Phase 6): CSV số liệu TikTok. Chỉ tải file khi đang chờ
+    # (analytics_bot.is_awaiting_csv) để không tải nhầm mọi document gửi tới.
+    document = message.get("document")
+    if document:
+        from notifier import analytics_bot
+        if analytics_bot.is_awaiting_csv():
+            content = _download_file(document.get("file_id", ""))
+            if content is None:
+                _send_text("⚠️ Không tải được file. Thử lại /import_tiktok_csv.")
+            else:
+                _send_text(analytics_bot.handle_csv_document(
+                    content, document.get("file_name", "")))
+        return
+
     # Plain (non-command) messages answer whichever conversation is awaiting
     # input: review gate FSM (reject reason / edit metadata, Phase 5) first,
     # then drama seed bot (/seed_vn, /seed_url — Phase 2). Commands below
@@ -363,9 +377,16 @@ def _handle_update(update: dict, publish_callback):
         return
 
     if text == "/skip":
-        from notifier import review_bot
+        from notifier import review_bot, analytics_bot
         reply = review_bot.skip_awaiting()
+        if reply is None:
+            reply = analytics_bot.skip_awaiting()
         _send_text(reply if reply is not None else "✨ Không có câu hỏi nào đang chờ.")
+        return
+
+    if text == "/import_tiktok_csv":
+        from notifier import analytics_bot
+        _send_text(analytics_bot.start_import_tiktok_csv())
         return
 
     if text.startswith("/approve_"):
@@ -453,7 +474,7 @@ def _handle_update(update: dict, publish_callback):
         _send_text(seed_bot.list_pending_text())
 
     elif text == "/help":
-        from notifier import review_bot, seed_bot
+        from notifier import review_bot, seed_bot, analytics_bot
         _send_text(
             "📖 Lệnh bot:\n"
             "/approve_<id> — Duyệt và đăng video\n"
@@ -461,7 +482,8 @@ def _handle_update(update: dict, publish_callback):
             "/script_<id> — Xem lại script video\n"
             "/status — Xem video đang chờ duyệt\n\n"
             + review_bot.help_text() + "\n\n"
-            + seed_bot.help_text()
+            + seed_bot.help_text() + "\n\n"
+            + analytics_bot.help_text()
         )
 
 
@@ -714,6 +736,33 @@ def _send_single_text(text: str) -> bool:
     except Exception as e:
         logger.error("Telegram send failed: %s", e)
         return False
+
+
+def _download_file(file_id: str) -> str | None:
+    """Tải nội dung 1 file Telegram về dưới dạng text (getFile → file_path → tải).
+
+    Dùng cho import CSV TikTok (Phase 6). Trả None nếu bất kỳ bước nào lỗi —
+    caller báo người dùng thử lại thay vì crash vòng long-polling.
+    """
+    if not file_id or not config.TELEGRAM_BOT_TOKEN:
+        return None
+    try:
+        get_url = (f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}"
+                   f"/getFile?file_id={file_id}")
+        with urlopen(Request(get_url), timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+        if not data.get("ok"):
+            logger.error("getFile failed: %s", data)
+            return None
+        file_path = data["result"]["file_path"]
+        dl_url = (f"https://api.telegram.org/file/bot{config.TELEGRAM_BOT_TOKEN}"
+                  f"/{file_path}")
+        with urlopen(Request(dl_url), timeout=60) as resp:
+            # utf-8-sig: TikTok Studio CSV hay có BOM ở đầu file.
+            return resp.read().decode("utf-8-sig")
+    except Exception as e:
+        logger.error("Telegram file download failed: %s", e)
+        return None
 
 
 def _get_updates(timeout: int = 30) -> list[dict]:

--- a/content-pipeline/processors/ai_analyzer.py
+++ b/content-pipeline/processors/ai_analyzer.py
@@ -49,6 +49,8 @@ def analyze_article(full_content: str) -> dict | None:
                 max_tokens=1000,
                 messages=[{"role": "user", "content": prompt}],
             )
+            from processors.ai_usage import log_token_usage
+            log_token_usage("ai_analyzer", None, message, ref_type="article")
             response_text = message.content[0].text.strip()
             # Extract JSON from markdown code blocks or raw text
             json_match = re.search(r'\{.*\}', response_text, re.DOTALL)

--- a/content-pipeline/processors/ai_scorer.py
+++ b/content-pipeline/processors/ai_scorer.py
@@ -53,6 +53,8 @@ def score_article(title: str, summary: str) -> float | None:
                 max_tokens=200,
                 messages=[{"role": "user", "content": prompt}],
             )
+            from processors.ai_usage import log_token_usage
+            log_token_usage("ai_scorer", None, message, ref_type="article")
             response_text = message.content[0].text.strip()
             # Extract JSON from markdown code blocks or raw text
             json_match = re.search(r'\{[^{}]*\}', response_text)

--- a/content-pipeline/processors/ai_usage.py
+++ b/content-pipeline/processors/ai_usage.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 """
-Shared token-usage logging for Drama processors (Phase 3 EPIC #3.2).
+Shared token-usage logging for AI calls (Phase 3 EPIC #3.2; cost persistence
+added Phase 6).
 
 Logs raw input/output token counts per call — not a $ estimate, since
 hardcoding per-model pricing here would silently go stale as prices change.
-Check the current Anthropic pricing page if you want a cost figure; token
-counts alone are enough to spot a run that's unexpectedly expensive.
+Token counts alone are enough to spot a run that's unexpectedly expensive; the
+$ conversion is a display-time overlay in analytics/pricing.py.
+
+Phase 6: besides logging, we now PERSIST each call's raw tokens into
+`cost_logs` (best-effort) so the analytics cost tab / weekly retro have real
+data. This makes phase-6-detailed.md's assumption that cost_logs "đã ghi từ
+Phase 3, 4" actually true. Persistence never raises into the caller — a DB
+without migration 007 just skips the write.
 """
 
 import logging
@@ -14,15 +21,35 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def log_token_usage(label: str, story_id: int, message) -> None:
-    """Log input/output token counts from an Anthropic Message response."""
+def log_token_usage(label: str, story_id, message,
+                    service: str = "anthropic", ref_type: str | None = "story") -> None:
+    """Log + persist input/output token counts from an Anthropic Message response.
+
+    `story_id` may be any reference (int story/article id, or a synthetic key
+    like "3_stories" for batch calls) — stored verbatim as cost_logs.ref_id.
+    """
     usage = getattr(message, "usage", None)
     if usage is None:
         return
+    input_tokens = getattr(usage, "input_tokens", 0)
+    output_tokens = getattr(usage, "output_tokens", 0)
+    model = getattr(message, "model", None)
     # %s (not %d): tolerates a non-int usage object (e.g. a test double)
     # without crashing logging's lazy message formatting.
     logger.info(
         "%s story=%s tokens: input=%s output=%s",
-        label, story_id,
-        getattr(usage, "input_tokens", 0), getattr(usage, "output_tokens", 0),
+        label, story_id, input_tokens, output_tokens,
     )
+
+    # Persist raw tokens for cost analytics. Best-effort: never let a logging
+    # helper break the pipeline (e.g. token counts are test doubles, or the DB
+    # predates migration 007).
+    try:
+        from storage.cost_logs import record_cost
+        record_cost(
+            service=service, model=model, label=label,
+            input_tokens=int(input_tokens), output_tokens=int(output_tokens),
+            ref_type=ref_type, ref_id=story_id,
+        )
+    except Exception as e:  # includes non-int test doubles → int() TypeError
+        logger.debug("cost persistence skipped for %s (non-fatal): %s", label, e)

--- a/content-pipeline/storage/channel_metrics.py
+++ b/content-pipeline/storage/channel_metrics.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `channel_metrics` (Phase 6 — Analytics & Iteration).
+
+Snapshot cấp KÊNH (subscriber, subscribers_gained, views). video_metrics một
+mình không suy ra được "kênh tăng bao nhiêu sub tuần này" — weekly retro cần
+số này (phase-6-detailed.md §3.6 "Sub growth từng kênh").
+
+Yêu cầu migration 007_analytics.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+_METRIC_FIELDS = ("subscribers", "subscribers_gained", "views")
+
+
+def _today() -> str:
+    return datetime.now().date().isoformat()
+
+
+def upsert_channel_metric(channel_key: str, platform: str,
+                          snapshot_date: Optional[str] = None, **metrics) -> int:
+    """Ghi/ghi đè snapshot cấp kênh. Idempotent theo (channel_key, snapshot_date)."""
+    unknown = set(metrics) - set(_METRIC_FIELDS)
+    if unknown:
+        raise ValueError(f"upsert_channel_metric: unknown field(s) {sorted(unknown)}")
+    snapshot_date = snapshot_date or _today()
+
+    cols = ["channel_key", "platform", "snapshot_date"]
+    vals = [channel_key, platform, snapshot_date]
+    for field in _METRIC_FIELDS:
+        if field in metrics:
+            cols.append(field)
+            vals.append(metrics[field])
+
+    placeholders = ", ".join("?" * len(cols))
+    update_cols = [c for c in cols if c not in ("channel_key", "snapshot_date")]
+    update_clause = ", ".join(f"{c} = excluded.{c}" for c in update_cols)
+
+    conn = get_connection()
+    try:
+        conn.execute(
+            f"INSERT INTO channel_metrics ({', '.join(cols)}) VALUES ({placeholders}) "
+            f"ON CONFLICT(channel_key, snapshot_date) DO UPDATE SET {update_clause}",
+            vals,
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT id FROM channel_metrics WHERE channel_key = ? AND snapshot_date = ?",
+            (channel_key, snapshot_date),
+        ).fetchone()
+        return int(row["id"]) if row else 0
+    finally:
+        conn.close()
+
+
+def get_range(channel_key: str, since: Optional[str] = None) -> list[dict]:
+    """Snapshot của 1 kênh, cũ → mới, lọc snapshot_date >= since nếu truyền."""
+    conn = get_connection()
+    try:
+        if since:
+            rows = conn.execute(
+                "SELECT * FROM channel_metrics WHERE channel_key = ? AND snapshot_date >= ? "
+                "ORDER BY snapshot_date, id",
+                (channel_key, since),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM channel_metrics WHERE channel_key = ? ORDER BY snapshot_date, id",
+                (channel_key,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def subs_gained(channel_key: str, since: str) -> int:
+    """Tổng subscribers_gained của 1 kênh kể từ `since` (cho retro sub growth)."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(subscribers_gained), 0) AS total FROM channel_metrics "
+            "WHERE channel_key = ? AND snapshot_date >= ?",
+            (channel_key, since),
+        ).fetchone()
+        return int(row["total"])
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print("channel_metrics module ok")

--- a/content-pipeline/storage/cost_logs.py
+++ b/content-pipeline/storage/cost_logs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `cost_logs` (Phase 6 — Analytics & Iteration).
+
+Ghi TOKEN THÔ mỗi call AI (không phải $) — quy đổi ra tiền là overlay ở
+analytics/pricing.py, cập nhật bảng giá không cần đụng dữ liệu lịch sử. Đây là
+lý do processors/ai_usage.py cố ý không nhét pricing vào chỗ ghi log: token
+thô không bao giờ "stale", tiền thì có.
+
+`record_cost()` được thiết kế KHÔNG raise ra ngoài (nuốt lỗi, chỉ log) vì nó
+được gọi trên đường nóng của pipeline AI — một DB chưa migrate 007 không được
+làm hỏng cả lần chạy. Yêu cầu migration 007_analytics để thực sự ghi được.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def _today() -> str:
+    return datetime.now().date().isoformat()
+
+
+def record_cost(service: str, model: Optional[str] = None,
+                label: Optional[str] = None,
+                input_tokens: Optional[int] = None,
+                output_tokens: Optional[int] = None,
+                units: Optional[float] = None,
+                ref_type: Optional[str] = None,
+                ref_id: Optional[str] = None,
+                date: Optional[str] = None) -> Optional[int]:
+    """Ghi 1 dòng chi phí. Returns row id, hoặc None nếu ghi thất bại (non-fatal)."""
+    conn = get_connection()
+    try:
+        cur = conn.execute(
+            "INSERT INTO cost_logs (service, model, label, input_tokens, output_tokens, "
+            "units, ref_type, ref_id, date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (service, model, label, input_tokens, output_tokens, units,
+             ref_type, str(ref_id) if ref_id is not None else None, date or _today()),
+        )
+        conn.commit()
+        return cur.lastrowid
+    except Exception as e:
+        logger.debug("record_cost skipped (non-fatal): %s", e)
+        return None
+    finally:
+        conn.close()
+
+
+def daily_totals(since: Optional[str] = None) -> list[dict]:
+    """Tổng token theo (date, service) từ `since`, mới → cũ. Cho dashboard cost tab."""
+    conn = get_connection()
+    try:
+        if since:
+            rows = conn.execute(
+                "SELECT date, service, "
+                "COALESCE(SUM(input_tokens), 0) AS input_tokens, "
+                "COALESCE(SUM(output_tokens), 0) AS output_tokens, "
+                "COUNT(*) AS calls FROM cost_logs WHERE date >= ? "
+                "GROUP BY date, service ORDER BY date DESC, service",
+                (since,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT date, service, "
+                "COALESCE(SUM(input_tokens), 0) AS input_tokens, "
+                "COALESCE(SUM(output_tokens), 0) AS output_tokens, "
+                "COUNT(*) AS calls FROM cost_logs "
+                "GROUP BY date, service ORDER BY date DESC, service",
+            ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def rows_since(since: str) -> list[dict]:
+    """Mọi dòng cost thô kể từ `since` (cho pricing overlay tính $ theo model)."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM cost_logs WHERE date >= ? ORDER BY date, id", (since,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    for row in daily_totals():
+        print(row)

--- a/content-pipeline/storage/database.py
+++ b/content-pipeline/storage/database.py
@@ -510,6 +510,39 @@ def get_videos_by_story(story_id: int) -> list[dict]:
         conn.close()
 
 
+def set_video_experiment(video_id: int, experiment_id: str, arm: str) -> None:
+    """Tag a video vào 1 nhánh thí nghiệm A/B (Phase 6 — experiment helper).
+
+    Requires migration 007 (`videos.experiment_id/experiment_arm`). Trên DB
+    pre-migration chỉ log warning chứ không raise (giữ pipeline chạy).
+    """
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE videos SET experiment_id = ?, experiment_arm = ? WHERE id = ?",
+            (experiment_id, arm, video_id),
+        )
+        conn.commit()
+    except sqlite3.OperationalError as e:
+        logger.warning("set_video_experiment skipped (need migration 007?): %s", e)
+    finally:
+        conn.close()
+
+
+def get_videos_by_experiment(experiment_id: str) -> list[dict]:
+    """Mọi video gắn `experiment_id` (Phase 6). [] trên DB pre-migration."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM videos WHERE experiment_id = ? ORDER BY id", (experiment_id,)
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
 def get_video(video_id: int) -> Optional[dict]:
     """Get a video by ID."""
     conn = get_connection()

--- a/content-pipeline/storage/migrations/007_analytics.sql
+++ b/content-pipeline/storage/migrations/007_analytics.sql
@@ -1,0 +1,88 @@
+-- Migration 007: analytics layer (Phase 6 — Analytics & Iteration).
+--
+-- 1. `video_metrics` — snapshot số liệu 1 video trên 1 platform tại 1 ngày
+--    (analytics/youtube_puller.py, analytics/tiktok_csv.py). Snapshot mỗi 24h.
+-- 2. `channel_metrics` — snapshot cấp KÊNH (subscriber, view) để tính sub
+--    growth cho weekly retro — video_metrics một mình không suy ra được số
+--    subscriber của cả kênh.
+-- 3. `cost_logs` — token/chi phí mỗi call AI (Anthropic) + dịch vụ ngoài
+--    (Replicate/TTS). Phase-6-detailed.md giả định bảng này "đã ghi từ Phase
+--    3/4" nhưng thực tế processors/ai_usage.py trước đây chỉ log ra Python
+--    logging, KHÔNG persist. Migration này hiện thực hoá bảng đó; ai_usage
+--    được nối dây (best-effort) để ghi vào đây. Lưu TOKEN THÔ (không phải $)
+--    — quy đổi ra tiền là 1 lớp overlay ở analytics/pricing.py, cập nhật giá
+--    không cần đụng dữ liệu lịch sử (giữ tinh thần ai_usage.py: token thô
+--    không bao giờ "stale").
+-- 4. Cột mới trên `videos`: experiment_id / experiment_arm — gắn 1 video vào
+--    1 nhánh thí nghiệm A/B (thumbnail/hook/length), so sánh ở
+--    analytics/experiment_compare.py.
+--
+-- Khác phase-6-issues.md (đặt tên `002_metrics_schema.sql`): repo đã dùng dãy
+-- số migration liên tục tới 006, nên tiếp tục 007 thay vì reset về 002 (tránh
+-- đụng version với 002_stories_metadata đã tồn tại).
+--
+-- Khác phase-6-detailed.md (`video_metrics.video_id NOT NULL`, `UNIQUE(video_id,
+-- snapshot_at)`): video_id để NULLABLE vì metric TikTok giai đoạn manual (CSV
+-- từ TikTok Studio) không có đường map đáng tin về `videos.id` — ép NOT NULL
+-- đồng nghĩa vứt toàn bộ số liệu TikTok. Khoá upsert thật là
+-- (platform, external_id, snapshot_date); video_id là FK best-effort điền khi
+-- biết (map qua scheduled_posts.platform_video_id).
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS video_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  video_id INTEGER,                    -- FK videos.id, NULL nếu chưa map được (TikTok manual)
+  platform TEXT NOT NULL,              -- 'youtube' | 'tiktok'
+  external_id TEXT NOT NULL,           -- youtube_video_id / tiktok video id
+  channel_key TEXT,                    -- khoá trong channels.py (kênh nguồn của số liệu)
+  snapshot_date TEXT NOT NULL,         -- 'YYYY-MM-DD' (1 snapshot/ngày)
+  views INTEGER,
+  likes INTEGER,
+  comments INTEGER,
+  shares INTEGER,
+  watch_time_minutes REAL,
+  avg_view_duration_seconds REAL,
+  retention_50_pct REAL,               -- % người xem tới giữa video
+  ctr REAL,                            -- click-through rate (YouTube impressions)
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+-- Khoá upsert: cùng platform+video+ngày chỉ giữ 1 snapshot (ghi đè trong ngày).
+CREATE UNIQUE INDEX IF NOT EXISTS ux_video_metrics_snapshot
+  ON video_metrics(platform, external_id, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_video_metrics_video ON video_metrics(video_id);
+CREATE INDEX IF NOT EXISTS idx_video_metrics_snapshot ON video_metrics(snapshot_date);
+
+CREATE TABLE IF NOT EXISTS channel_metrics (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  channel_key TEXT NOT NULL,           -- khoá trong channels.py
+  platform TEXT NOT NULL,              -- 'youtube' | 'tiktok'
+  snapshot_date TEXT NOT NULL,
+  subscribers INTEGER,                 -- tổng subscriber tại thời điểm snapshot (nếu API trả)
+  subscribers_gained INTEGER,          -- subscriber tăng trong kỳ (retro dùng cho sub growth)
+  views INTEGER,                       -- view của kênh trong kỳ
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_channel_metrics_snapshot
+  ON channel_metrics(channel_key, snapshot_date);
+
+CREATE TABLE IF NOT EXISTS cost_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  service TEXT NOT NULL,               -- 'anthropic' | 'replicate' | 'tts' | ...
+  model TEXT,                          -- vd 'claude-haiku-4-5' (để pricing overlay quy đổi $)
+  label TEXT,                          -- bước gọi (drama_scorer, drama_rewriter, ...)
+  input_tokens INTEGER,
+  output_tokens INTEGER,
+  units REAL,                          -- đơn vị phi-token (giây TTS, ảnh Replicate) nếu có
+  ref_type TEXT,                       -- 'story' | 'article' | 'video' (loại id tham chiếu)
+  ref_id TEXT,
+  date TEXT NOT NULL,                  -- 'YYYY-MM-DD' (giờ local) để tổng hợp theo ngày
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_cost_logs_date ON cost_logs(date);
+CREATE INDEX IF NOT EXISTS idx_cost_logs_service ON cost_logs(service);
+
+ALTER TABLE videos ADD COLUMN experiment_id TEXT;
+ALTER TABLE videos ADD COLUMN experiment_arm TEXT;
+CREATE INDEX IF NOT EXISTS idx_videos_experiment ON videos(experiment_id);

--- a/content-pipeline/storage/migrations/007_analytics_down.sql
+++ b/content-pipeline/storage/migrations/007_analytics_down.sql
@@ -1,0 +1,10 @@
+-- Rollback for 007_analytics.
+-- SQLite (3.35+) hỗ trợ DROP COLUMN; các index trên bảng bị drop tự biến mất.
+
+DROP INDEX IF EXISTS idx_videos_experiment;
+ALTER TABLE videos DROP COLUMN experiment_arm;
+ALTER TABLE videos DROP COLUMN experiment_id;
+
+DROP TABLE IF EXISTS video_metrics;
+DROP TABLE IF EXISTS channel_metrics;
+DROP TABLE IF EXISTS cost_logs;

--- a/content-pipeline/storage/video_metrics.py
+++ b/content-pipeline/storage/video_metrics.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `video_metrics` (Phase 6 — Analytics & Iteration).
+
+Mỗi row là 1 snapshot số liệu của 1 video trên 1 platform tại 1 ngày. Khoá
+upsert là (platform, external_id, snapshot_date): pull lại trong ngày sẽ GHI ĐÈ
+snapshot cũ thay vì đẻ thêm dòng (metric có độ trễ 24-48h nên chạy lại cùng
+ngày là bình thường — xem phase-6-detailed.md §5 "YouTube Analytics latency").
+
+Yêu cầu migration 007_analytics (`python -m storage.migrate up`).
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Cột số liệu được phép upsert — allowlist để không dựng UPDATE động từ tên cột
+# tuỳ ý (cùng pattern storage/stories.update_status, database.update_video_metadata).
+_METRIC_FIELDS = (
+    "views", "likes", "comments", "shares", "watch_time_minutes",
+    "avg_view_duration_seconds", "retention_50_pct", "ctr",
+)
+
+
+def _today() -> str:
+    return datetime.now().date().isoformat()
+
+
+def resolve_video_id(platform: str, external_id: str) -> Optional[int]:
+    """Map một platform video id về `videos.id` qua scheduled_posts.
+
+    Scheduler lưu `platform_video_id` khi upload thành công (Phase 5). Metric
+    puller dùng hàm này để nối số liệu về đúng video nội bộ. Trả None nếu
+    không map được (vd TikTok upload tay không đi qua scheduler) — caller vẫn
+    lưu metric với video_id=NULL.
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT video_id FROM scheduled_posts WHERE platform_video_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (external_id,),
+        ).fetchone()
+        return int(row["video_id"]) if row else None
+    except Exception as e:  # bảng chưa tồn tại trên DB pre-migration
+        logger.debug("resolve_video_id failed: %s", e)
+        return None
+    finally:
+        conn.close()
+
+
+def upsert_metric(platform: str, external_id: str, snapshot_date: Optional[str] = None,
+                  video_id: Optional[int] = None, channel_key: Optional[str] = None,
+                  **metrics) -> int:
+    """Ghi (hoặc ghi đè) 1 snapshot metric. Returns row id.
+
+    `metrics`: chỉ nhận các key trong `_METRIC_FIELDS` (ValueError nếu sai).
+    Nếu `video_id` không truyền, tự thử map qua resolve_video_id().
+    Idempotent theo (platform, external_id, snapshot_date).
+    """
+    unknown = set(metrics) - set(_METRIC_FIELDS)
+    if unknown:
+        raise ValueError(f"upsert_metric: unknown metric field(s) {sorted(unknown)}")
+
+    snapshot_date = snapshot_date or _today()
+    if video_id is None:
+        video_id = resolve_video_id(platform, external_id)
+
+    cols = ["platform", "external_id", "snapshot_date", "video_id", "channel_key"]
+    vals = [platform, external_id, snapshot_date, video_id, channel_key]
+    for field in _METRIC_FIELDS:
+        if field in metrics:
+            cols.append(field)
+            vals.append(metrics[field])
+
+    placeholders = ", ".join("?" * len(cols))
+    # ON CONFLICT trên khoá upsert: cập nhật mọi cột vừa cung cấp (giữ nguyên
+    # cột không truyền trong lần pull này — vd YouTube trả ctr, TikTok không).
+    update_cols = [c for c in cols if c not in ("platform", "external_id", "snapshot_date")]
+    update_clause = ", ".join(f"{c} = excluded.{c}" for c in update_cols)
+
+    conn = get_connection()
+    try:
+        cur = conn.execute(
+            f"INSERT INTO video_metrics ({', '.join(cols)}) VALUES ({placeholders}) "
+            f"ON CONFLICT(platform, external_id, snapshot_date) DO UPDATE SET {update_clause}",
+            vals,
+        )
+        conn.commit()
+        # lastrowid không đáng tin sau ON CONFLICT UPDATE — tra lại id thật.
+        row = conn.execute(
+            "SELECT id FROM video_metrics WHERE platform = ? AND external_id = ? "
+            "AND snapshot_date = ?",
+            (platform, external_id, snapshot_date),
+        ).fetchone()
+        return int(row["id"]) if row else cur.lastrowid
+    finally:
+        conn.close()
+
+
+def get_metrics_for_video(video_id: int) -> list[dict]:
+    """Mọi snapshot của 1 video (mọi platform), cũ → mới."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM video_metrics WHERE video_id = ? ORDER BY snapshot_date, id",
+            (video_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def latest_per_video(platform: Optional[str] = None,
+                     since: Optional[str] = None) -> list[dict]:
+    """Snapshot MỚI NHẤT của mỗi video (mỗi platform).
+
+    `platform`: lọc theo platform nếu truyền. `since`: chỉ tính snapshot có
+    snapshot_date >= since (YYYY-MM-DD) — dùng cho báo cáo tuần.
+    """
+    where = []
+    params: list = []
+    if platform:
+        where.append("platform = ?")
+        params.append(platform)
+    if since:
+        where.append("snapshot_date >= ?")
+        params.append(since)
+    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+
+    conn = get_connection()
+    try:
+        # Với mỗi (platform, external_id) lấy dòng snapshot_date lớn nhất.
+        rows = conn.execute(
+            f"""
+            SELECT vm.* FROM video_metrics vm
+            JOIN (
+                SELECT platform, external_id, MAX(snapshot_date) AS md
+                FROM video_metrics {where_sql}
+                GROUP BY platform, external_id
+            ) last
+            ON vm.platform = last.platform AND vm.external_id = last.external_id
+               AND vm.snapshot_date = last.md
+            """,
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def top_videos(metric: str = "views", limit: int = 10,
+               since: Optional[str] = None, ascending: bool = False) -> list[dict]:
+    """Top/bottom video theo 1 metric, dựa trên snapshot mới nhất mỗi video.
+
+    `ascending=True` → bottom N (dùng cho retro "video cần phân tích"). Bỏ qua
+    video có metric NULL để không xếp hạng nhầm chỗ thiếu dữ liệu.
+    """
+    if metric not in _METRIC_FIELDS:
+        raise ValueError(f"top_videos: unknown metric {metric!r}")
+    rows = [r for r in latest_per_video(since=since) if r.get(metric) is not None]
+    rows.sort(key=lambda r: r[metric], reverse=not ascending)
+    return rows[:limit]
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    latest = latest_per_video()
+    print(f"{len(latest)} video có snapshot mới nhất.")
+    for r in top_videos(limit=5):
+        print(f"  {r['platform']}:{r['external_id']} views={r.get('views')}")

--- a/content-pipeline/storage/video_metrics.py
+++ b/content-pipeline/storage/video_metrics.py
@@ -35,12 +35,18 @@ def _today() -> str:
 
 
 def resolve_video_id(platform: str, external_id: str) -> Optional[int]:
-    """Map một platform video id về `videos.id` qua scheduled_posts.
+    """Map một platform video id về `videos.id`.
 
-    Scheduler lưu `platform_video_id` khi upload thành công (Phase 5). Metric
-    puller dùng hàm này để nối số liệu về đúng video nội bộ. Trả None nếu
-    không map được (vd TikTok upload tay không đi qua scheduler) — caller vẫn
-    lưu metric với video_id=NULL.
+    Hai nguồn map (theo thứ tự ưu tiên):
+    1. scheduled_posts.platform_video_id — flow Phase 5 (scheduler lưu id khi
+       upload thành công).
+    2. videos.publish_url — flow AI legacy (main.publish_video →
+       upload_video() chỉ lưu URL `youtu.be/<id>`, KHÔNG qua scheduler). Không
+       có fallback này thì mọi video AI cũ bị video_id=NULL, dashboard/A-B
+       không nối lại được (finding review PR #71).
+
+    Trả None nếu không map được (vd TikTok upload tay) — caller vẫn lưu metric
+    với video_id=NULL.
     """
     conn = get_connection()
     try:
@@ -49,9 +55,23 @@ def resolve_video_id(platform: str, external_id: str) -> Optional[int]:
             "ORDER BY id DESC LIMIT 1",
             (external_id,),
         ).fetchone()
-        return int(row["video_id"]) if row else None
+        if row and row["video_id"] is not None:
+            return int(row["video_id"])
     except Exception as e:  # bảng chưa tồn tại trên DB pre-migration
-        logger.debug("resolve_video_id failed: %s", e)
+        logger.debug("resolve_video_id via scheduled_posts failed: %s", e)
+    finally:
+        conn.close()
+
+    # Fallback: khớp external_id trong publish_url của video (flow AI legacy).
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id FROM videos WHERE publish_url LIKE ? ORDER BY id DESC LIMIT 1",
+            (f"%{external_id}%",),
+        ).fetchone()
+        return int(row["id"]) if row else None
+    except Exception as e:
+        logger.debug("resolve_video_id via publish_url failed: %s", e)
         return None
     finally:
         conn.close()
@@ -77,7 +97,11 @@ def upsert_metric(platform: str, external_id: str, snapshot_date: Optional[str] 
     cols = ["platform", "external_id", "snapshot_date", "video_id", "channel_key"]
     vals = [platform, external_id, snapshot_date, video_id, channel_key]
     for field in _METRIC_FIELDS:
-        if field in metrics:
+        # Bỏ qua field có giá trị None: youtube_puller luôn truyền
+        # retention_50_pct kể cả khi report tạm không có — nếu ghi None vào
+        # ON CONFLICT thì lần retry cùng ngày (chỉ định refresh views/likes) sẽ
+        # XOÁ retention đã bắt được trước đó (finding review PR #71).
+        if field in metrics and metrics[field] is not None:
             cols.append(field)
             vals.append(metrics[field])
 

--- a/content-pipeline/tests/test_analytics_bot.py
+++ b/content-pipeline/tests/test_analytics_bot.py
@@ -1,0 +1,68 @@
+"""Tests for notifier/analytics_bot.py (Phase 6 — TikTok CSV import handlers)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+from notifier import analytics_bot
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self.state = os.path.join(self.tmp, ".analytics_state.json")
+        self._patches = [
+            patch.object(db.config, "DB_PATH", self.dbpath),
+            patch.object(analytics_bot, "_STATE_FILE", self.state),
+        ]
+        for p in self._patches:
+            p.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+
+
+class TestFlow(Base):
+    def test_start_sets_awaiting(self):
+        self.assertFalse(analytics_bot.is_awaiting_csv())
+        analytics_bot.start_import_tiktok_csv()
+        self.assertTrue(analytics_bot.is_awaiting_csv())
+
+    def test_handle_csv_imports_and_clears_state(self):
+        analytics_bot.start_import_tiktok_csv()
+        csv_text = ("Video link,Total views,Likes\n"
+                    "https://www.tiktok.com/@x/video/111,100,10\n")
+        reply = analytics_bot.handle_csv_document(csv_text, "stats.csv")
+        self.assertIn("Đã nạp", reply)
+        self.assertFalse(analytics_bot.is_awaiting_csv())
+        self.assertEqual(len(vm.latest_per_video(platform="tiktok")), 1)
+
+    def test_non_csv_filename_rejected(self):
+        analytics_bot.start_import_tiktok_csv()
+        reply = analytics_bot.handle_csv_document("x", "photo.png")
+        self.assertIn("không phải .csv", reply)
+        self.assertFalse(analytics_bot.is_awaiting_csv())
+
+    def test_skip_clears_state(self):
+        analytics_bot.start_import_tiktok_csv()
+        self.assertIsNotNone(analytics_bot.skip_awaiting())
+        self.assertFalse(analytics_bot.is_awaiting_csv())
+
+    def test_skip_when_idle_returns_none(self):
+        self.assertIsNone(analytics_bot.skip_awaiting())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_channel_metrics.py
+++ b/content-pipeline/tests/test_channel_metrics.py
@@ -1,0 +1,54 @@
+"""Tests for storage/channel_metrics.py (Phase 6)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.channel_metrics as cm
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestChannelMetrics(Base):
+    def test_upsert_idempotent_same_day(self):
+        cm.upsert_channel_metric("ai_youtube", "youtube",
+                                 subscribers=1000, snapshot_date="2026-07-01")
+        cm.upsert_channel_metric("ai_youtube", "youtube",
+                                 subscribers=1100, snapshot_date="2026-07-01")
+        rng = cm.get_range("ai_youtube")
+        self.assertEqual(len(rng), 1)
+        self.assertEqual(rng[-1]["subscribers"], 1100)
+
+    def test_subs_gained_sums_over_range(self):
+        cm.upsert_channel_metric("ai_youtube", "youtube",
+                                 subscribers_gained=10, snapshot_date="2026-07-01")
+        cm.upsert_channel_metric("ai_youtube", "youtube",
+                                 subscribers_gained=15, snapshot_date="2026-07-02")
+        self.assertEqual(cm.subs_gained("ai_youtube", "2026-07-01"), 25)
+        self.assertEqual(cm.subs_gained("ai_youtube", "2026-07-02"), 15)
+
+    def test_unknown_field_rejected(self):
+        with self.assertRaises(ValueError):
+            cm.upsert_channel_metric("ai_youtube", "youtube", bogus=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_cost_logs.py
+++ b/content-pipeline/tests/test_cost_logs.py
@@ -1,0 +1,91 @@
+"""Tests for storage/cost_logs.py + ai_usage persistence (Phase 6)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.cost_logs as cl
+from processors import ai_usage
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestRecord(Base):
+    def test_record_and_daily_totals(self):
+        cl.record_cost("anthropic", "claude-haiku-4-5", "scorer",
+                       input_tokens=500, output_tokens=50, date="2026-07-01")
+        cl.record_cost("anthropic", "claude-sonnet-4-5", "rewriter",
+                       input_tokens=2000, output_tokens=400, date="2026-07-01")
+        totals = cl.daily_totals(since="2026-07-01")
+        by_service = {(r["date"], r["service"]): r for r in totals}
+        row = by_service[("2026-07-01", "anthropic")]
+        self.assertEqual(row["input_tokens"], 2500)
+        self.assertEqual(row["output_tokens"], 450)
+        self.assertEqual(row["calls"], 2)
+
+    def test_rows_since_filters(self):
+        cl.record_cost("anthropic", "m", "l", input_tokens=1, date="2026-06-01")
+        cl.record_cost("anthropic", "m", "l", input_tokens=2, date="2026-07-01")
+        rows = cl.rows_since("2026-06-15")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["input_tokens"], 2)
+
+
+class _FakeUsage:
+    def __init__(self, i, o):
+        self.input_tokens = i
+        self.output_tokens = o
+
+
+class _FakeMessage:
+    def __init__(self, model, i, o):
+        self.model = model
+        self.usage = _FakeUsage(i, o)
+
+
+class TestAiUsagePersistence(Base):
+    def test_log_token_usage_persists(self):
+        msg = _FakeMessage("claude-haiku-4-5", 500, 50)
+        ai_usage.log_token_usage("drama_scorer", 42, msg)
+        rows = cl.rows_since("2000-01-01")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["model"], "claude-haiku-4-5")
+        self.assertEqual(rows[0]["ref_id"], "42")
+        self.assertEqual(rows[0]["label"], "drama_scorer")
+
+    def test_no_usage_no_row(self):
+        class NoUsage:
+            usage = None
+        ai_usage.log_token_usage("x", 1, NoUsage())
+        self.assertEqual(cl.rows_since("2000-01-01"), [])
+
+    def test_non_int_usage_does_not_raise(self):
+        class Weird:
+            class usage:  # noqa
+                input_tokens = "NaN"
+                output_tokens = "NaN"
+            model = "claude-haiku-4-5"
+        # Must not raise even though int("NaN") fails inside persistence.
+        ai_usage.log_token_usage("x", 1, Weird())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_experiment_compare.py
+++ b/content-pipeline/tests/test_experiment_compare.py
@@ -1,0 +1,73 @@
+"""Tests for analytics/experiment_compare.py (Phase 6)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+from analytics import experiment_compare as ec
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _tag(self, experiment, arm, views):
+        vid = db.insert_video("short", "s", track="drama")
+        db.set_video_experiment(vid, experiment, arm)
+        vm.upsert_metric("youtube", f"ext{vid}", video_id=vid, views=views)
+        return vid
+
+
+class TestCompareArms(Base):
+    def test_enough_samples_and_better_arm(self):
+        for i in range(6):
+            self._tag("exp1", "A", 1000 + i)
+            self._tag("exp1", "B", 500 + i)
+        r = ec.compare_arms("exp1", "views", min_samples=5)
+        self.assertTrue(r["enough_samples"])
+        self.assertFalse(r["recommended_samples_met"])  # 6 < 10
+        self.assertEqual(r["better"], "A")
+        self.assertGreater(r["delta"], 0)
+        self.assertIsNotNone(r["p_value"])
+
+    def test_insufficient_samples_flagged(self):
+        self._tag("exp2", "A", 100)
+        self._tag("exp2", "B", 200)
+        r = ec.compare_arms("exp2", "views", min_samples=5)
+        self.assertFalse(r["enough_samples"])
+        self.assertIn("Chưa đủ mẫu", r["note"])
+
+    def test_video_without_metrics_excluded(self):
+        vid = db.insert_video("short", "s", track="drama")
+        db.set_video_experiment(vid, "exp3", "A")  # no metrics
+        r = ec.compare_arms("exp3", "views")
+        self.assertEqual(r["arms"], {})
+        self.assertIn("Chưa có video", r["note"])
+
+    def test_format_comparison_renders(self):
+        for i in range(5):
+            self._tag("exp4", "A", 1000)
+            self._tag("exp4", "B", 900)
+        text = ec.format_comparison(ec.compare_arms("exp4", "views"))
+        self.assertIn("exp4", text)
+        self.assertIn("Arm A", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_experiment_compare.py
+++ b/content-pipeline/tests/test_experiment_compare.py
@@ -53,6 +53,29 @@ class TestCompareArms(Base):
         self.assertFalse(r["enough_samples"])
         self.assertIn("Chưa đủ mẫu", r["note"])
 
+    def test_single_arm_not_enough_samples(self):
+        for _ in range(6):
+            self._tag("exp_solo", "A", 1000)  # chỉ arm A, không có arm B
+        r = ec.compare_arms("exp_solo", "views", min_samples=5)
+        self.assertFalse(r["enough_samples"])  # 1 arm không đủ để so
+        self.assertFalse(r["recommended_samples_met"])
+
+    def test_rate_metric_averaged_across_platforms(self):
+        vid = db.insert_video("short", "s", track="drama")
+        db.set_video_experiment(vid, "exp_rate", "A")
+        vm.upsert_metric("youtube", "ytx", video_id=vid, retention_50_pct=55)
+        vm.upsert_metric("tiktok", "ttx", video_id=vid, retention_50_pct=45)
+        m = ec._metric_by_video_id("retention_50_pct")
+        self.assertEqual(m[vid], 50.0)  # trung bình, KHÔNG phải 100
+
+    def test_count_metric_summed_across_platforms(self):
+        vid = db.insert_video("short", "s", track="drama")
+        db.set_video_experiment(vid, "exp_sum", "A")
+        vm.upsert_metric("youtube", "ytv", video_id=vid, views=1000)
+        vm.upsert_metric("tiktok", "ttv", video_id=vid, views=500)
+        m = ec._metric_by_video_id("views")
+        self.assertEqual(m[vid], 1500)
+
     def test_video_without_metrics_excluded(self):
         vid = db.insert_video("short", "s", track="drama")
         db.set_video_experiment(vid, "exp3", "A")  # no metrics

--- a/content-pipeline/tests/test_pricing.py
+++ b/content-pipeline/tests/test_pricing.py
@@ -26,6 +26,12 @@ class TestRates(unittest.TestCase):
                                      "PRICE_CLAUDE_HAIKU_4_5_OUT": "8"}):
             self.assertEqual(pricing.rates_for("claude-haiku-4-5"), (2.0, 8.0))
 
+    def test_base_env_override_applies_to_dated_id(self):
+        # Override đặt theo tên base phải áp cho cả id có hậu tố ngày.
+        with patch.dict(os.environ, {"PRICE_CLAUDE_HAIKU_4_5_IN": "2",
+                                     "PRICE_CLAUDE_HAIKU_4_5_OUT": "8"}):
+            self.assertEqual(pricing.rates_for("claude-haiku-4-5-20251001"), (2.0, 8.0))
+
     def test_cost_usd(self):
         # 1M input @ $1 + 100k output @ $5 = 1.0 + 0.5 = 1.5
         self.assertAlmostEqual(pricing.cost_usd("claude-haiku-4-5", 1_000_000, 100_000), 1.5)

--- a/content-pipeline/tests/test_pricing.py
+++ b/content-pipeline/tests/test_pricing.py
@@ -1,0 +1,52 @@
+"""Tests for analytics/pricing.py (Phase 6 — token→USD overlay)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from analytics import pricing
+
+
+class TestRates(unittest.TestCase):
+    def test_known_model(self):
+        self.assertEqual(pricing.rates_for("claude-haiku-4-5"), (1.0, 5.0))
+
+    def test_prefix_match_dated_id(self):
+        self.assertEqual(pricing.rates_for("claude-haiku-4-5-20251001"), (1.0, 5.0))
+
+    def test_unknown_model_none(self):
+        self.assertIsNone(pricing.rates_for("gpt-9"))
+
+    def test_env_override(self):
+        with patch.dict(os.environ, {"PRICE_CLAUDE_HAIKU_4_5_IN": "2",
+                                     "PRICE_CLAUDE_HAIKU_4_5_OUT": "8"}):
+            self.assertEqual(pricing.rates_for("claude-haiku-4-5"), (2.0, 8.0))
+
+    def test_cost_usd(self):
+        # 1M input @ $1 + 100k output @ $5 = 1.0 + 0.5 = 1.5
+        self.assertAlmostEqual(pricing.cost_usd("claude-haiku-4-5", 1_000_000, 100_000), 1.5)
+
+    def test_cost_unknown_model_none(self):
+        self.assertIsNone(pricing.cost_usd("mystery", 100, 100))
+
+
+class TestSummarize(unittest.TestCase):
+    def test_summary_totals_and_unpriced(self):
+        rows = [
+            {"model": "claude-haiku-4-5", "service": "anthropic",
+             "input_tokens": 1_000_000, "output_tokens": 0},
+            {"model": "mystery", "service": "anthropic",
+             "input_tokens": 100, "output_tokens": 50},
+        ]
+        s = pricing.summarize_costs(rows)
+        self.assertAlmostEqual(s["total_usd"], 1.0)
+        self.assertIn("mystery", s["unpriced_models"])
+        self.assertEqual(s["by_model"]["claude-haiku-4-5"]["calls"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_stats.py
+++ b/content-pipeline/tests/test_stats.py
@@ -1,0 +1,43 @@
+"""Tests for analytics/stats.py (Phase 6 — Welch t-test không cần scipy)."""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from analytics import stats
+
+
+class TestWelchTTest(unittest.TestCase):
+    def test_identical_samples_p_one(self):
+        r = stats.welch_ttest([10, 20, 30], [10, 20, 30])
+        self.assertEqual(r["t"], 0.0)
+        self.assertAlmostEqual(r["p_value"], 1.0, places=6)
+
+    def test_known_value_matches_scipy(self):
+        # scipy.stats.ttest_ind([1,2,3],[4,5,6], equal_var=False) → t=-3.674, p≈0.02131
+        r = stats.welch_ttest([1, 2, 3], [4, 5, 6])
+        self.assertAlmostEqual(r["t"], -3.6742, places=3)
+        self.assertAlmostEqual(r["df"], 4.0, places=6)
+        self.assertAlmostEqual(r["p_value"], 0.02131, places=4)
+
+    def test_p_value_symmetric_in_argument_order(self):
+        r1 = stats.welch_ttest([1, 2, 3], [4, 5, 6])
+        r2 = stats.welch_ttest([4, 5, 6], [1, 2, 3])
+        self.assertAlmostEqual(r1["p_value"], r2["p_value"], places=9)
+
+    def test_too_few_samples_returns_none(self):
+        r = stats.welch_ttest([1], [2, 3])
+        self.assertIsNone(r["t"])
+        self.assertIsNone(r["p_value"])
+        self.assertEqual(r["n_a"], 1)
+
+    def test_zero_variance_both_groups(self):
+        r = stats.welch_ttest([5, 5, 5], [5, 5, 5])
+        self.assertIsNone(r["t"])  # denom == 0 → t vô định
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_tiktok_csv.py
+++ b/content-pipeline/tests/test_tiktok_csv.py
@@ -1,0 +1,91 @@
+"""Tests for analytics/tiktok_csv.py (Phase 6 — TikTok Studio CSV parser)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+from analytics import tiktok_csv as tc
+
+
+class TestParse(unittest.TestCase):
+    def test_parse_english_headers_and_suffixes(self):
+        csv_text = (
+            "Video title,Video link,Post time,Total views,Likes,Comments,Shares,"
+            "Average watch time,Watched full video\n"
+            "T1,https://www.tiktok.com/@x/video/7412345678901234567,2026-07-01,"
+            "\"1,234\",1.2K,45,12,0:12,38%\n"
+        )
+        recs = tc.parse_csv_text(csv_text)
+        self.assertEqual(len(recs), 1)
+        r = recs[0]
+        self.assertEqual(r["external_id"], "7412345678901234567")
+        self.assertEqual(r["views"], 1234)
+        self.assertEqual(r["likes"], 1200)      # 1.2K
+        self.assertEqual(r["avg_view_duration_seconds"], 12.0)  # 0:12
+        self.assertEqual(r["retention_50_pct"], 38.0)
+        self.assertEqual(r["snapshot_date"], "2026-07-01")
+
+    def test_vietnamese_headers(self):
+        csv_text = ("Tiêu đề,Liên kết video,Lượt xem,Lượt thích\n"
+                    "T,https://www.tiktok.com/@x/video/999888777666,500,50\n")
+        r = tc.parse_csv_text(csv_text)[0]
+        self.assertEqual(r["external_id"], "999888777666")
+        self.assertEqual(r["views"], 500)
+        self.assertEqual(r["likes"], 50)
+
+    def test_row_without_id_or_title_skipped(self):
+        csv_text = "Total views,Likes\n100,10\n"
+        self.assertEqual(tc.parse_csv_text(csv_text), [])
+
+    def test_duration_mmss(self):
+        self.assertEqual(tc._duration_seconds("1:05"), 65.0)
+        self.assertEqual(tc._duration_seconds("12s"), 12.0)
+        self.assertIsNone(tc._duration_seconds(""))
+
+    def test_num_suffixes(self):
+        self.assertEqual(tc._num("2.5M"), 2_500_000.0)
+        self.assertEqual(tc._num("1,000"), 1000.0)
+        self.assertIsNone(tc._num("abc"))
+
+
+class TestImport(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_import_upserts_and_summary(self):
+        csv_text = (
+            "Video link,Total views,Likes\n"
+            "https://www.tiktok.com/@x/video/111,100,10\n"
+            "https://www.tiktok.com/@x/video/222,200,20\n"
+        )
+        summary = tc.import_csv_text(csv_text, snapshot_date="2026-07-05")
+        self.assertEqual(summary["imported"], 2)
+        self.assertEqual(summary["skipped"], 0)
+        latest = vm.latest_per_video(platform="tiktok")
+        self.assertEqual({r["external_id"] for r in latest}, {"111", "222"})
+
+    def test_forced_snapshot_date_overrides(self):
+        csv_text = ("Video link,Post time,Total views\n"
+                    "https://www.tiktok.com/@x/video/111,2026-07-01,100\n")
+        tc.import_csv_text(csv_text, snapshot_date="2026-07-09")
+        self.assertEqual(vm.latest_per_video()[0]["snapshot_date"], "2026-07-09")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_video_metrics.py
+++ b/content-pipeline/tests/test_video_metrics.py
@@ -1,0 +1,97 @@
+"""Tests for storage/video_metrics.py (Phase 6)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+import storage.scheduled_posts as sp
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestUpsert(Base):
+    def test_upsert_idempotent_same_day(self):
+        vm.upsert_metric("youtube", "abc", video_id=1, views=100, snapshot_date="2026-07-01")
+        vm.upsert_metric("youtube", "abc", views=150, snapshot_date="2026-07-01")
+        latest = vm.latest_per_video()
+        self.assertEqual(len(latest), 1)
+        self.assertEqual(latest[0]["views"], 150)
+
+    def test_different_days_separate_rows(self):
+        vm.upsert_metric("youtube", "abc", video_id=7, views=100, snapshot_date="2026-07-01")
+        vm.upsert_metric("youtube", "abc", video_id=7, views=200, snapshot_date="2026-07-02")
+        # Hai snapshot khác ngày = 2 dòng, nhưng latest_per_video chỉ trả dòng mới nhất.
+        self.assertEqual(len(vm.get_metrics_for_video(7)), 2)
+        latest = vm.latest_per_video()
+        self.assertEqual(len(latest), 1)
+        self.assertEqual(latest[0]["views"], 200)  # newest wins
+
+    def test_partial_update_keeps_other_columns(self):
+        vm.upsert_metric("youtube", "abc", views=100, likes=10, snapshot_date="2026-07-01")
+        vm.upsert_metric("youtube", "abc", views=150, snapshot_date="2026-07-01")  # no likes
+        latest = vm.latest_per_video()[0]
+        self.assertEqual(latest["views"], 150)
+        self.assertEqual(latest["likes"], 10)  # preserved
+
+    def test_unknown_metric_rejected(self):
+        with self.assertRaises(ValueError):
+            vm.upsert_metric("youtube", "abc", bogus=1)
+
+
+class TestResolveVideoId(Base):
+    def test_resolve_via_scheduled_posts(self):
+        vid = db.insert_video("short", "x")
+        post_id = sp.insert_post(vid, "drama_youtube", "2099-01-01 12:00:00")
+        sp.record_platform_id(post_id, "yt_external_1", url="https://youtu.be/yt_external_1")
+        self.assertEqual(vm.resolve_video_id("youtube", "yt_external_1"), vid)
+
+    def test_upsert_auto_resolves_video_id(self):
+        vid = db.insert_video("short", "x")
+        post_id = sp.insert_post(vid, "drama_youtube", "2099-01-01 12:00:00")
+        sp.record_platform_id(post_id, "yt_ext_2")
+        vm.upsert_metric("youtube", "yt_ext_2", views=5)  # no video_id passed
+        self.assertEqual(vm.latest_per_video()[0]["video_id"], vid)
+
+    def test_unresolvable_leaves_null(self):
+        vm.upsert_metric("tiktok", "no_map", views=5)
+        self.assertIsNone(vm.latest_per_video()[0]["video_id"])
+
+
+class TestTopVideos(Base):
+    def test_top_and_bottom(self):
+        vm.upsert_metric("youtube", "a", views=100, retention_50_pct=50)
+        vm.upsert_metric("youtube", "b", views=300, retention_50_pct=20)
+        vm.upsert_metric("youtube", "c", views=200, retention_50_pct=80)
+        top = vm.top_videos("views", limit=2)
+        self.assertEqual([r["external_id"] for r in top], ["b", "c"])
+        bottom = vm.top_videos("retention_50_pct", limit=1, ascending=True)
+        self.assertEqual(bottom[0]["external_id"], "b")
+
+    def test_null_metric_excluded(self):
+        vm.upsert_metric("youtube", "a", views=100)  # no retention
+        vm.upsert_metric("youtube", "b", views=50, retention_50_pct=30)
+        top = vm.top_videos("retention_50_pct")
+        self.assertEqual([r["external_id"] for r in top], ["b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_video_metrics.py
+++ b/content-pipeline/tests/test_video_metrics.py
@@ -56,6 +56,16 @@ class TestUpsert(Base):
         with self.assertRaises(ValueError):
             vm.upsert_metric("youtube", "abc", bogus=1)
 
+    def test_none_metric_does_not_erase_existing(self):
+        vm.upsert_metric("youtube", "abc", views=100, retention_50_pct=60,
+                         snapshot_date="2026-07-01")
+        # Retry cùng ngày refresh views nhưng retention tạm không có (None).
+        vm.upsert_metric("youtube", "abc", views=150, retention_50_pct=None,
+                         snapshot_date="2026-07-01")
+        latest = vm.latest_per_video()[0]
+        self.assertEqual(latest["views"], 150)
+        self.assertEqual(latest["retention_50_pct"], 60)  # không bị xoá về NULL
+
 
 class TestResolveVideoId(Base):
     def test_resolve_via_scheduled_posts(self):
@@ -74,6 +84,14 @@ class TestResolveVideoId(Base):
     def test_unresolvable_leaves_null(self):
         vm.upsert_metric("tiktok", "no_map", views=5)
         self.assertIsNone(vm.latest_per_video()[0]["video_id"])
+
+    def test_resolve_via_legacy_publish_url(self):
+        # Flow AI legacy: chỉ lưu publish_url, không qua scheduled_posts.
+        vid = db.insert_video("short", "x")
+        db.update_video_publish_url(vid, "https://youtu.be/legacyABC")
+        self.assertEqual(vm.resolve_video_id("youtube", "legacyABC"), vid)
+        vm.upsert_metric("youtube", "legacyABC", views=9)  # auto-resolve
+        self.assertEqual(vm.latest_per_video()[0]["video_id"], vid)
 
 
 class TestTopVideos(Base):

--- a/content-pipeline/tests/test_weekly_retro.py
+++ b/content-pipeline/tests/test_weekly_retro.py
@@ -1,0 +1,85 @@
+"""Tests for analytics/weekly_retro.py + dashboard/data.py (Phase 6)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+import storage.channel_metrics as cm
+import storage.cost_logs as cl
+from analytics import weekly_retro as wr
+from dashboard import data as dd
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+        self._seed()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _seed(self):
+        v1 = db.insert_video("short", "a", youtube_title="Vid A", track="drama")
+        v2 = db.insert_video("short", "b", youtube_title="Vid B", track="drama")
+        vm.upsert_metric("youtube", "e1", video_id=v1, views=5000,
+                         retention_50_pct=55, snapshot_date="2026-07-06")
+        vm.upsert_metric("youtube", "e2", video_id=v2, views=800,
+                         retention_50_pct=30, snapshot_date="2026-07-06")
+        cm.upsert_channel_metric("drama_youtube", "youtube",
+                                 subscribers_gained=40, snapshot_date="2026-07-06")
+        cl.record_cost("anthropic", "claude-haiku-4-5", "scorer",
+                       input_tokens=1_000_000, output_tokens=0, date="2026-07-06")
+
+
+class TestRetro(Base):
+    def test_report_has_all_sections_and_fits_telegram(self):
+        report = wr.generate_retro_report(since="2026-07-01")
+        for marker in ("RETRO TUẦN", "TOP 3", "SUB GROWTH", "CHI PHÍ", "ĐỀ XUẤT"):
+            self.assertIn(marker, report)
+        self.assertLessEqual(len(report), wr.MAX_REPORT_CHARS)
+
+    def test_cost_reflected(self):
+        report = wr.generate_retro_report(since="2026-07-01")
+        # 1M input @ $1/1M = $1.00
+        self.assertIn("$1.00", report)
+
+    def test_top_video_labelled_by_title(self):
+        report = wr.generate_retro_report(since="2026-07-01")
+        self.assertIn("Vid A", report)
+
+    def test_send_uses_telegram(self):
+        with patch("notifier.telegram_bot.send_alert", return_value=True) as m:
+            self.assertTrue(wr.send_weekly_retro(since="2026-07-01"))
+            m.assert_called_once()
+
+
+class TestDashboardData(Base):
+    def test_overview_uses_latest_snapshot(self):
+        ov = dd.overview(since="2026-07-01")
+        self.assertEqual(ov["n_videos"], 2)
+        self.assertEqual(ov["views"], 5800)
+
+    def test_format_breakdown_groups_by_track_type(self):
+        rows = dd.format_breakdown(since="2026-07-01")
+        self.assertTrue(any(r["track"] == "drama" for r in rows))
+
+    def test_cost_breakdown(self):
+        cb = dd.cost_breakdown(since="2026-07-01")
+        self.assertAlmostEqual(cb["summary"]["total_usd"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_youtube_puller.py
+++ b/content-pipeline/tests/test_youtube_puller.py
@@ -1,0 +1,108 @@
+"""Tests for analytics/youtube_puller.py using injected fake API services."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.video_metrics as vm
+import storage.channel_metrics as cm
+from analytics import youtube_puller as yp
+
+
+class _Req:
+    def __init__(self, resp):
+        self._r = resp
+
+    def execute(self):
+        return self._r
+
+
+class _Reports:
+    def query(self, **kw):
+        dims = kw.get("dimensions", "")
+        if dims == "video":
+            return _Req({
+                "columnHeaders": [{"name": n} for n in
+                                  ("video", "views", "likes", "comments", "shares",
+                                   "estimatedMinutesWatched", "averageViewDuration")],
+                "rows": [["vidA", 1000, 50, 10, 5, 300.0, 45.0],
+                         ["vidB", 200, 5, 1, 0, 20.0, 30.0]],
+            })
+        if dims == "elapsedVideoTimeRatio":
+            return _Req({
+                "columnHeaders": [{"name": "elapsedVideoTimeRatio"},
+                                  {"name": "audienceWatchRatio"}],
+                "rows": [[0.0, 1.0], [0.5, 0.62], [1.0, 0.2]],
+            })
+        return _Req({  # channel totals
+            "columnHeaders": [{"name": "subscribersGained"},
+                              {"name": "subscribersLost"}, {"name": "views"}],
+            "rows": [[30, 5, 1200]],
+        })
+
+
+class _Analytics:
+    def reports(self):
+        return _Reports()
+
+
+class _Channels:
+    def list(self, **kw):
+        return _Req({"items": [{"statistics": {"subscriberCount": "1500"}}]})
+
+
+class _Data:
+    def channels(self):
+        return _Channels()
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+
+class TestPull(Base):
+    def test_pull_stores_video_and_channel_metrics(self):
+        n = yp.pull_metrics_for_channel("ai_youtube", analytics=_Analytics(),
+                                        data=_Data(), snapshot_date="2026-07-08")
+        self.assertEqual(n, 2)
+        latest = {r["external_id"]: r for r in vm.latest_per_video()}
+        self.assertEqual(latest["vidA"]["views"], 1000)
+        self.assertEqual(latest["vidA"]["retention_50_pct"], 62.0)  # ratio 0.5 → 62%
+        self.assertEqual(latest["vidA"]["watch_time_minutes"], 300.0)
+
+        ch = cm.get_range("ai_youtube")
+        self.assertEqual(ch[-1]["subscribers"], 1500)
+        self.assertEqual(ch[-1]["subscribers_gained"], 25)  # 30 gained - 5 lost
+
+    def test_with_retention_false_skips_retention(self):
+        yp.pull_metrics_for_channel("ai_youtube", with_retention=False,
+                                    analytics=_Analytics(), data=_Data())
+        latest = vm.latest_per_video()
+        self.assertTrue(all(r["retention_50_pct"] is None for r in latest))
+
+    def test_non_youtube_channel_returns_zero(self):
+        self.assertEqual(
+            yp.pull_metrics_for_channel("tiktok_main", analytics=_Analytics(),
+                                        data=_Data()),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/webui/health.py
+++ b/content-pipeline/webui/health.py
@@ -83,6 +83,20 @@ def build_health_payload() -> dict:
         finally:
             conn.close()
 
+    def analytics():
+        # Phase 6: số snapshot metric mới nhất + chi phí AI 7 ngày. Bọc riêng
+        # nên DB chưa migrate 007 chỉ báo lỗi section này, không sập payload.
+        from datetime import timedelta
+        from storage import video_metrics, cost_logs
+        from analytics import pricing
+        since = (datetime.now().date() - timedelta(days=7)).isoformat()
+        latest = video_metrics.latest_per_video(since=since)
+        cost = pricing.summarize_costs(cost_logs.rows_since(since))
+        return {
+            "videos_with_metrics_7d": len(latest),
+            "ai_cost_usd_7d": cost["total_usd"],
+        }
+
     return {
         "generated_at": datetime.now().isoformat(sep=" ", timespec="seconds"),
         "videos": _section(videos),
@@ -90,6 +104,7 @@ def build_health_payload() -> dict:
         "scheduler": _section(scheduler),
         "quota": _section(quota),
         "collectors": _section(collectors),
+        "analytics": _section(analytics),
     }
 
 

--- a/docs/current/experiments-log.md
+++ b/docs/current/experiments-log.md
@@ -1,0 +1,78 @@
+# Experiments Log — A/B thí nghiệm nội dung (Phase 6)
+
+> Nhật ký các thí nghiệm A/B chạy trên video đã đăng. Mỗi video được gắn
+> `experiment_id` + `experiment_arm` (cột trên bảng `videos`, migration 007)
+> và so sánh bằng `analytics/experiment_compare.py`
+> (`compare_arms(experiment_id, metric)`).
+
+## Nguyên tắc (đọc trước khi kết luận)
+
+- **Mẫu tối thiểu:** ≥5 video/arm để xem xu hướng (acceptance criteria); ≥10
+  video/arm trước khi thực sự cắt/nhân format (phase-6-detailed.md §5). Công cụ
+  báo `enough_samples` / `recommended_samples_met` tương ứng.
+- **Độ trễ:** metric YouTube trễ 24–48h — đừng so sánh trước 72h sau khi đăng.
+- **Metric ưu tiên:** `retention_50_pct` và `avg_view_duration_seconds` quan
+  trọng hơn `views` (view cao mà retention thấp → thuật toán không đẩy tiếp).
+  So sánh cả hai, đừng chỉ nhìn views.
+- **1 biến / thí nghiệm:** mỗi experiment chỉ đổi ĐÚNG một yếu tố; giữ mọi thứ
+  khác như nhau giữa 2 arm.
+
+## Cách gắn video vào thí nghiệm
+
+```python
+from storage.database import set_video_experiment
+set_video_experiment(video_id, "thumbnail_style_v1", "A")  # hoặc "B"
+```
+
+So sánh:
+
+```bash
+python -m analytics.experiment_compare thumbnail_style_v1 --metric retention_50_pct
+```
+
+---
+
+## Thí nghiệm #1 — Thumbnail style
+
+| | |
+|---|---|
+| `experiment_id` | `thumbnail_style_v1` |
+| Arm A | Thumbnail = ảnh minh hoạ AI (Replicate illustration) |
+| Arm B | Thumbnail = text overlay lớn phong cách "reaction/drama" |
+| Giả thuyết | Text overlay CTR cao hơn với khán giả lướt feed |
+| Metric chính | `views` (proxy CTR khi impressions ngang nhau), phụ: `retention_50_pct` |
+| Trạng thái | 🔲 Chưa bắt đầu |
+| Kết luận | — |
+
+## Thí nghiệm #2 — Hook variant
+
+| | |
+|---|---|
+| `experiment_id` | `hook_variant_v1` |
+| Arm A | Hook dạng **khẳng định** ("Sếp tôi đã làm điều không tưởng...") |
+| Arm B | Hook dạng **câu hỏi** ("Bạn sẽ làm gì nếu sếp...?") |
+| Giả thuyết | Câu hỏi giữ chân 3s đầu tốt hơn |
+| Metric chính | `retention_50_pct`, phụ: `avg_view_duration_seconds` |
+| Trạng thái | 🔲 Chưa bắt đầu |
+| Kết luận | — |
+
+## Thí nghiệm #3 — Độ dài (Drama Shorts)
+
+| | |
+|---|---|
+| `experiment_id` | `length_drama_v1` |
+| Arm A | 60s |
+| Arm B | 90s |
+| Giả thuyết | 60s hoàn thành video (retention tới cuối) cao hơn, đổi lại ít
+| | chiều sâu; đo xem đánh đổi có đáng không |
+| Metric chính | `retention_50_pct` + `views` |
+| Trạng thái | 🔲 Chưa bắt đầu |
+| Kết luận | — |
+
+---
+
+## Liên kết
+
+- Thiết kế: [`phase-6-detailed.md`](phase-6-detailed.md) §3.5
+- Công cụ so sánh: `analytics/experiment_compare.py`
+- Thống kê (Welch t-test, không cần scipy): `analytics/stats.py`


### PR DESCRIPTION
## Tóm tắt

Triển khai đầy đủ **Phase 6 — Analytics & Iteration** (đóng vòng "đo lường để học" của chiến lược 1.0). Pull metric từ YouTube/TikTok → snapshot theo ngày → dashboard KPI + so sánh A/B + báo cáo tuần Telegram. Xem `docs/current/phase-6-detailed.md` / `phase-6-issues.md`.

## Thay đổi theo EPIC

**#6.1 — Metrics schema & pullers**
- Migration `007_analytics.sql`: `video_metrics`, `channel_metrics`, `cost_logs` + cột `videos.experiment_id/experiment_arm`.
- `storage/video_metrics.py`, `channel_metrics.py`, `cost_logs.py` — CRUD + upsert idempotent theo ngày.
- `analytics/youtube_puller.py` — YouTube Analytics API v2 (`ids=channel==MINE`), per-video + per-channel (sub growth), `retention_50_pct` từ report `audienceRetention`. Token analytics scope chỉ-đọc riêng. Cron 23h.
- `analytics/tiktok_csv.py` + `notifier/analytics_bot.py` — `/import_tiktok_csv` → đính kèm CSV TikTok Studio → parse (khoan dung header Anh/Việt, số `1.2K`/`45%`/`0:12`) → upsert; `telegram_bot._download_file()` tải file.

**#6.2 — KPI Dashboard**
- `dashboard/data.py` (thuần, test được) + `dashboard/app.py` (Streamlit 4 tab: Overview / Top videos / Format / Cost).
- `webui/health.py` thêm section `analytics`.

**#6.3 — A/B experiment helper**
- `analytics/stats.py` — Welch's t-test + p-value qua incomplete-beta, **không cần scipy**.
- `analytics/experiment_compare.py` — `compare_arms()` theo metric thật; chặn kết luận non mẫu (`enough_samples` ≥5/arm, `recommended_samples_met` ≥10/arm).
- `database.set_video_experiment()`; `docs/current/experiments-log.md` (3 thí nghiệm đầu: thumbnail / hook / length).

**#6.4 — Weekly retro**
- `analytics/weekly_retro.py` — báo cáo ≤1500 ký tự (top 3 / bottom 3 / sub growth / cost / action items). Cron CN 19h.

**Cost tracking**
- Hiện thực hoá `cost_logs` mà doc giả định "đã ghi từ Phase 3/4": `ai_usage.log_token_usage()` nay persist token thô (best-effort, non-fatal); `ai_scorer`/`ai_analyzer` cũng ghi.
- `analytics/pricing.py` — overlay token → USD, đổi giá qua env `PRICE_<MODEL>_IN/_OUT`, không migrate dữ liệu (giữ tinh thần token thô không stale).

## Khác tài liệu thiết kế (có chủ đích)
- `video_metrics.video_id` để **NULLABLE** (doc ghi NOT NULL) + khoá upsert `(platform, external_id, snapshot_date)` — vì metric TikTok manual (CSV) không map đáng tin về `videos.id`; ép NOT NULL = vứt hết số liệu TikTok.
- Migration đánh số **007** (doc ghi `002_metrics_schema.sql`) — tiếp dãy liên tục, tránh đụng `002` đã tồn tại.
- Token analytics tách khỏi token upload (scope chỉ-đọc khác scope upload); analytics_bot là handler thuần trong cùng vòng long-polling (như seed_bot/review_bot).

## Kiểm thử
- 55 test mới (stats, pricing, video/channel_metrics, cost_logs, experiment_compare, tiktok_csv, analytics_bot, youtube_puller với fake service, weekly_retro + dashboard data).
- Toàn bộ suite: **671 tests pass** (chỉ 1 lỗi môi trường tiền-tồn: `test_reddit_drama_collector` do thiếu `feedparser`, không liên quan Phase 6).
- Migration 007 up/down verified; các plugin cron mới (`metrics-pull`, `weekly-retro`) + README launchd cập nhật.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyZHYkQqrAgpbHejAvxvCT