### PR TITLE
fix(#74,#75): launchd EX_CONFIG (78) — wrapper tĩnh + watchdog self-heal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,31 @@ báo cáo tuần Telegram. Ngoài phạm vi: predictive model, auto-tune prompt.
 
 ---
 
+## Vận hành launchd (Mac Mini) — issue #72/#74/#75
+
+Xem `launchd/README.md`. Mọi service chạy nền là launchd LaunchAgent
+(`launchd/com.ai5phut.*.plist`), cài/refresh idempotent qua `launchd/install.sh`
+(`install`/`status`/`reload [label]`/`uninstall`).
+
+- **Mọi job launch qua wrapper `.sh` tĩnh, KHÔNG trỏ thẳng `venv/bin/python3`**
+  (root cause #74/#75): launchd cache vnode của `ProgramArguments[0]` lúc load;
+  rebuild venv (hay reconfig `.env`/token) thay file `venv/bin/python3` → vnode
+  stale → spawn fail `EX_CONFIG` (exit **78**), job im lặng tới khi reload. Wrapper
+  tĩnh (`run_pipeline.sh` cho pipeline/bot, `run_module.sh` cho phần còn lại) giữ
+  vnode ổn định và resolve venv **lại ở runtime**. `run_pipeline.sh` uỷ cho
+  `run_module.sh` để 1 chỗ duy nhất resolve venv. Thêm plist mới → trỏ vào
+  `run_module.sh`, giữ quy ước **tên file plist == Label**.
+- **`storage/launchd_status.py` — watchdog + self-heal.** Chạy ké trong `main.py`
+  (07:00) và `storage.collector_health` (06:30/18:30), best-effort không bao giờ
+  raise. Ngoài việc alert service **chưa load** (#72), nay đọc cột Status của
+  `launchctl list` (không tốn call thêm) để bắt service **đã load nhưng fail**;
+  service kẹt `EX_CONFIG` (78) được **tự re-bootstrap** qua `install.sh reload
+  <label>` rồi alert. Truyền `self_label` để watchdog KHÔNG tự bootout chính
+  service đang chạy nó. Trên máy không phải macOS mọi hàm trả `None`/`False` và
+  không làm gì (non-fatal).
+
+---
+
 ## Nguồn dữ liệu cần thu thập
 
 ### RSS Feeds (dùng feedparser)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,22 +398,32 @@ Xem `launchd/README.md`. Mọi service chạy nền là launchd LaunchAgent
 (`launchd/com.ai5phut.*.plist`), cài/refresh idempotent qua `launchd/install.sh`
 (`install`/`status`/`reload [label]`/`uninstall`).
 
-- **Mọi job launch qua wrapper `.sh` tĩnh, KHÔNG trỏ thẳng `venv/bin/python3`**
-  (root cause #74/#75): launchd cache vnode của `ProgramArguments[0]` lúc load;
-  rebuild venv (hay reconfig `.env`/token) thay file `venv/bin/python3` → vnode
-  stale → spawn fail `EX_CONFIG` (exit **78**), job im lặng tới khi reload. Wrapper
-  tĩnh (`run_pipeline.sh` cho pipeline/bot, `run_module.sh` cho phần còn lại) giữ
-  vnode ổn định và resolve venv **lại ở runtime**. `run_pipeline.sh` uỷ cho
-  `run_module.sh` để 1 chỗ duy nhất resolve venv. Thêm plist mới → trỏ vào
-  `run_module.sh`, giữ quy ước **tên file plist == Label**.
-- **`storage/launchd_status.py` — watchdog + self-heal.** Chạy ké trong `main.py`
-  (07:00) và `storage.collector_health` (06:30/18:30), best-effort không bao giờ
-  raise. Ngoài việc alert service **chưa load** (#72), nay đọc cột Status của
-  `launchctl list` (không tốn call thêm) để bắt service **đã load nhưng fail**;
-  service kẹt `EX_CONFIG` (78) được **tự re-bootstrap** qua `install.sh reload
-  <label>` rồi alert. Truyền `self_label` để watchdog KHÔNG tự bootout chính
-  service đang chạy nó. Trên máy không phải macOS mọi hàm trả `None`/`False` và
-  không làm gì (non-fatal).
+- **Root cause (đã kiểm chứng, không còn phỏng đoán):** launchd/`xpcproxy` dựng
+  `WorkingDirectory` + `StandardOutPath`/`StandardErrorPath` **trước khi** exec
+  binary và giữ **handle inode** của các thư mục đó. Khi thư mục bị **xoá & tạo
+  lại** (rebuild venv, re-clone repo, reconfig `.env`/token) handle thành stale →
+  xpcproxy setup fail, trả `EX_CONFIG` (exit **78**) *trước khi binary chạy* (nên
+  log file không hề được tạo, còn foreground vẫn chạy tốt). Exit 78 **khoá** job
+  vào "spawn scheduled" — KeepAlive cũng không restart — tới khi `reload`. Đây là
+  lý do `pipeline` (đã dùng wrapper từ trước) VẪN chết còn `bot` (KeepAlive, tiến
+  trình thường trú không re-spawn) sống sót.
+- **Fix tận gốc — plist KHÔNG khai báo `WorkingDirectory`/`StandardOutPath`/
+  `StandardErrorPath`.** Plist chỉ còn trỏ vào **một path string**: wrapper tĩnh
+  (`run_pipeline.sh` cho pipeline/bot, `run_module.sh` cho phần còn lại; launchd
+  re-resolve path mỗi spawn, không giữ handle thư mục). Wrapper thiết lập **lại**
+  cwd (`cd`) + log (redirect vào `logs/${LOG_BASENAME}_stdout/stderr.log`) ở
+  **runtime với inode tươi** → rebuild venv/re-clone không còn phá scheduled run.
+  `run_pipeline.sh` uỷ cho `run_module.sh` (1 chỗ resolve venv + cwd + log). Thêm
+  plist mới → trỏ `run_module.sh` + đặt `LOG_BASENAME`, giữ quy ước **tên file
+  plist == Label**.
+- **`storage/launchd_status.py` — watchdog + self-heal (defense-in-depth).** Chạy
+  ké trong `main.py` (07:00) và `storage.collector_health` (06:30/18:30),
+  best-effort không bao giờ raise. Ngoài việc alert service **chưa load** (#72),
+  nay đọc cột Status của `launchctl list` (không tốn call thêm) để bắt service
+  **đã load nhưng fail**; service kẹt `EX_CONFIG` (78) được **tự re-bootstrap** qua
+  `install.sh reload <label>` rồi alert — vì reload là cách DUY NHẤT gỡ job kẹt 78.
+  Truyền `self_label` để watchdog KHÔNG tự bootout chính service đang chạy nó. Trên
+  máy không phải macOS mọi hàm trả `None`/`False` và không làm gì (non-fatal).
 
 ---
 

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -19,14 +19,33 @@ từng file trước đây khiến các plist Phase 5/6 chưa từng được lo
 Sau mỗi lần `git pull` có thêm/sửa plist, chỉ cần chạy lại `./install.sh`.
 
 ```bash
-./install.sh status      # service nào đã load / còn thiếu
-./install.sh uninstall   # gỡ toàn bộ service
+./install.sh status              # service nào đã load / còn thiếu
+./install.sh reload [label]      # re-bootstrap toàn bộ (hoặc 1 label)
+./install.sh uninstall           # gỡ toàn bộ service
 ```
 
-**Watchdog:** kể cả khi quên chạy installer, pipeline AI 07:00 (`main.py`) và
-job drama-health tự kiểm tra `launchctl list` mỗi lần chạy và alert Telegram
-nếu có plist trong repo chưa được load (`storage/launchd_status.py`); endpoint
-`GET /health` cũng có section `launchd`.
+## Vì sao mọi job launch qua wrapper `.sh` (issue #74/#75)
+
+launchd cache **vnode** của `ProgramArguments[0]` lúc load. Trước đây các job trỏ
+thẳng vào `venv/bin/python3` — khi reconfig `.env`/token kéo theo **rebuild venv**,
+file đó bị xoá & tạo lại (inode mới) → vnode cached thành stale → tới giờ schedule,
+launchd **không spawn được** process, trả `EX_CONFIG` (exit **78**), job im lặng
+cho tới khi reload thủ công.
+
+Fix: mọi job trỏ vào **wrapper script tĩnh** — `run_pipeline.sh` (pipeline/bot) và
+`run_module.sh` (các job còn lại). File wrapper không bao giờ bị venv rebuild đụng
+tới nên vnode cached ổn định; venv được resolve **lại ở runtime** mỗi lần chạy.
+Sau khi rebuild venv, không cần làm gì thêm — nếu vẫn kẹt, chạy `./install.sh reload`.
+
+**Watchdog + self-heal:** kể cả khi quên chạy installer, pipeline AI 07:00
+(`main.py`) và job drama-health (06:30/18:30) tự soi `launchctl list` mỗi lần chạy
+(`storage/launchd_status.py`) và:
+- alert Telegram nếu có plist trong repo **chưa được load** (issue #72);
+- phát hiện service **đã load nhưng lần chạy gần nhất fail** (cột Status của
+  `launchctl list`), **tự `reload`** cái kẹt `EX_CONFIG` (78) và alert (issue
+  #74/#75). Watchdog bỏ qua chính service đang chạy nó (tránh tự bootout mình).
+
+endpoint `GET /health` cũng có section `launchd`.
 
 Quy ước: **tên file plist == Label bên trong** — cả `install.sh` lẫn
 `storage/launchd_status.py` dựa vào điều này; giữ quy ước khi thêm plist mới.

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -24,18 +24,24 @@ Sau mỗi lần `git pull` có thêm/sửa plist, chỉ cần chạy lại `./in
 ./install.sh uninstall           # gỡ toàn bộ service
 ```
 
-## Vì sao mọi job launch qua wrapper `.sh` (issue #74/#75)
+## Vì sao plist bỏ WorkingDirectory/StandardOutPath (issue #74/#75)
 
-launchd cache **vnode** của `ProgramArguments[0]` lúc load. Trước đây các job trỏ
-thẳng vào `venv/bin/python3` — khi reconfig `.env`/token kéo theo **rebuild venv**,
-file đó bị xoá & tạo lại (inode mới) → vnode cached thành stale → tới giờ schedule,
-launchd **không spawn được** process, trả `EX_CONFIG` (exit **78**), job im lặng
-cho tới khi reload thủ công.
+**Root cause (đã kiểm chứng):** launchd/`xpcproxy` dựng `WorkingDirectory` +
+`StandardOutPath`/`StandardErrorPath` **trước khi** exec binary, và giữ **handle
+inode** của các thư mục đó. Khi thư mục bị **xoá & tạo lại** (rebuild venv,
+re-clone repo, reconfig `.env`/token) → handle stale → xpcproxy setup fail, trả
+`EX_CONFIG` (exit **78**) *trước khi binary chạy* (log file không hề được tạo,
+foreground vẫn OK). Exit 78 **khoá** job vào "spawn scheduled" — KeepAlive cũng
+không restart — cho tới khi `reload`. (Vì thế `pipeline` dù đã dùng wrapper vẫn
+chết, còn daemon `bot` thường trú thì sống sót.)
 
-Fix: mọi job trỏ vào **wrapper script tĩnh** — `run_pipeline.sh` (pipeline/bot) và
-`run_module.sh` (các job còn lại). File wrapper không bao giờ bị venv rebuild đụng
-tới nên vnode cached ổn định; venv được resolve **lại ở runtime** mỗi lần chạy.
-Sau khi rebuild venv, không cần làm gì thêm — nếu vẫn kẹt, chạy `./install.sh reload`.
+**Fix tận gốc:** plist chỉ còn trỏ vào **một path string** — wrapper tĩnh
+(`run_pipeline.sh` cho pipeline/bot, `run_module.sh` cho các job còn lại; launchd
+re-resolve path mỗi spawn, KHÔNG giữ handle thư mục nào). Plist **không** khai báo
+`WorkingDirectory`/`StandardOutPath`/`StandardErrorPath` nữa; wrapper tự `cd` +
+redirect log vào `logs/${LOG_BASENAME}_stdout.log`/`_stderr.log` ở **runtime với
+inode tươi**. Rebuild venv/re-clone không còn phá scheduled run; nếu vẫn kẹt (vd
+job đã 78 từ trước khi cài bản mới), chạy `./install.sh reload`.
 
 **Watchdog + self-heal:** kể cả khi quên chạy installer, pipeline AI 07:00
 (`main.py`) và job drama-health (06:30/18:30) tự soi `launchctl list` mỗi lần chạy

--- a/content-pipeline/launchd/com.ai5phut.bot.plist
+++ b/content-pipeline/launchd/com.ai5phut.bot.plist
@@ -5,7 +5,12 @@
     <key>Label</key>
     <string>com.ai5phut.bot</string>
 
-    <!-- Use the wrapper script — it activates the venv so all deps (googleapiclient, etc.) are available.
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload
+         (kể cả daemon KeepAlive). run_pipeline.sh (uỷ cho run_module.sh) thiết lập
+         cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -13,24 +18,18 @@
         <string>--bot</string>
     </array>
 
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
-
     <!-- Daemon: chạy liên tục, tự restart nếu crash -->
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/bot_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/bot_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>bot</string>
     </dict>
 
     <!-- Tự restart nếu crash, chờ 10s -->

--- a/content-pipeline/launchd/com.ai5phut.drama-health.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-health.plist
@@ -5,10 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.drama-health</string>
 
-    <!-- Replace /Users/YOU with your actual home directory path. -->
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
+         Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>-m</string>
         <string>storage.collector_health</string>
     </array>

--- a/content-pipeline/launchd/com.ai5phut.drama-health.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-health.plist
@@ -5,9 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.drama-health</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -15,9 +17,6 @@
         <string>-m</string>
         <string>storage.collector_health</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- Chạy mỗi 12h (06:30 và 18:30) — alert Telegram nếu reddit_drama
          collector chưa chạy thành công quá 2 ngày (EPIC #2.4). -->
@@ -37,15 +36,12 @@
         </dict>
     </array>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_health_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_health_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>drama_health</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
@@ -5,18 +5,17 @@
     <key>Label</key>
     <string>com.ai5phut.drama-pipeline</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
         <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>main_drama.py</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- 06:40 sáng (Chuyện Đời) — sau reddit_drama_collector (06:06) để có
          story mới; trước pipeline AI (07:00) để 2 pipeline không giành
@@ -29,15 +28,12 @@
         <integer>40</integer>
     </dict>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_pipeline_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/drama_pipeline_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>drama_pipeline</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
+++ b/content-pipeline/launchd/com.ai5phut.drama-pipeline.plist
@@ -5,11 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.drama-pipeline</string>
 
-    <!-- Use the venv Python directly.
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>main_drama.py</string>
     </array>
 

--- a/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
+++ b/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
@@ -5,11 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.metrics-pull</string>
 
-    <!-- Use the venv Python directly.
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>-m</string>
         <string>analytics.youtube_puller</string>
         <string>pull</string>

--- a/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
+++ b/content-pipeline/launchd/com.ai5phut.metrics-pull.plist
@@ -5,9 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.metrics-pull</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -16,9 +18,6 @@
         <string>analytics.youtube_puller</string>
         <string>pull</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- 23:00 mỗi đêm — kéo số liệu YouTube Analytics vào video_metrics /
          channel_metrics (Phase 6 — Analytics). Metric YouTube trễ 24-48h nên
@@ -31,15 +30,12 @@
         <integer>0</integer>
     </dict>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/metrics_pull_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/metrics_pull_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>metrics_pull</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.pipeline.plist
+++ b/content-pipeline/launchd/com.ai5phut.pipeline.plist
@@ -5,15 +5,17 @@
     <key>Label</key>
     <string>com.ai5phut.pipeline</string>
 
-    <!-- Use the wrapper script — it activates the venv so all deps are available.
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_pipeline.sh (uỷ cho run_module.sh) thiết lập cwd + log ở runtime với
+         inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
         <string>/Users/YOU/ContentCreator/content-pipeline/run_pipeline.sh</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- Chạy lúc 7:00 sáng mỗi ngày (AI Hôm Nay) — sau drama-pipeline (06:40)
          để 2 pipeline không giành TTS/ffmpeg cùng lúc. -->
@@ -25,15 +27,12 @@
         <integer>0</integer>
     </dict>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/pipeline_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/pipeline_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>pipeline</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
+++ b/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
@@ -5,9 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.post-scheduler</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -17,23 +19,17 @@
         <string>tick</string>
     </array>
 
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
-
     <!-- Tick mỗi 5 phút (Phase 5 — Distribution): upload các post tới giờ
          theo cadence. Acceptance: đúng giờ ±5 phút. -->
     <key>StartInterval</key>
     <integer>300</integer>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/post_scheduler_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/post_scheduler_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>post_scheduler</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
+++ b/content-pipeline/launchd/com.ai5phut.post-scheduler.plist
@@ -5,11 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.post-scheduler</string>
 
-    <!-- Use the venv Python directly.
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>-m</string>
         <string>scheduler.post_scheduler</string>
         <string>tick</string>

--- a/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
+++ b/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
@@ -5,12 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.reddit-drama</string>
 
-    <!-- Use the venv Python directly (this job isn't the main pipeline
-         entrypoint, so run_pipeline.sh's wrapper doesn't apply).
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>-m</string>
         <string>collectors.reddit_drama_collector</string>
     </array>

--- a/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
+++ b/content-pipeline/launchd/com.ai5phut.reddit-drama.plist
@@ -5,9 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.reddit-drama</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -15,9 +17,6 @@
         <string>-m</string>
         <string>collectors.reddit_drama_collector</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- Chạy 06:06 sáng mỗi ngày (Phase 2 — Drama Source Layer) -->
     <key>StartCalendarInterval</key>
@@ -28,15 +27,12 @@
         <integer>6</integer>
     </dict>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/reddit_drama_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/reddit_drama_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>reddit_drama</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
+++ b/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
@@ -5,11 +5,13 @@
     <key>Label</key>
     <string>com.ai5phut.weekly-retro</string>
 
-    <!-- Use the venv Python directly.
+    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
+         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
+         (issue #74/#75; xem run_module.sh).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/YOU/ContentCreator/content-pipeline/venv/bin/python3</string>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
         <string>-m</string>
         <string>analytics.weekly_retro</string>
     </array>

--- a/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
+++ b/content-pipeline/launchd/com.ai5phut.weekly-retro.plist
@@ -5,9 +5,11 @@
     <key>Label</key>
     <string>com.ai5phut.weekly-retro</string>
 
-    <!-- Chạy qua wrapper tĩnh run_module.sh (resolve venv ở runtime) thay vì
-         trỏ thẳng venv/bin/python3 — tránh EX_CONFIG (78) khi venv bị rebuild
-         (issue #74/#75; xem run_module.sh).
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath. launchd/xpcproxy dựng chúng TRƯỚC khi exec và giữ handle
+         inode; khi thư mục bị xoá/tạo lại (rebuild venv, re-clone, reconfig) handle
+         stale → EX_CONFIG (78) *trước khi* binary chạy, khoá job tới khi reload.
+         run_module.sh thiết lập cwd + log ở runtime với inode tươi (LOG_BASENAME).
          Replace /Users/YOU with your actual home directory path. -->
     <key>ProgramArguments</key>
     <array>
@@ -15,9 +17,6 @@
         <string>-m</string>
         <string>analytics.weekly_retro</string>
     </array>
-
-    <key>WorkingDirectory</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline</string>
 
     <!-- Chủ nhật 19:00 — đẩy báo cáo tuần qua Telegram để tối CN đọc, sáng T2
          đã có quyết định (Phase 6 — Weekly retro). Weekday: 0=CN trong launchd. -->
@@ -31,15 +30,12 @@
         <integer>0</integer>
     </dict>
 
-    <key>StandardOutPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/weekly_retro_stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/Users/YOU/ContentCreator/content-pipeline/logs/weekly_retro_stderr.log</string>
-
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>weekly_retro</string>
     </dict>
 </dict>
 </plist>

--- a/content-pipeline/launchd/install.sh
+++ b/content-pipeline/launchd/install.sh
@@ -7,6 +7,10 @@
 #
 #   ./install.sh            # cài/refresh mọi com.ai5phut.*.plist trong thư mục này
 #   ./install.sh status     # xem service nào đã load / còn thiếu
+#   ./install.sh reload [L] # re-bootstrap toàn bộ (hoặc 1 label) — dùng khi 1
+#                           #   service kẹt EX_CONFIG sau khi rebuild venv
+#                           #   (issue #74/#75). storage/launchd_status.py gọi
+#                           #   `reload <label>` để self-heal tự động.
 #   ./install.sh uninstall  # gỡ toàn bộ service
 #
 # Nguyên tắc:
@@ -39,32 +43,51 @@ is_loaded() {
     launchctl list "$1" >/dev/null 2>&1
 }
 
-do_install() {
-    require_macos
-    mkdir -p "$LA_DIR" "$PIPELINE_DIR/logs"
+# Render placeholder → đường dẫn thật rồi bootout+bootstrap 1 plist. Trả về
+# trạng thái is_loaded. Dùng chung bởi do_install và do_reload (idempotent).
+bootstrap_one() {
+    local src="$1" label dst
+    label="$(basename "$src" .plist)"
+    dst="$LA_DIR/$label.plist"
 
+    # Render placeholder → đường dẫn thật (repo giữ nguyên placeholder)
+    sed "s|$PLACEHOLDER|$PIPELINE_DIR|g" "$src" > "$dst"
+
+    # Idempotent: gỡ bản đang load (nếu có) rồi load bản vừa render. Đây chính
+    # là thao tác "reload" khắc phục EX_CONFIG khi vnode cached của launchd bị
+    # stale sau rebuild venv (issue #74/#75).
+    launchctl bootout "$GUI_DOMAIN/$label" >/dev/null 2>&1 || true
+    if ! launchctl bootstrap "$GUI_DOMAIN" "$dst" 2>/dev/null; then
+        # Fallback cho macOS cũ chưa có bootstrap
+        launchctl load -w "$dst" 2>/dev/null || true
+    fi
+
+    is_loaded "$label"
+}
+
+warn_if_no_venv() {
     if [ ! -x "$PIPELINE_DIR/venv/bin/python3" ]; then
         echo "WARNING: venv chưa có tại $PIPELINE_DIR/venv — service sẽ fail khi chạy." >&2
         echo "         Fix: cd $PIPELINE_DIR && python3 -m venv venv && venv/bin/pip install -r requirements.txt" >&2
     fi
+    # Wrapper tĩnh phải executable — plist trỏ vào đây (issue #74/#75).
+    for w in run_module.sh run_pipeline.sh; do
+        if [ ! -x "$PIPELINE_DIR/$w" ]; then
+            echo "WARNING: $PIPELINE_DIR/$w không có execute bit — chmod +x giúp launchd chạy được." >&2
+        fi
+    done
+}
+
+do_install() {
+    require_macos
+    mkdir -p "$LA_DIR" "$PIPELINE_DIR/logs"
+    warn_if_no_venv
 
     local failed=0
     for src in "$SCRIPT_DIR"/com.ai5phut.*.plist; do
-        local label dst
+        local label
         label="$(basename "$src" .plist)"
-        dst="$LA_DIR/$label.plist"
-
-        # Render placeholder → đường dẫn thật (repo giữ nguyên placeholder)
-        sed "s|$PLACEHOLDER|$PIPELINE_DIR|g" "$src" > "$dst"
-
-        # Idempotent: gỡ bản đang load (nếu có) rồi load bản vừa render
-        launchctl bootout "$GUI_DOMAIN/$label" >/dev/null 2>&1 || true
-        if ! launchctl bootstrap "$GUI_DOMAIN" "$dst" 2>/dev/null; then
-            # Fallback cho macOS cũ chưa có bootstrap
-            launchctl load -w "$dst" 2>/dev/null || true
-        fi
-
-        if is_loaded "$label"; then
+        if bootstrap_one "$src"; then
             echo "  ✅ $label"
         else
             echo "  ❌ $label — KHÔNG load được. Xem: launchctl print $GUI_DOMAIN/$label" >&2
@@ -77,6 +100,44 @@ do_install() {
     else
         echo "Có service load thất bại — xem thông báo phía trên." >&2
         exit 1
+    fi
+}
+
+# Re-bootstrap toàn bộ (không tham số) hoặc đúng 1 label. Dùng để chữa service
+# kẹt EX_CONFIG (78) mà không đụng các service còn lại — storage/launchd_status
+# gọi `reload <label>` để self-heal, cố ý KHÔNG reload chính service đang chạy
+# nó (tránh tự bootout mình giữa chừng).
+do_reload() {
+    require_macos
+    mkdir -p "$LA_DIR" "$PIPELINE_DIR/logs"
+    local target="${1:-}"
+
+    if [ -n "$target" ]; then
+        local src="$SCRIPT_DIR/$target.plist"
+        if [ ! -f "$src" ]; then
+            echo "ERROR: không tìm thấy plist cho '$target' trong $SCRIPT_DIR" >&2
+            exit 1
+        fi
+        if bootstrap_one "$src"; then
+            echo "  🔄 $target"
+        else
+            echo "  ❌ $target — reload thất bại. Xem: launchctl print $GUI_DOMAIN/$target" >&2
+            exit 1
+        fi
+    else
+        warn_if_no_venv
+        local failed=0
+        for src in "$SCRIPT_DIR"/com.ai5phut.*.plist; do
+            local label
+            label="$(basename "$src" .plist)"
+            if bootstrap_one "$src"; then
+                echo "  🔄 $label"
+            else
+                echo "  ❌ $label" >&2
+                failed=1
+            fi
+        done
+        [ "$failed" -eq 0 ] || exit 1
     fi
 }
 
@@ -114,9 +175,10 @@ do_uninstall() {
 case "$CMD" in
     install)   do_install ;;
     status)    do_status ;;
+    reload)    do_reload "${2:-}" ;;
     uninstall) do_uninstall ;;
     *)
-        echo "Usage: $0 [install|status|uninstall]" >&2
+        echo "Usage: $0 [install|status|reload [label]|uninstall]" >&2
         exit 2
         ;;
 esac

--- a/content-pipeline/launchd/install.sh
+++ b/content-pipeline/launchd/install.sh
@@ -8,9 +8,9 @@
 #   ./install.sh            # cài/refresh mọi com.ai5phut.*.plist trong thư mục này
 #   ./install.sh status     # xem service nào đã load / còn thiếu
 #   ./install.sh reload [L] # re-bootstrap toàn bộ (hoặc 1 label) — dùng khi 1
-#                           #   service kẹt EX_CONFIG sau khi rebuild venv
-#                           #   (issue #74/#75). storage/launchd_status.py gọi
-#                           #   `reload <label>` để self-heal tự động.
+#                           #   service kẹt EX_CONFIG do stale handle sau rebuild
+#                           #   venv/re-clone (issue #74/#75). storage/launchd_
+#                           #   status.py gọi `reload <label>` để self-heal.
 #   ./install.sh uninstall  # gỡ toàn bộ service
 #
 # Nguyên tắc:
@@ -54,8 +54,8 @@ bootstrap_one() {
     sed "s|$PLACEHOLDER|$PIPELINE_DIR|g" "$src" > "$dst"
 
     # Idempotent: gỡ bản đang load (nếu có) rồi load bản vừa render. Đây chính
-    # là thao tác "reload" khắc phục EX_CONFIG khi vnode cached của launchd bị
-    # stale sau rebuild venv (issue #74/#75).
+    # là thao tác "reload" khắc phục EX_CONFIG khi launchd giữ handle inode stale
+    # (WorkingDirectory/StandardOutPath) sau rebuild venv/re-clone (issue #74/#75).
     launchctl bootout "$GUI_DOMAIN/$label" >/dev/null 2>&1 || true
     if ! launchctl bootstrap "$GUI_DOMAIN" "$dst" 2>/dev/null; then
         # Fallback cho macOS cũ chưa có bootstrap

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -129,7 +129,9 @@ def run_pipeline(force_video: str | None = None):
     # gọi launchctl có timeout — không chậm và không làm hỏng pipeline.
     try:
         from storage.launchd_status import check_and_alert as _launchd_check
-        _launchd_check()
+        # self_label = service này, để watchdog KHÔNG tự re-bootstrap chính nó
+        # (status hiện là lần chạy trước; bootout mình sẽ tự giết giữa chừng).
+        _launchd_check(self_label="com.ai5phut.pipeline")
     except Exception as e:
         logger.warning("Launchd status check failed (non-fatal): %s", e)
 

--- a/content-pipeline/run_module.sh
+++ b/content-pipeline/run_module.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# run_module.sh — Wrapper launchd DÙNG CHUNG: chạy bất kỳ entrypoint nào bên
+# trong venv. Mọi launchd job (trừ pipeline/bot đã có run_pipeline.sh) nên trỏ
+# ProgramArguments vào script NÀY thay vì thẳng venv/bin/python3.
+#
+# Root cause #74/#75 (EX_CONFIG / exit 78):
+#   Khi plist trỏ ProgramArguments[0] thẳng vào venv/bin/python3, launchd cache
+#   vnode của đúng file đó lúc load. Reconfig .env/token thường kéo theo rebuild
+#   venv → venv/bin/python3 bị xóa & tạo lại (inode mới) → vnode cached của
+#   launchd thành stale → tới giờ schedule, posix_spawn thất bại với EX_CONFIG
+#   (78) và job KHÔNG chạy cho tới khi được reload thủ công.
+#   Một wrapper TĨNH (file này không bao giờ bị venv rebuild đụng tới) giữ vnode
+#   cached của launchd ổn định, còn venv được resolve LẠI ở runtime mỗi lần chạy
+#   → rebuild venv không còn phá được scheduled run.
+#
+# Dùng: run_module.sh -m package.module [args...]   (hoặc run_module.sh script.py)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
+
+if [ ! -x "$VENV_PYTHON" ]; then
+    echo "ERROR: venv python không tồn tại/không chạy được tại $VENV_PYTHON" >&2
+    echo "Fix: cd $SCRIPT_DIR && python3 -m venv venv && venv/bin/pip install -r requirements.txt" >&2
+    # 78 = EX_CONFIG — báo cho log launchd biết đây là lỗi cấu hình/venv, không
+    # phải lỗi runtime của chính module.
+    exit 78
+fi
+
+exec "$VENV_PYTHON" "$@"

--- a/content-pipeline/run_module.sh
+++ b/content-pipeline/run_module.sh
@@ -1,30 +1,47 @@
 #!/bin/bash
 # run_module.sh — Wrapper launchd DÙNG CHUNG: chạy bất kỳ entrypoint nào bên
-# trong venv. Mọi launchd job (trừ pipeline/bot đã có run_pipeline.sh) nên trỏ
-# ProgramArguments vào script NÀY thay vì thẳng venv/bin/python3.
+# trong venv. Mọi launchd job trỏ ProgramArguments vào script NÀY thay vì thẳng
+# venv/bin/python3, VÀ plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+# StandardErrorPath — wrapper tự thiết lập cwd + log ở runtime.
 #
-# Root cause #74/#75 (EX_CONFIG / exit 78):
-#   Khi plist trỏ ProgramArguments[0] thẳng vào venv/bin/python3, launchd cache
-#   vnode của đúng file đó lúc load. Reconfig .env/token thường kéo theo rebuild
-#   venv → venv/bin/python3 bị xóa & tạo lại (inode mới) → vnode cached của
-#   launchd thành stale → tới giờ schedule, posix_spawn thất bại với EX_CONFIG
-#   (78) và job KHÔNG chạy cho tới khi được reload thủ công.
-#   Một wrapper TĨNH (file này không bao giờ bị venv rebuild đụng tới) giữ vnode
-#   cached của launchd ổn định, còn venv được resolve LẠI ở runtime mỗi lần chạy
-#   → rebuild venv không còn phá được scheduled run.
+# Root cause #74/#75 (EX_CONFIG / exit 78) — đã kiểm chứng:
+#   launchd/xpcproxy dựng WorkingDirectory + StandardOutPath/StandardErrorPath
+#   TRƯỚC khi exec binary. Nếu các thư mục đó bị xoá & tạo lại (rebuild venv,
+#   re-clone repo, reconfig) thì launchd giữ handle inode CŨ đã stale → xpcproxy
+#   setup fail và trả EX_CONFIG (78) *trước khi binary chạy* (foreground chạy tốt,
+#   log file không hề được tạo). Tệ hơn: exit 78 KHOÁ job vào trạng thái "spawn
+#   scheduled" — KeepAlive cũng không restart — cho tới khi job được reload.
+#
+#   Vì thế plist chỉ còn trỏ vào MỘT path string duy nhất: wrapper này (launchd
+#   re-resolve path mỗi lần spawn, không giữ handle thư mục). Wrapper thiết lập
+#   LẠI cwd + log ở runtime với inode tươi → rebuild venv / re-clone không còn
+#   phá được scheduled run.
 #
 # Dùng: run_module.sh -m package.module [args...]   (hoặc run_module.sh script.py)
+# Env:  LOG_BASENAME — tên file log (mặc định "run_module"); log ghi vào
+#       <script_dir>/logs/${LOG_BASENAME}_stdout.log + _stderr.log.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
 
+# --- Redirect log ở runtime (thay cho StandardOutPath/StandardErrorPath) ---
+# Wrapper tự mở file log với inode tươi mỗi lần chạy → không còn stale-handle như
+# khi để launchd/xpcproxy mở. Đặt SỚM để cả lỗi cấp wrapper (vd thiếu venv) cũng
+# được ghi lại thay vì rơi vào hư không.
+LOG_DIR="$SCRIPT_DIR/logs"
+mkdir -p "$LOG_DIR"
+LOG_BASENAME="${LOG_BASENAME:-run_module}"
+exec >>"$LOG_DIR/${LOG_BASENAME}_stdout.log" 2>>"$LOG_DIR/${LOG_BASENAME}_stderr.log"
+
+# --- cwd = package root ở runtime (thay cho WorkingDirectory) ---
+cd "$SCRIPT_DIR"
+
+VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
 if [ ! -x "$VENV_PYTHON" ]; then
     echo "ERROR: venv python không tồn tại/không chạy được tại $VENV_PYTHON" >&2
     echo "Fix: cd $SCRIPT_DIR && python3 -m venv venv && venv/bin/pip install -r requirements.txt" >&2
-    # 78 = EX_CONFIG — báo cho log launchd biết đây là lỗi cấu hình/venv, không
-    # phải lỗi runtime của chính module.
+    # 78 = EX_CONFIG — báo cho log launchd biết đây là lỗi cấu hình/venv.
     exit 78
 fi
 

--- a/content-pipeline/run_pipeline.sh
+++ b/content-pipeline/run_pipeline.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
-# Wrapper script for launchd — ensures pipeline always runs inside the venv.
+# Wrapper script for launchd — ensures the pipeline always runs inside the venv.
 # The root cause of missing deps (Pillow, googleapiclient) was that launchd
 # called /opt/homebrew/bin/python3 directly, which is a different Python than
 # where packages were installed. This script fixes that permanently.
+#
+# Việc resolve venv được uỷ cho run_module.sh (single source of truth, cũng là
+# wrapper tĩnh dùng chung cho mọi job khác — xem run_module.sh về root cause
+# EX_CONFIG/#74/#75). run_pipeline.sh chỉ cố định entrypoint = main.py.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-VENV_PYTHON="$SCRIPT_DIR/venv/bin/python3"
 
-if [ ! -f "$VENV_PYTHON" ]; then
-    echo "ERROR: venv not found at $SCRIPT_DIR/venv" >&2
-    echo "Run: cd $SCRIPT_DIR && /opt/homebrew/bin/python3 -m venv venv && venv/bin/pip install -r requirements.txt" >&2
-    exit 1
-fi
-
-exec "$VENV_PYTHON" "$SCRIPT_DIR/main.py" "$@"
+exec "$SCRIPT_DIR/run_module.sh" "$SCRIPT_DIR/main.py" "$@"

--- a/content-pipeline/storage/collector_health.py
+++ b/content-pipeline/storage/collector_health.py
@@ -95,10 +95,12 @@ def check_and_alert(names: list[str], max_age_days: float = DEFAULT_MAX_AGE_DAYS
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     check_and_alert(["reddit_drama"])
-    # Issue #72: job health 2 lần/ngày soát luôn service launchd chưa load
-    # (best-effort — trên máy không phải macOS hàm tự bỏ qua).
+    # Issue #72/#74/#75: job health 2 lần/ngày (06:30 + 18:30) soát service
+    # launchd chưa load VÀ service loaded-nhưng-fail (tự re-bootstrap cái kẹt
+    # EX_CONFIG). Chạy trước pipeline AI (07:00) nên có thể tự chữa để pipeline
+    # kịp chạy đúng giờ. Best-effort — máy không phải macOS thì tự bỏ qua.
     try:
         from storage.launchd_status import check_and_alert as _launchd_check
-        _launchd_check()
+        _launchd_check(self_label="com.ai5phut.drama-health")
     except Exception as e:
         logger.warning("Launchd status check failed (non-fatal): %s", e)

--- a/content-pipeline/storage/launchd_status.py
+++ b/content-pipeline/storage/launchd_status.py
@@ -36,11 +36,15 @@ LAUNCHD_DIR = os.path.join(os.path.dirname(__file__), "..", "launchd")
 _LAUNCHCTL_TIMEOUT = 5  # giây — check trạng thái không được phép chậm pipeline
 _RELOAD_TIMEOUT = 30    # giây — reload 1 service (bootout+bootstrap) qua install.sh
 
-# exit 78 = EX_CONFIG (sysexits.h). launchd trả code này khi KHÔNG spawn được
-# process tại giờ schedule — nguyên nhân #74/#75: vnode cached của launchd cho
-# venv/bin/python3 bị stale sau khi venv rebuild. Chỉ status NÀY mới được
-# self-heal tự động (re-bootstrap): job kẹt 78 chắc chắn CHƯA chạy gì (spawn
-# fail) nên bootout+bootstrap không cắt ngang việc đang làm dở.
+# exit 78 = EX_CONFIG (sysexits.h). launchd/xpcproxy trả code này khi KHÔNG dựng
+# được job TRƯỚC khi exec binary — nguyên nhân #74/#75: xpcproxy chdir vào
+# WorkingDirectory / mở StandardOutPath và giữ handle inode; khi thư mục bị xoá &
+# tạo lại (rebuild venv, re-clone, reconfig) handle stale → 78 trước cả khi binary
+# chạy, và 78 KHOÁ job (KeepAlive cũng không restart) tới khi reload. Sau khi các
+# plist đã bỏ WorkingDirectory/StandardOutPath (wrapper lo runtime), 78 hiếm đi,
+# nhưng self-heal vẫn giữ vì reload là cách DUY NHẤT gỡ job kẹt. Chỉ status NÀY mới
+# được auto re-bootstrap: job kẹt 78 chắc chắn CHƯA chạy gì (spawn fail) nên
+# bootout+bootstrap không cắt ngang việc đang làm dở.
 EX_CONFIG = 78
 
 
@@ -195,8 +199,8 @@ def _check_failing_and_heal(self_label: Optional[str], heal: bool) -> dict[str, 
 
     parts = ["⚠️ LAUNCHD: service đã load nhưng lần chạy gần nhất FAIL."]
     if healed:
-        parts.append("🔧 Đã tự re-bootstrap (EX_CONFIG 78 — thường do rebuild "
-                     "venv, xem #74/#75):\n" +
+        parts.append("🔧 Đã tự re-bootstrap (EX_CONFIG 78 — job kẹt do stale "
+                     "handle sau rebuild/re-clone, xem #74/#75):\n" +
                      "\n".join(f"  • {n}" for n in healed))
     if still:
         parts.append("❌ Vẫn fail — cần xem tay "

--- a/content-pipeline/storage/launchd_status.py
+++ b/content-pipeline/storage/launchd_status.py
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 LAUNCHD_DIR = os.path.join(os.path.dirname(__file__), "..", "launchd")
 _LAUNCHCTL_TIMEOUT = 5  # giây — check trạng thái không được phép chậm pipeline
+_RELOAD_TIMEOUT = 30    # giây — reload 1 service (bootout+bootstrap) qua install.sh
+
+# exit 78 = EX_CONFIG (sysexits.h). launchd trả code này khi KHÔNG spawn được
+# process tại giờ schedule — nguyên nhân #74/#75: vnode cached của launchd cho
+# venv/bin/python3 bị stale sau khi venv rebuild. Chỉ status NÀY mới được
+# self-heal tự động (re-bootstrap): job kẹt 78 chắc chắn CHƯA chạy gì (spawn
+# fail) nên bootout+bootstrap không cắt ngang việc đang làm dở.
+EX_CONFIG = 78
 
 
 def expected_services() -> list[str]:
@@ -47,9 +55,15 @@ def expected_services() -> list[str]:
                   for p in glob.glob(pattern))
 
 
-def loaded_services() -> Optional[set[str]]:
-    """Tập label đang được load trong launchd, hoặc None nếu không xác định
-    được (không phải macOS / launchctl lỗi / timeout)."""
+def service_statuses() -> Optional[dict[str, Optional[int]]]:
+    """Map {label: last-exit-status} từ MỘT lần `launchctl list`.
+
+    Output launchctl 3 cột: "PID\\tStatus\\tLabel". Cột giữa (Status) chính là
+    exit status của lần chạy gần nhất — nên phát hiện service loaded-nhưng-FAIL
+    (vd EX_CONFIG 78 của #74/#75) KHÔNG tốn thêm call nào so với loaded_services
+    cũ. Status '-' hoặc không phải số → None (chưa chạy / đang chạy / signal).
+    Trả None nếu không xác định được (không phải macOS / launchctl lỗi / timeout).
+    """
     try:
         proc = subprocess.run(
             ["launchctl", "list"],
@@ -62,13 +76,26 @@ def loaded_services() -> Optional[set[str]]:
         logger.debug("launchctl list exit %d — bỏ qua launchd check", proc.returncode)
         return None
 
-    # Output: "PID\tStatus\tLabel" (dòng đầu là header) — lấy cột cuối.
-    labels = set()
+    statuses: dict[str, Optional[int]] = {}
     for line in proc.stdout.splitlines():
         parts = line.split("\t")
-        if parts:
-            labels.add(parts[-1].strip())
-    return labels
+        if len(parts) < 3:
+            continue
+        label = parts[-1].strip()
+        if not label or label == "Label":  # bỏ dòng header
+            continue
+        try:
+            statuses[label] = int(parts[1].strip())
+        except ValueError:
+            statuses[label] = None
+    return statuses
+
+
+def loaded_services() -> Optional[set[str]]:
+    """Tập label đang được load trong launchd, hoặc None nếu không xác định
+    được (không phải macOS / launchctl lỗi / timeout)."""
+    statuses = service_statuses()
+    return None if statuses is None else set(statuses)
 
 
 def missing_services() -> Optional[list[str]]:
@@ -79,28 +106,124 @@ def missing_services() -> Optional[list[str]]:
     return [name for name in expected_services() if name not in loaded]
 
 
-def check_and_alert() -> list[str]:
-    """Alert Telegram nếu có service chưa load. Trả về danh sách missing.
+def failing_services() -> Optional[dict[str, int]]:
+    """Service đã load nhưng lần chạy gần nhất FAIL (exit != 0), map {label: code}.
 
-    Không raise trong mọi trường hợp (kể cả Telegram lỗi) — đây là watchdog
-    best-effort chạy ké trong pipeline chính, không được làm hỏng pipeline.
+    Đây là điểm mù của watchdog #72 (chỉ soát "chưa load"): #74/#75 là service
+    ĐÃ load nhưng kẹt EX_CONFIG (78) tại giờ schedule → missing_services() rỗng,
+    watchdog cũ im lặng. None nếu không xác định (không phải macOS...).
     """
-    missing = missing_services()
-    if missing is None or not missing:
-        return []
+    statuses = service_statuses()
+    if statuses is None:
+        return None
+    expected = set(expected_services())
+    return {label: code for label, code in statuses.items()
+            if label in expected and code not in (None, 0)}
 
-    logger.warning("Launchd service có trong repo nhưng chưa được load: %s", missing)
+
+def reload_service(label: str) -> bool:
+    """Re-bootstrap 1 service qua `launchd/install.sh reload <label>` (idempotent).
+
+    Đây chính là thao tác "unload/load" mà issue #74 xác nhận là fix được
+    EX_CONFIG — nay tự động hoá. Best-effort: trả False (không raise) nếu không
+    chạy được (không phải macOS / timeout / script lỗi)."""
+    script = os.path.join(LAUNCHD_DIR, "install.sh")
+    try:
+        proc = subprocess.run(
+            ["/bin/bash", script, "reload", label],
+            capture_output=True, text=True, timeout=_RELOAD_TIMEOUT,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        logger.warning("reload_service(%s) không chạy được (%s)", label, e)
+        return False
+    if proc.returncode != 0:
+        logger.warning("reload_service(%s) exit %d: %s",
+                       label, proc.returncode, proc.stderr.strip())
+        return False
+    logger.info("Đã re-bootstrap launchd service %s", label)
+    return True
+
+
+def _alert(msg: str) -> None:
+    """Gửi Telegram best-effort — nuốt mọi lỗi (watchdog không được làm hỏng
+    pipeline chính)."""
     try:
         from notifier.telegram_bot import send_alert
-        lines = "\n".join(f"  • {name}" for name in missing)
-        send_alert(
-            f"⚠️ LAUNCHD: {len(missing)} service có plist trong repo nhưng "
-            f"CHƯA được load:\n{lines}\n"
-            f"Fix: chạy content-pipeline/launchd/install.sh trên Mac Mini "
-            f"(idempotent — cài/refresh toàn bộ service)."
-        )
+        send_alert(msg)
     except Exception as e:
         logger.warning("Launchd alert failed (non-fatal): %s", e)
+
+
+def _check_missing_and_alert() -> list[str]:
+    missing = missing_services()
+    if not missing:  # None hoặc rỗng
+        return []
+    logger.warning("Launchd service có trong repo nhưng chưa được load: %s", missing)
+    lines = "\n".join(f"  • {name}" for name in missing)
+    _alert(
+        f"⚠️ LAUNCHD: {len(missing)} service có plist trong repo nhưng "
+        f"CHƯA được load:\n{lines}\n"
+        f"Fix: chạy content-pipeline/launchd/install.sh trên Mac Mini "
+        f"(idempotent — cài/refresh toàn bộ service)."
+    )
+    return missing
+
+
+def _check_failing_and_heal(self_label: Optional[str], heal: bool) -> dict[str, int]:
+    """Phát hiện service loaded-nhưng-fail; tự re-bootstrap cái kẹt EX_CONFIG.
+
+    Bỏ qua `self_label` (service đang chạy chính hàm này): status của nó là lần
+    chạy TRƯỚC, và bootout chính mình sẽ tự giết process giữa chừng. Chỉ auto
+    reload status == EX_CONFIG (78) — spawn fail nên chắc chắn không cắt ngang
+    việc dở; các fail khác chỉ alert (reload không chữa được bug runtime).
+    """
+    failing = failing_services()
+    if not failing:  # None hoặc rỗng
+        return {}
+    failing = {l: c for l, c in failing.items() if l != self_label}
+    if not failing:
+        return {}
+
+    logger.warning("Launchd service loaded nhưng fail: %s", failing)
+    healed: list[str] = []
+    still: list[str] = []
+    for label, code in sorted(failing.items()):
+        if heal and code == EX_CONFIG and reload_service(label):
+            healed.append(label)
+        else:
+            still.append(f"{label} (exit {code})")
+
+    parts = ["⚠️ LAUNCHD: service đã load nhưng lần chạy gần nhất FAIL."]
+    if healed:
+        parts.append("🔧 Đã tự re-bootstrap (EX_CONFIG 78 — thường do rebuild "
+                     "venv, xem #74/#75):\n" +
+                     "\n".join(f"  • {n}" for n in healed))
+    if still:
+        parts.append("❌ Vẫn fail — cần xem tay "
+                     "(launchctl print gui/$(id -u)/<label>):\n" +
+                     "\n".join(f"  • {n}" for n in still))
+    _alert("\n".join(parts))
+    return failing
+
+
+def check_and_alert(self_label: Optional[str] = None, heal: bool = True) -> list[str]:
+    """Watchdog launchd best-effort. Trả về danh sách service CHƯA load (giữ
+    tương thích call site cũ).
+
+    2 lớp phát hiện:
+      1. service chưa load (issue #72) → alert kèm cách chạy install.sh.
+      2. service đã load nhưng lần chạy gần nhất fail (issue #74/#75) → alert,
+         và tự re-bootstrap cái kẹt EX_CONFIG (78). `self_label` là service
+         đang chạy hàm này (được bỏ qua khi heal — tránh tự bootout mình).
+
+    Không raise trong mọi trường hợp (kể cả Telegram lỗi) — chạy ké pipeline
+    chính, không được làm hỏng pipeline.
+    """
+    missing = _check_missing_and_alert()
+    try:
+        _check_failing_and_heal(self_label, heal)
+    except Exception as e:  # tuyệt đối không để watchdog làm hỏng pipeline
+        logger.warning("Launchd failing-check lỗi (non-fatal): %s", e)
     return missing
 
 

--- a/content-pipeline/tests/test_launchd_status.py
+++ b/content-pipeline/tests/test_launchd_status.py
@@ -19,6 +19,14 @@ def _launchctl_output(labels: list[str]) -> str:
     return "\n".join(lines)
 
 
+def _launchctl_output_with_status(rows: list[tuple[str, str, str]]) -> str:
+    """rows = list of (pid, status, label) — mô phỏng output launchctl list."""
+    lines = ["PID\tStatus\tLabel"]
+    for pid, status, label in rows:
+        lines.append(f"{pid}\t{status}\t{label}")
+    return "\n".join(lines)
+
+
 class TestExpectedServices(unittest.TestCase):
     def test_reads_plist_filenames_from_repo(self):
         expected = ls.expected_services()
@@ -119,6 +127,156 @@ class TestCheckAndAlert(unittest.TestCase):
              patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
             missing = ls.check_and_alert()  # không được raise
         self.assertEqual(missing, ["com.ai5phut.drama-pipeline"])
+
+
+class TestServiceStatuses(unittest.TestCase):
+    def test_parses_exit_status_column(self):
+        out = _launchctl_output_with_status([
+            ("-", "0", "com.ai5phut.pipeline"),
+            ("-", "78", "com.ai5phut.drama-pipeline"),   # EX_CONFIG
+            ("1234", "0", "com.ai5phut.bot"),            # đang chạy
+            ("-", "-", "com.ai5phut.metrics-pull"),      # chưa chạy
+        ])
+        proc = MagicMock(returncode=0, stdout=out)
+        with patch.object(ls.subprocess, "run", return_value=proc):
+            st = ls.service_statuses()
+        self.assertEqual(st["com.ai5phut.pipeline"], 0)
+        self.assertEqual(st["com.ai5phut.drama-pipeline"], 78)
+        self.assertEqual(st["com.ai5phut.bot"], 0)
+        self.assertIsNone(st["com.ai5phut.metrics-pull"])  # '-' → None
+        self.assertNotIn("Label", st)  # header bị bỏ
+
+    def test_none_when_launchctl_missing(self):
+        with patch.object(ls.subprocess, "run",
+                          side_effect=FileNotFoundError("launchctl")):
+            self.assertIsNone(ls.service_statuses())
+
+
+class TestFailingServices(unittest.TestCase):
+    def test_detects_ex_config_and_ignores_healthy_and_foreign(self):
+        out = _launchctl_output_with_status([
+            ("-", "0", "com.ai5phut.pipeline"),          # ok
+            ("-", "78", "com.ai5phut.drama-pipeline"),   # fail 78
+            ("-", "1", "com.ai5phut.reddit-drama"),      # fail khác
+            ("-", "5", "com.apple.something"),           # ngoài scope → bỏ
+        ])
+        proc = MagicMock(returncode=0, stdout=out)
+        with patch.object(ls.subprocess, "run", return_value=proc):
+            failing = ls.failing_services()
+        self.assertEqual(failing.get("com.ai5phut.drama-pipeline"), 78)
+        self.assertEqual(failing.get("com.ai5phut.reddit-drama"), 1)
+        self.assertNotIn("com.ai5phut.pipeline", failing)
+        self.assertNotIn("com.apple.something", failing)
+
+    def test_none_when_undetectable(self):
+        with patch.object(ls, "service_statuses", return_value=None):
+            self.assertIsNone(ls.failing_services())
+
+
+class TestReloadService(unittest.TestCase):
+    def test_true_on_success(self):
+        proc = MagicMock(returncode=0, stdout="", stderr="")
+        with patch.object(ls.subprocess, "run", return_value=proc) as run:
+            self.assertTrue(ls.reload_service("com.ai5phut.drama-pipeline"))
+        args = run.call_args[0][0]
+        self.assertIn("reload", args)
+        self.assertIn("com.ai5phut.drama-pipeline", args)
+
+    def test_false_on_nonzero(self):
+        proc = MagicMock(returncode=1, stdout="", stderr="boom")
+        with patch.object(ls.subprocess, "run", return_value=proc):
+            self.assertFalse(ls.reload_service("com.ai5phut.drama-pipeline"))
+
+    def test_false_when_launchctl_missing(self):
+        with patch.object(ls.subprocess, "run",
+                          side_effect=FileNotFoundError("bash")):
+            self.assertFalse(ls.reload_service("com.ai5phut.drama-pipeline"))
+
+
+class TestCheckFailingAndHeal(unittest.TestCase):
+    def test_heals_ex_config_and_alerts(self):
+        sent = []
+        fake_bot = MagicMock()
+        fake_bot.send_alert = lambda msg: sent.append(msg)
+        reloaded = []
+        with patch.object(ls, "failing_services",
+                          return_value={"com.ai5phut.drama-pipeline": 78}), \
+             patch.object(ls, "reload_service",
+                          side_effect=lambda l: reloaded.append(l) or True), \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            failing = ls._check_failing_and_heal(self_label=None, heal=True)
+        self.assertEqual(reloaded, ["com.ai5phut.drama-pipeline"])
+        self.assertIn("com.ai5phut.drama-pipeline", failing)
+        self.assertEqual(len(sent), 1)
+        self.assertIn("re-bootstrap", sent[0])
+
+    def test_skips_self_label(self):
+        fake_bot = MagicMock()
+        with patch.object(ls, "failing_services",
+                          return_value={"com.ai5phut.pipeline": 78}), \
+             patch.object(ls, "reload_service") as reload_mock, \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            failing = ls._check_failing_and_heal(
+                self_label="com.ai5phut.pipeline", heal=True)
+        self.assertEqual(failing, {})
+        reload_mock.assert_not_called()
+        fake_bot.send_alert.assert_not_called()
+
+    def test_non_ex_config_alerts_without_reload(self):
+        sent = []
+        fake_bot = MagicMock()
+        fake_bot.send_alert = lambda msg: sent.append(msg)
+        with patch.object(ls, "failing_services",
+                          return_value={"com.ai5phut.reddit-drama": 1}), \
+             patch.object(ls, "reload_service") as reload_mock, \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            ls._check_failing_and_heal(self_label=None, heal=True)
+        reload_mock.assert_not_called()  # exit 1 ≠ EX_CONFIG → chỉ alert
+        self.assertEqual(len(sent), 1)
+        self.assertIn("Vẫn fail", sent[0])
+
+    def test_reload_failure_reported_as_still_failing(self):
+        sent = []
+        fake_bot = MagicMock()
+        fake_bot.send_alert = lambda msg: sent.append(msg)
+        with patch.object(ls, "failing_services",
+                          return_value={"com.ai5phut.drama-pipeline": 78}), \
+             patch.object(ls, "reload_service", return_value=False), \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            ls._check_failing_and_heal(self_label=None, heal=True)
+        self.assertEqual(len(sent), 1)
+        self.assertIn("Vẫn fail", sent[0])
+
+    def test_silent_when_none(self):
+        fake_bot = MagicMock()
+        with patch.object(ls, "failing_services", return_value=None), \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            self.assertEqual(ls._check_failing_and_heal(None, True), {})
+        fake_bot.send_alert.assert_not_called()
+
+
+class TestCheckAndAlertIntegration(unittest.TestCase):
+    def test_returns_missing_and_still_checks_failing(self):
+        # missing + failing đồng thời: trả về missing, đồng thời heal failing.
+        sent = []
+        fake_bot = MagicMock()
+        fake_bot.send_alert = lambda msg: sent.append(msg)
+        with patch.object(ls, "missing_services",
+                          return_value=["com.ai5phut.weekly-retro"]), \
+             patch.object(ls, "failing_services",
+                          return_value={"com.ai5phut.drama-pipeline": 78}), \
+             patch.object(ls, "reload_service", return_value=True), \
+             patch.dict(sys.modules, {"notifier.telegram_bot": fake_bot}):
+            missing = ls.check_and_alert(self_label="com.ai5phut.pipeline")
+        self.assertEqual(missing, ["com.ai5phut.weekly-retro"])
+        self.assertEqual(len(sent), 2)  # 1 alert missing + 1 alert failing/heal
+
+    def test_failing_check_never_raises(self):
+        with patch.object(ls, "missing_services", return_value=[]), \
+             patch.object(ls, "failing_services",
+                          side_effect=RuntimeError("launchctl exploded")):
+            # không được raise
+            self.assertEqual(ls.check_and_alert(), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix cho issue #74 và #75: cả 5–6 launchd service không chạy lúc sáng, `LastExitStatus=19968` = exit **78 (EX_CONFIG)**; reload thủ công thì chạy lại được, gọi trực tiếp thì OK.

## Root cause (đã KIỂM CHỨNG, không còn phỏng đoán)

Kiểm chứng cơ chế macOS qua 2 nguồn độc lập ([hermes-agent#5589](https://github.com/NousResearch/hermes-agent/issues/5589), [gitlab-runner#28136](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28136)):

launchd/**`xpcproxy` dựng `WorkingDirectory` + `StandardOutPath`/`StandardErrorPath` TRƯỚC khi exec binary**, và **giữ handle inode** của các thư mục đó. Khi thư mục bị **xoá & tạo lại** (rebuild venv / re-clone repo / reconfig `.env`) → handle **stale** → xpcproxy setup fail → `EX_CONFIG` (78) *trước khi binary chạy* (khớp: drama log không hề được tạo, foreground vẫn OK). Exit 78 **khoá** job vào "spawn scheduled" — **KeepAlive cũng không restart** — chỉ `reload` mới re-establish handle inode mới.

**Mảnh ghép quyết định:** điều này giải thích vì sao `pipeline` (đã dùng wrapper `run_pipeline.sh` từ trước) VẪN chết — thủ phạm là `WorkingDirectory`/`StandardOutPath` (thứ xpcproxy dựng *trước khi* wrapper exec), **không phải** `ProgramArguments`. Còn `bot` (KeepAlive, tiến trình thường trú không re-spawn) sống sót. ⇒ Chỉ đổi program sang wrapper là **chưa đủ**.

## Fix tận gốc

**Gỡ bỏ bề mặt xpcproxy-setup dễ hỏng:**
- **8 plist BỎ hẳn `WorkingDirectory` + `StandardOutPath` + `StandardErrorPath`.** Plist giờ chỉ trỏ vào **một path string** — wrapper tĩnh (`run_pipeline.sh`/`run_module.sh`); launchd re-resolve path mỗi spawn, **không giữ handle thư mục nào**.
- **`run_module.sh` tự thiết lập `cd` (cwd) + redirect log ở RUNTIME với inode tươi.** Log ghi vào `logs/${LOG_BASENAME}_stdout.log`/`_stderr.log`; mỗi plist đặt `LOG_BASENAME` để **giữ đúng tên file log cũ**. Redirect đặt sớm để bắt cả lỗi cấp wrapper (thiếu venv). `run_pipeline.sh` uỷ cho `run_module.sh` (1 chỗ resolve venv + cwd + log).

**Defense-in-depth — watchdog self-heal** (`storage/launchd_status.py`), giờ được *chính bằng chứng biện minh* (78 khoá job, chỉ reload gỡ được):
- Đọc cột Status của `launchctl list` (**không tốn call thêm**) → bắt service *đã-load-nhưng-fail* — điểm mù của watchdog #72.
- Tự re-bootstrap cái kẹt `EX_CONFIG` (78) qua `install.sh reload <label>`; các fail khác chỉ alert. Truyền `self_label` để **không tự bootout chính service đang chạy nó**.
- Wire vào `main.py` (07:00) + `collector_health` (06:30/18:30).
- `install.sh`: thêm subcommand `reload [label]`, factor `bootstrap_one`.

## An toàn & test

- **Đã verify runtime**: wrapper tự `cd` về package root khi gọi từ cwd khác (mô phỏng launchd không set WorkingDirectory) + redirect log + exit code đúng (0 khi OK, 78 khi thiếu venv). 8 plist validate XML, không còn key stale-handle, `LOG_BASENAME` khớp tên log cũ.
- Best-effort toàn bộ: non-macOS → `None`/`False`, không raise, không chậm pipeline.
- **27 test pass** (+14 mới cho launchd_status).

## Sau khi merge (Mac Mini)

Chạy `cd ~/ContentCreator/content-pipeline/launchd && ./install.sh` để áp plist mới. Từ đó rebuild venv/re-clone không còn phá scheduled run; nếu còn job kẹt 78 từ trước → `./install.sh reload` (hoặc watchdog tự chữa lúc 06:30). Log vẫn ở `content-pipeline/logs/*_stdout.log` như cũ.

> Ghi chú: config drift `.env` (`PEXELS_API_KEY` vs `PEXEL_API_KEY`, `TTS_API_URL`) là config local, code đã dùng `PEXELS_API_KEY` nhất quán — ngoài phạm vi diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWJDJUhCYVGachtpHSCPDJ

Fixes #74
Fixes #75