### PR TITLE
fix(#78): unblock Reddit collection via OAuth app-only client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,12 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   TỪNG post (pattern 1-RSS-cộng-N-detail: chậm ~2s/detail, dễ 403/429) — nay
   chuyển hẳn sang JSON listing qua `reddit_client`, bỏ được cả RSS (hết phụ
   thuộc `feedparser` ở collector này) lẫn vòng N detail call → nhanh hơn nhiều
-  và ít bị chặn. 403 khiến `get_json` trả `None` → collector coi là "0 story"
-  (KHÔNG raise); block kéo dài lộ ra qua alert staleness 2 ngày của
-  `collector_health`. Chạy: `python -m collectors.reddit_drama_collector`
+  và ít bị chặn. 403 khiến `get_json` trả `None`; `fetch_subreddit_top` biến
+  cái đó thành `RedditFetchError` (phân biệt với "fetch xong nhưng rỗng"). Nếu
+  MỌI subreddit fail → `collect_all_drama` raise → `__main__` KHÔNG gọi
+  `record_success` → alert staleness 2 ngày mới bắt được. (Không raise thì
+  block kéo dài vẫn refresh `last_success` mỗi ngày → alert không bao giờ fire —
+  lỗi Codex bắt ở PR #79.) Chạy: `python -m collectors.reddit_drama_collector`
   (06:06 sáng, xem `launchd/com.ai5phut.reddit-drama.plist`).
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,9 @@ content-pipeline/
 ├── collectors/
 │   ├── rss_collector.py         # Thu thập RSS feeds (The Rundown, Ben's Bites, VnExpress)
 │   ├── twitter_collector.py     # Twitter API v2
-│   ├── reddit_collector.py      # Reddit API (r/ChatGPT, r/artificial) — track AI
-│   └── reddit_drama_collector.py # Reddit RSS+JSON (AITA, ProRevenge, ...) — track Drama (Phase 2)
+│   ├── reddit_client.py         # Shared Reddit HTTP (OAuth app-only + fallback) — issue #78
+│   ├── reddit_collector.py      # Reddit JSON API (r/ChatGPT, r/artificial) — track AI
+│   └── reddit_drama_collector.py # Reddit JSON listing (AITA, ProRevenge, ...) — track Drama (Phase 2, #78)
 ├── analytics/
 │   ├── youtube_puller.py       # Pull metric YouTube Analytics API v2 → video_metrics/channel_metrics (Phase 6)
 │   ├── tiktok_csv.py           # Parse CSV TikTok Studio → video_metrics (Phase 6)
@@ -116,16 +117,32 @@ Từ Phase 1, pipeline hỗ trợ nhiều kênh/nhiều track thay vì 1 kênh A
 Xem `docs/current/phase-2-detailed.md`. Xây tầng thu thập nguồn cho track
 Drama — chưa có logic chấm điểm/rewrite (Phase 3).
 
+- **`collectors/reddit_client.py`** — single source of truth cho MỌI truy cập
+  Reddit (issue #78), cả track AI lẫn Drama đều đi qua đây. **Root cause #78:**
+  Reddit chặn quyết liệt request KHÔNG xác thực tới `www.reddit.com/*.json` +
+  `.rss` (403/429), nhất là từ IP datacenter; User-Agent generic (`example.com`)
+  càng dễ bị chặn. Fix đúng gốc = OAuth2. `get_json(path, params)` dùng OAuth
+  app-only (`client_credentials` grant → `oauth.reddit.com`, ~100 req/phút) khi
+  có `REDDIT_CLIENT_ID`/`SECRET`; chưa cấu hình thì fallback
+  `www.reddit.com/<path>.json` (best-effort, cảnh báo 1 lần). Token cache tới
+  ~1 phút trước hạn; rate-limit chung 1 req/`REDDIT_MIN_INTERVAL`s cho cả token
+  lẫn data. Xử lý lỗi: **429 tôn trọng header `Retry-After`** (cap
+  `REDDIT_RETRY_AFTER_CAP` để giá trị điên không treo cron), **403 = chặn cứng,
+  KHÔNG retry** (retry một block chỉ phí cả cửa sổ cron), 401 refresh token 1
+  lần, 5xx/mạng backoff + retry. Chỉ dùng stdlib (urllib) — không thêm dependency.
 - **`collectors/reddit_drama_collector.py`** — cào top post từ 5 subreddit
   (`AmItheAsshole`, `AskReddit`, `relationship_advice`, `MaliciousCompliance`,
-  `ProRevenge`) qua RSS (`/top/.rss?t=day`), sau đó gọi JSON API
-  (`/comments/{id}.json`) để lấy `score`/`selftext`/`over_18` — RSS không có
-  các trường này. **Khác với tài liệu thiết kế:** lọc NSFW dùng cờ `over_18`
-  chính thức từ JSON detail (không đoán từ RSS, vì Reddit không document rõ
-  field NSFW trong RSS) — đằng nào cũng phải gọi JSON API nên dùng luôn nguồn
-  đáng tin cậy hơn. Rate limit 1 req/2s, retry 3 lần backoff cho JSON call.
-  Chạy: `python -m collectors.reddit_drama_collector` (06:06 sáng, xem
-  `launchd/com.ai5phut.reddit-drama.plist`).
+  `ProRevenge`) qua JSON listing `/r/{sub}/top?t=day` (một request đã mang đủ
+  `score`/`selftext`/`over_18`). Lọc NSFW bằng cờ `over_18` chính thức, bỏ post
+  `stickied` (megathread/thông báo) và selftext `[removed]`/`[deleted]`.
+  **Đổi kiến trúc ở #78:** bản Phase 2 dùng RSS rồi gọi thêm 1 JSON detail cho
+  TỪNG post (pattern 1-RSS-cộng-N-detail: chậm ~2s/detail, dễ 403/429) — nay
+  chuyển hẳn sang JSON listing qua `reddit_client`, bỏ được cả RSS (hết phụ
+  thuộc `feedparser` ở collector này) lẫn vòng N detail call → nhanh hơn nhiều
+  và ít bị chặn. 403 khiến `get_json` trả `None` → collector coi là "0 story"
+  (KHÔNG raise); block kéo dài lộ ra qua alert staleness 2 ngày của
+  `collector_health`. Chạy: `python -m collectors.reddit_drama_collector`
+  (06:06 sáng, xem `launchd/com.ai5phut.reddit-drama.plist`).
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
@@ -433,8 +450,11 @@ Xem `launchd/README.md`. Mọi service chạy nền là launchd LaunchAgent
 - `https://www.therundown.ai/feed` — Newsletter AI hàng ngày
 - `https://bensbites.beehiiv.com/feed` — Ben's Bites newsletter
 - `https://vnexpress.net/rss/khoa-hoc-cong-nghe.rss` — VnExpress Công nghệ
-- `https://www.reddit.com/r/ChatGPT/.rss` — Reddit r/ChatGPT
-- `https://www.reddit.com/r/artificial/.rss` — Reddit r/artificial
+
+> Reddit r/ChatGPT + r/artificial **không** lấy qua RSS nữa (issue #78): các
+> endpoint `www.reddit.com/*.rss` bị chặn 403/429 cho client không xác thực và
+> trùng lặp với `collectors/reddit_collector.py`. Track AI lấy 2 subreddit này
+> qua JSON API đã xác thực (`reddit_client`) — xem Drama Source Layer (Phase 2).
 
 ### Twitter/X (Twitter API v2)
 Theo dõi tweets từ các account: `OpenAI`, `AnthropicAI`, `GoogleDeepMind`, `sama`, `levelsio`

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -7,6 +7,24 @@ TELEGRAM_TIKTOK_CHAT_ID=
 TWITTER_BEARER_TOKEN=...
 PRODUCTHUNT_API_TOKEN=...
 
+# --- Reddit API (issue #78) ---
+# Reddit blocks unauthenticated www.reddit.com/*.json + .rss (403/429), so both
+# the AI collector (r/ChatGPT, r/artificial) and the Drama collector need OAuth.
+# Create a "script"-type app at https://www.reddit.com/prefs/apps → the string
+# under the app name is the client id, and "secret" is the client secret.
+# Leave BOTH empty to run unauthenticated (best-effort — expect throttling).
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+# MUST be unique + descriptive (Reddit's API rules). Format:
+# <platform>:<app id>:<version> (by /u/<your reddit username>)
+REDDIT_USER_AGENT=python:ai5phut-content-pipeline:1.1 (by /u/ai5phut_bot)
+# HTTP tuning — defaults are sane; override only if you hit throttling.
+REDDIT_TIMEOUT=15
+REDDIT_MAX_RETRIES=3
+REDDIT_RETRY_BACKOFF=2
+REDDIT_MIN_INTERVAL=1.0
+REDDIT_RETRY_AFTER_CAP=60
+
 # --- Pexels (free stock video backgrounds) ---
 PEXELS_API_KEY=...
 

--- a/content-pipeline/collectors/reddit_client.py
+++ b/content-pipeline/collectors/reddit_client.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+"""
+Shared Reddit HTTP client — single source of truth for Reddit access (issue #78).
+
+Root cause of #78: unauthenticated requests to www.reddit.com/*.json and .rss
+are aggressively rate-limited (429) and blocked (403), especially from
+datacenter IPs. The generic/placeholder User-Agent the collectors used made it
+worse — Reddit's API rules require a unique, descriptive UA. The supported fix
+is OAuth2, so this module centralises ALL Reddit HTTP here and both collectors
+(track AI `reddit_collector` + track Drama `reddit_drama_collector`) go through
+it, instead of each hand-rolling urllib with its own UA.
+
+Behaviour:
+- If REDDIT_CLIENT_ID/SECRET are configured: app-only OAuth2 (client_credentials
+  grant) → requests hit https://oauth.reddit.com (documented ~100 req/min),
+  which bypasses the block. The bearer token is cached until ~1 min before it
+  expires and refreshed transparently.
+- If NOT configured: fall back to unauthenticated https://www.reddit.com/<path>.json
+  with the compliant UA (best-effort — may still be throttled, but the pipeline
+  keeps running and logs a clear one-time hint to set up OAuth).
+- A single module-level rate limiter spaces out every call (token requests
+  included) so a burst across subreddits can't trip the throttle.
+- 429 honours the Retry-After header (capped so a bad value can't stall cron);
+  403 is treated as a hard block and NOT retried (retrying a block wastes the
+  whole cron window); 401 refreshes the token once; 5xx/network back off + retry.
+
+Why JSON-only (no RSS): oauth.reddit.com serves JSON, not .rss, and the JSON
+listing endpoints already carry score/selftext/over_18 — the very fields the
+drama collector previously made a second per-post call to fetch. Moving to JSON
+both unblocks us and collapses the old 1-RSS-plus-N-detail-calls pattern into
+one request per subreddit.
+"""
+
+import base64
+import json
+import logging
+import threading
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+
+logger = logging.getLogger(__name__)
+
+_OAUTH_BASE = "https://oauth.reddit.com"
+_PUBLIC_BASE = "https://www.reddit.com"
+_TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+
+# Token cache + rate-limiter state, guarded by a lock so a threaded caller
+# can't race the refresh or double up requests.
+_lock = threading.Lock()
+_token: dict = {"access_token": None, "expires_at": 0.0}
+_last_call_at = 0.0
+_warned_no_oauth = False
+
+
+def has_oauth_credentials() -> bool:
+    """True when both a client id and secret are configured."""
+    return bool(config.REDDIT_CLIENT_ID and config.REDDIT_CLIENT_SECRET)
+
+
+def reset_state() -> None:
+    """Clear the cached token + rate-limiter clock (test helper)."""
+    global _last_call_at, _warned_no_oauth
+    with _lock:
+        _token["access_token"] = None
+        _token["expires_at"] = 0.0
+        _last_call_at = 0.0
+        _warned_no_oauth = False
+
+
+def _throttle() -> None:
+    """Sleep so consecutive Reddit calls are >= REDDIT_MIN_INTERVAL apart."""
+    global _last_call_at
+    with _lock:
+        now = time.monotonic()
+        wait = config.REDDIT_MIN_INTERVAL - (now - _last_call_at)
+        if wait > 0:
+            time.sleep(wait)
+        _last_call_at = time.monotonic()
+
+
+def _parse_retry_after(err: HTTPError) -> float | None:
+    """Seconds to wait from a 429's Retry-After header, or None if absent/odd.
+
+    Reddit sends an integer number of seconds. An HTTP-date value (rare here) is
+    ignored rather than parsed — we fall back to exponential backoff for it.
+    The value is capped so a pathological Retry-After can't park cron for hours.
+    """
+    try:
+        raw = err.headers.get("Retry-After") if err.headers else None
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        secs = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(secs, config.REDDIT_RETRY_AFTER_CAP))
+
+
+def _fetch_access_token() -> str | None:
+    """Return a cached-or-fresh app-only OAuth bearer token, or None on failure."""
+    with _lock:
+        if _token["access_token"] and time.monotonic() < _token["expires_at"]:
+            return _token["access_token"]
+
+    creds = f"{config.REDDIT_CLIENT_ID}:{config.REDDIT_CLIENT_SECRET}".encode("utf-8")
+    basic = base64.b64encode(creds).decode("ascii")
+    body = urlencode({"grant_type": "client_credentials"}).encode("ascii")
+    req = Request(_TOKEN_URL, data=body, method="POST")
+    req.add_header("Authorization", f"Basic {basic}")
+    req.add_header("User-Agent", config.REDDIT_USER_AGENT)
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    _throttle()
+    try:
+        with urlopen(req, timeout=config.REDDIT_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except HTTPError as e:
+        # 401 here means the client id/secret themselves are wrong — retrying
+        # won't help, so surface it clearly.
+        logger.error("Reddit OAuth token request failed: HTTP %s %s", e.code, e.reason)
+        return None
+    except Exception as e:
+        logger.error("Reddit OAuth token request failed: %s", e)
+        return None
+
+    access_token = data.get("access_token")
+    if not access_token:
+        logger.error("Reddit OAuth response had no access_token: %s", data)
+        return None
+    expires_in = data.get("expires_in", 3600)
+    with _lock:
+        _token["access_token"] = access_token
+        # Refresh a minute early so an in-flight request never uses a token
+        # that expires mid-call.
+        _token["expires_at"] = time.monotonic() + max(0.0, float(expires_in) - 60.0)
+    logger.info("Obtained Reddit app-only OAuth token (expires in %ss)", expires_in)
+    return access_token
+
+
+def _build_request(path: str, query: str, token: str | None) -> Request:
+    if token:
+        url = f"{_OAUTH_BASE}{path}"
+    else:
+        url = f"{_PUBLIC_BASE}{path}.json"
+    if query:
+        url = f"{url}?{query}"
+    req = Request(url)
+    req.add_header("User-Agent", config.REDDIT_USER_AGENT)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    return req
+
+
+def get_json(path: str, params: dict | None = None):
+    """GET a Reddit JSON endpoint and return the parsed body (or None on failure).
+
+    Args:
+        path: API path beginning with '/', WITHOUT the '.json' suffix, e.g.
+            '/r/AskReddit/top' or '/r/ChatGPT/hot'. The suffix is added only on
+            the unauthenticated fallback (oauth.reddit.com doesn't use it).
+        params: query params, e.g. {"t": "day", "limit": 25}.
+
+    Returns None (not raising) after exhausting retries, so callers keep the
+    "one source failing doesn't sink the run" resilience the codebase favours.
+    403 is a hard block and returns immediately without burning retries.
+    """
+    global _warned_no_oauth
+    query_params = dict(params or {})
+    use_oauth = has_oauth_credentials()
+    if use_oauth:
+        # Ask Reddit not to HTML-escape unicode in JSON string values.
+        query_params.setdefault("raw_json", 1)
+    elif not _warned_no_oauth:
+        _warned_no_oauth = True
+        logger.warning(
+            "Reddit OAuth not configured (REDDIT_CLIENT_ID/SECRET empty) — using "
+            "unauthenticated www.reddit.com, which Reddit heavily rate-limits/blocks "
+            "(issue #78). Create a 'script' app at reddit.com/prefs/apps to fix."
+        )
+    query = urlencode(query_params)
+
+    last_error = None
+    for attempt in range(config.REDDIT_MAX_RETRIES):
+        token = _fetch_access_token() if use_oauth else None
+        if use_oauth and not token:
+            # Couldn't authenticate this cycle; degrade to the public endpoint
+            # rather than give up entirely.
+            logger.warning("Falling back to unauthenticated Reddit for %s (no token)", path)
+            token = None
+
+        req = _build_request(path, query, token)
+        _throttle()
+        try:
+            with urlopen(req, timeout=config.REDDIT_TIMEOUT) as resp:
+                return json.loads(resp.read().decode("utf-8", errors="replace"))
+        except HTTPError as e:
+            last_error = e
+            if e.code == 401 and token:
+                # Stale/invalid token — drop it and let the next attempt refetch.
+                logger.warning("Reddit 401 on %s — refreshing token and retrying", path)
+                with _lock:
+                    _token["access_token"] = None
+                    _token["expires_at"] = 0.0
+                continue
+            if e.code == 403:
+                hint = "" if use_oauth else " (set up REDDIT_CLIENT_ID/SECRET for OAuth — issue #78)"
+                logger.error("Reddit 403 (blocked) on %s — not retrying%s", path, hint)
+                return None
+            if e.code == 429:
+                retry_after = _parse_retry_after(e)
+                wait = retry_after if retry_after is not None \
+                    else float(config.REDDIT_RETRY_BACKOFF ** (attempt + 1))
+                logger.warning(
+                    "Reddit 429 (rate-limited) on %s — waiting %.0fs (attempt %d/%d)",
+                    path, wait, attempt + 1, config.REDDIT_MAX_RETRIES,
+                )
+                if attempt < config.REDDIT_MAX_RETRIES - 1:
+                    time.sleep(wait)
+                continue
+            # Other HTTP status (5xx, etc.) — back off and retry.
+            logger.warning(
+                "Reddit HTTP %s on %s (attempt %d/%d): %s",
+                e.code, path, attempt + 1, config.REDDIT_MAX_RETRIES, e.reason,
+            )
+            if attempt < config.REDDIT_MAX_RETRIES - 1:
+                time.sleep(config.REDDIT_RETRY_BACKOFF ** (attempt + 1))
+        except (URLError, TimeoutError, json.JSONDecodeError) as e:
+            last_error = e
+            logger.warning(
+                "Reddit request error on %s (attempt %d/%d): %s",
+                path, attempt + 1, config.REDDIT_MAX_RETRIES, e,
+            )
+            if attempt < config.REDDIT_MAX_RETRIES - 1:
+                time.sleep(config.REDDIT_RETRY_BACKOFF ** (attempt + 1))
+
+    logger.error(
+        "Reddit request to %s failed after %d attempts: %s",
+        path, config.REDDIT_MAX_RETRIES, last_error,
+    )
+    return None

--- a/content-pipeline/collectors/reddit_collector.py
+++ b/content-pipeline/collectors/reddit_collector.py
@@ -1,31 +1,29 @@
-"""Reddit collector using Reddit's JSON API (no auth required for public subreddits)."""
+"""Reddit collector for the AI track (r/ChatGPT, r/artificial).
+
+HTTP goes through collectors/reddit_client.py — OAuth app-only when credentials
+are configured, unauthenticated fallback otherwise (issue #78). This is the same
+client the Drama collector uses, so both tracks share one User-Agent, one token
+cache, and one rate limiter.
+"""
 
 import logging
-import json
-from urllib.request import Request, urlopen
 
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from collectors import reddit_client
 from storage.database import insert_article, init_db
 
 logger = logging.getLogger(__name__)
 
 SUBREDDITS = ["ChatGPT", "artificial"]
-REDDIT_USER_AGENT = "ContentPipeline/1.0 (content curation bot; contact: admin@example.com)"
 
 
 def collect_subreddit(subreddit: str, limit: int = 20) -> int:
     """Collect hot posts from a subreddit. Returns count of new articles."""
-    url = f"https://www.reddit.com/r/{subreddit}/hot.json?limit={limit}"
-    req = Request(url)
-    req.add_header("User-Agent", REDDIT_USER_AGENT)
-
-    try:
-        with urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read().decode())
-    except Exception as e:
-        logger.error("Failed to fetch r/%s: %s", subreddit, e)
+    data = reddit_client.get_json(f"/r/{subreddit}/hot", {"limit": limit})
+    if data is None:
+        logger.error("Failed to fetch r/%s (blocked or network error)", subreddit)
         return 0
 
     posts = data.get("data", {}).get("children", [])

--- a/content-pipeline/collectors/reddit_drama_collector.py
+++ b/content-pipeline/collectors/reddit_drama_collector.py
@@ -45,6 +45,18 @@ LISTING_LIMIT = 50
 _REMOVED_SENTINELS = {"[removed]", "[deleted]"}
 
 
+class RedditFetchError(Exception):
+    """A subreddit listing could not be fetched (block/network), as opposed to
+    fetching fine and finding 0 eligible posts.
+
+    This distinction matters for collector_health: a genuine "0 new stories
+    today" is a success, but a fetch failure must NOT be recorded as one — see
+    collect_all_drama(). reddit_client.get_json() deliberately returns None (not
+    raising) to stay resilient for all callers; this collector re-raises that
+    None so a total block propagates instead of masquerading as an empty day.
+    """
+
+
 def _permalink_url(permalink: str) -> str:
     """Turn a Reddit permalink path into an absolute URL (best-effort)."""
     if not permalink:
@@ -87,13 +99,20 @@ def parse_listing(raw_json) -> list[dict]:
 
 
 def fetch_subreddit_top(subreddit: str, period: str = "day") -> list[dict]:
-    """Fetch + parse the top listing for a subreddit. Returns [] on any error."""
+    """Fetch + parse the top listing for a subreddit.
+
+    Raises RedditFetchError when the listing couldn't be fetched (get_json
+    returned None — a 403 block or network failure), so the caller can tell that
+    apart from a successfully-fetched-but-empty listing. A valid empty listing
+    returns [].
+    """
     raw = reddit_client.get_json(
         f"/r/{subreddit}/top", {"t": period, "limit": LISTING_LIMIT}
     )
     if raw is None:
-        logger.warning("No listing returned for r/%s (blocked or network error)", subreddit)
-        return []
+        raise RedditFetchError(
+            f"listing fetch failed for r/{subreddit} (blocked or network error)"
+        )
     posts = parse_listing(raw)
     logger.info("r/%s top listing returned %d posts", subreddit, len(posts))
     return posts
@@ -166,17 +185,18 @@ def collect_all_drama() -> int:
 
     A single failing subreddit doesn't fail the run (logged and skipped — same
     resilience philosophy as the rest of this codebase). But if EVERY subreddit
-    call raises — a systemic failure like a total network outage, not "just
-    found nothing new today" — this raises RuntimeError instead of silently
-    returning 0. That distinction matters to the caller: __main__ only calls
-    collector_health.record_success() after this returns normally, so a
-    fully-failed run correctly stays unrecorded and the 2-day staleness alert
-    can eventually catch it.
+    call raises — a systemic failure like a total network outage or a Reddit
+    block (issue #78), not "just found nothing new today" — this raises
+    RuntimeError instead of silently returning 0. That distinction matters to
+    the caller: __main__ only calls collector_health.record_success() after this
+    returns normally, so a fully-failed run correctly stays UNRECORDED and the
+    2-day staleness alert can eventually catch it.
 
-    NOTE: a 403 block (issue #78) makes reddit_client.get_json return None, so
-    collect_subreddit returns 0 — that path is a quiet "0 stories", NOT a raise.
-    A persistent block therefore surfaces via the staleness alert (no new
-    stories for 2 days), which is the right signal for "the source went dark".
+    A 403 block makes reddit_client.get_json return None; fetch_subreddit_top
+    turns that into a RedditFetchError (rather than a quiet "0 stories"), so a
+    total block counts as a total failure here and record_success is skipped —
+    otherwise a persistent block would keep refreshing last_success and stay
+    invisible to the staleness alert forever.
     """
     total = 0
     failures = 0

--- a/content-pipeline/collectors/reddit_drama_collector.py
+++ b/content-pipeline/collectors/reddit_drama_collector.py
@@ -3,38 +3,30 @@ from __future__ import annotations
 """
 Reddit Drama Collector — cào top post từ các subreddit "drama" (Phase 2).
 
-Khác với collectors/reddit_collector.py (dùng cho track AI, JSON API 'hot'),
-collector này:
-1. Dùng RSS (`/top/.rss?t=day`) để lấy danh sách post — nhẹ, không cần auth.
-2. Gọi thêm JSON API (`/comments/{id}.json`) cho từng post để lấy `score`
-   (upvotes) và `selftext` đầy đủ — RSS không có 2 trường này.
-3. Lọc theo `min_upvotes` (khác nhau mỗi subreddit) và bỏ NSFW (`over_18`).
-4. Lưu vào bảng `stories` (track='drama') qua storage/stories.py, dedupe theo
-   `source_id`.
+Khác với collectors/reddit_collector.py (track AI, listing 'hot'), collector này
+lấy listing 'top' theo ngày và lọc theo `min_upvotes`/NSFW cho từng subreddit.
 
-Lưu ý thiết kế (khác với phase-2-detailed.md mục 3.1): NSFW được lọc bằng
-cờ `over_18` chính thức từ JSON detail response — không cố đoán từ RSS, vì
-định dạng RSS của Reddit không có trường NSFW được document rõ ràng. Đằng
-nào cũng phải gọi JSON API để lấy score/selftext, nên dùng luôn `over_18`
-từ đó là nguồn duy nhất, đáng tin cậy hơn.
+Kiến trúc HTTP (issue #78): mọi request đi qua collectors/reddit_client.py —
+OAuth app-only khi có credentials (oauth.reddit.com, không bị chặn), fallback
+www.reddit.com khi chưa cấu hình. Xem docstring reddit_client để hiểu root cause.
+
+Lịch sử: bản Phase 2 dùng RSS (`/top/.rss`) rồi gọi thêm JSON detail cho TỪNG
+post để lấy score/selftext/over_18 (RSS không có) — pattern 1-RSS-cộng-N-detail
+vừa chậm (rate-limit 2s/detail) vừa dễ bị 403/429. Từ issue #78 chuyển hẳn sang
+JSON listing `/r/{sub}/top`: một request đã mang đủ score/selftext/over_18, nên
+bỏ được cả RSS lẫn vòng N detail call. NSFW vẫn lọc bằng cờ `over_18` chính thức
+(giờ có sẵn ngay trong listing).
 """
 
-import json
 import logging
-import re
-import time
-from urllib.request import Request, urlopen
-
-import feedparser
-
 import sys
 import os
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from collectors import reddit_client
 from storage.stories import insert_story, dedupe_check
 
 logger = logging.getLogger(__name__)
-
-REDDIT_USER_AGENT = "ContentPipeline/1.0 (drama story collector; contact: admin@example.com)"
 
 DRAMA_SUBREDDITS = [
     {"name": "AmItheAsshole", "min_upvotes": 5000, "weight": 1.5},
@@ -44,127 +36,67 @@ DRAMA_SUBREDDITS = [
     {"name": "ProRevenge", "min_upvotes": 3000, "weight": 1.4},
 ]
 
-# Reddit JSON API detail fetch: rate limit + retry tuning.
-DETAIL_MIN_INTERVAL_SECONDS = 2.0
-DETAIL_MAX_RETRIES = 3
-DETAIL_RETRY_BACKOFF_BASE = 2  # seconds: 2, 4, 8...
+# How many top posts to request per subreddit. Reddit caps a single listing page
+# at 100; the top-of-day list is short so this is plenty.
+LISTING_LIMIT = 50
 
-_POST_ID_FROM_LINK_RE = re.compile(r"/comments/([a-z0-9]+)/", re.IGNORECASE)
-_POST_ID_FROM_FULLNAME_RE = re.compile(r"t3_([a-z0-9]+)", re.IGNORECASE)
-
-
-class _RateLimiter:
-    """Sleeps as needed so consecutive calls are >= min_interval apart."""
-
-    def __init__(self, min_interval: float = DETAIL_MIN_INTERVAL_SECONDS):
-        self.min_interval = min_interval
-        self._last_call = 0.0
-
-    def wait(self):
-        now = time.monotonic()
-        elapsed = now - self._last_call
-        if elapsed < self.min_interval:
-            time.sleep(self.min_interval - elapsed)
-        self._last_call = time.monotonic()
+# Bodies for moderator/user-removed posts come back as these literal sentinels —
+# truthy, so they'd otherwise be stored as if they were real story content.
+_REMOVED_SENTINELS = {"[removed]", "[deleted]"}
 
 
-_rate_limiter = _RateLimiter()
+def _permalink_url(permalink: str) -> str:
+    """Turn a Reddit permalink path into an absolute URL (best-effort)."""
+    if not permalink:
+        return ""
+    if permalink.startswith("http"):
+        return permalink
+    return f"https://www.reddit.com{permalink}"
 
 
-def _extract_post_id(entry: dict) -> str | None:
-    """Extract the bare Reddit post id (e.g. 'abc123') from a feedparser entry."""
-    link = entry.get("link", "") or ""
-    m = _POST_ID_FROM_LINK_RE.search(link)
-    if m:
-        return m.group(1)
-    entry_id = entry.get("id", "") or ""
-    m = _POST_ID_FROM_FULLNAME_RE.search(entry_id)
-    if m:
-        return m.group(1)
-    return None
+def parse_listing(raw_json) -> list[dict]:
+    """Extract posts from a /r/{sub}/top listing JSON response.
 
-
-def _fetch_rss_content(url: str) -> str:
-    """Fetch RSS content with a proper User-Agent (network call)."""
-    req = Request(url)
-    req.add_header("User-Agent", REDDIT_USER_AGENT)
-    with urlopen(req, timeout=15) as resp:
-        return resp.read().decode("utf-8", errors="replace")
-
-
-def parse_rss_entries(rss_content: str) -> list[dict]:
-    """Parse RSS/Atom content into a list of {post_id, title, link, summary}.
-
-    Pure function (no network) — entries with no resolvable post id are
-    skipped since we can't dedupe/detail-fetch them.
+    Pure function (no network). Each returned dict carries everything the
+    collector needs — post_id, title, link, selftext, ups, over_18, stickied —
+    so there's no second per-post request. Returns [] on an unexpected shape.
     """
-    feed = feedparser.parse(rss_content)
-    result = []
-    for entry in feed.entries:
-        post_id = _extract_post_id(entry)
+    try:
+        children = raw_json["data"]["children"]
+    except (KeyError, TypeError):
+        return []
+    if not isinstance(children, list):
+        return []
+
+    posts: list[dict] = []
+    for child in children:
+        data = child.get("data", {}) if isinstance(child, dict) else {}
+        post_id = data.get("id")
         if not post_id:
             continue
-        result.append({
+        posts.append({
             "post_id": post_id,
-            "title": (entry.get("title", "") or "").strip(),
-            "link": entry.get("link", "") or "",
-            "summary": entry.get("summary", "") or "",
+            "title": (data.get("title") or "").strip(),
+            "link": _permalink_url(data.get("permalink", "") or ""),
+            "selftext": data.get("selftext", "") or "",
+            "ups": data.get("score", data.get("ups", 0)) or 0,
+            "over_18": bool(data.get("over_18", False)),
+            "stickied": bool(data.get("stickied", False)),
         })
-    return result
+    return posts
 
 
-def fetch_subreddit_rss(subreddit: str, sort: str = "top", period: str = "day") -> list[dict]:
-    """Fetch + parse the RSS feed for a subreddit. Returns [] on any error."""
-    url = f"https://www.reddit.com/r/{subreddit}/{sort}/.rss?t={period}"
-    try:
-        content = _fetch_rss_content(url)
-    except Exception as e:
-        logger.warning("Failed to fetch RSS for r/%s: %s", subreddit, e)
+def fetch_subreddit_top(subreddit: str, period: str = "day") -> list[dict]:
+    """Fetch + parse the top listing for a subreddit. Returns [] on any error."""
+    raw = reddit_client.get_json(
+        f"/r/{subreddit}/top", {"t": period, "limit": LISTING_LIMIT}
+    )
+    if raw is None:
+        logger.warning("No listing returned for r/%s (blocked or network error)", subreddit)
         return []
-    entries = parse_rss_entries(content)
-    logger.info("r/%s RSS returned %d entries", subreddit, len(entries))
-    return entries
-
-
-def _fetch_post_json(subreddit: str, post_id: str) -> dict | None:
-    """Fetch raw JSON for a post's detail (network call), rate-limited + retried."""
-    url = f"https://www.reddit.com/r/{subreddit}/comments/{post_id}.json"
-    last_error = None
-    for attempt in range(DETAIL_MAX_RETRIES):
-        _rate_limiter.wait()
-        req = Request(url)
-        req.add_header("User-Agent", REDDIT_USER_AGENT)
-        try:
-            with urlopen(req, timeout=15) as resp:
-                return json.loads(resp.read().decode("utf-8", errors="replace"))
-        except Exception as e:
-            last_error = e
-            wait = DETAIL_RETRY_BACKOFF_BASE ** (attempt + 1)
-            logger.warning(
-                "Attempt %d/%d fetching detail for %s/%s failed: %s",
-                attempt + 1, DETAIL_MAX_RETRIES, subreddit, post_id, e,
-            )
-            if attempt < DETAIL_MAX_RETRIES - 1:
-                time.sleep(wait)
-    logger.error("Giving up on %s/%s after %d attempts: %s",
-                 subreddit, post_id, DETAIL_MAX_RETRIES, last_error)
-    return None
-
-
-def parse_post_detail(raw_json) -> dict | None:
-    """Extract {selftext, ups, over_18} from a /comments/{id}.json response.
-
-    Pure function (no network). Returns None if the shape is unexpected.
-    """
-    try:
-        post_data = raw_json[0]["data"]["children"][0]["data"]
-    except (KeyError, IndexError, TypeError):
-        return None
-    return {
-        "selftext": post_data.get("selftext", "") or "",
-        "ups": post_data.get("score", post_data.get("ups", 0)) or 0,
-        "over_18": bool(post_data.get("over_18", False)),
-    }
+    posts = parse_listing(raw)
+    logger.info("r/%s top listing returned %d posts", subreddit, len(posts))
+    return posts
 
 
 def collect_subreddit(sub_config: dict) -> int:
@@ -173,61 +105,57 @@ def collect_subreddit(sub_config: dict) -> int:
     min_upvotes = sub_config["min_upvotes"]
     weight = sub_config.get("weight", 1.0)
 
-    entries = fetch_subreddit_rss(name)
+    posts = fetch_subreddit_top(name)
     count = 0
     skipped_dup = 0
     skipped_nsfw = 0
     skipped_low_score = 0
-    skipped_no_detail = 0
+    skipped_removed = 0
+    skipped_stickied = 0
 
-    for entry in entries:
-        source_id = f"reddit_{entry['post_id']}"
+    for post in posts:
+        # Pinned/announcement posts (megathreads, rules) aren't drama stories.
+        if post["stickied"]:
+            skipped_stickied += 1
+            continue
+
+        source_id = f"reddit_{post['post_id']}"
         if dedupe_check(source_id):
             skipped_dup += 1
             continue
 
-        raw_json = _fetch_post_json(name, entry["post_id"])
-        if raw_json is None:
-            skipped_no_detail += 1
-            continue
-        detail = parse_post_detail(raw_json)
-        if detail is None:
-            skipped_no_detail += 1
-            continue
-
-        if detail["over_18"]:
+        if post["over_18"]:
             skipped_nsfw += 1
             continue
-        if detail["ups"] < min_upvotes:
+        if post["ups"] < min_upvotes:
             skipped_low_score += 1
             continue
-        if detail["selftext"].strip() in ("[removed]", "[deleted]"):
-            # Moderator/user-removed posts return this literal sentinel as
-            # selftext — truthy, so it would otherwise be stored as if it
-            # were real story content.
-            skipped_no_detail += 1
+        if post["selftext"].strip() in _REMOVED_SENTINELS:
+            skipped_removed += 1
             continue
 
-        raw_content = detail["selftext"] or entry["title"]
+        raw_content = post["selftext"] or post["title"]
         insert_story(
             source="reddit",
             source_id=source_id,
             raw_content=raw_content,
             track="drama",
-            title=entry["title"],
+            title=post["title"],
             metadata={
                 "subreddit": name,
-                "upvotes": detail["ups"],
-                "url": entry["link"],
+                "upvotes": post["ups"],
+                "url": post["link"],
                 "weight": weight,
             },
         )
         count += 1
 
-    if skipped_dup or skipped_nsfw or skipped_low_score or skipped_no_detail:
+    if skipped_dup or skipped_nsfw or skipped_low_score or skipped_removed or skipped_stickied:
         logger.info(
-            "r/%s skipped: %d duplicates, %d nsfw, %d below %d upvotes, %d detail-fetch failed",
-            name, skipped_dup, skipped_nsfw, skipped_low_score, min_upvotes, skipped_no_detail,
+            "r/%s skipped: %d duplicates, %d nsfw, %d below %d upvotes, "
+            "%d removed/deleted, %d stickied",
+            name, skipped_dup, skipped_nsfw, skipped_low_score, min_upvotes,
+            skipped_removed, skipped_stickied,
         )
     logger.info("Collected %d new drama stories from r/%s", count, name)
     return count
@@ -236,14 +164,19 @@ def collect_subreddit(sub_config: dict) -> int:
 def collect_all_drama() -> int:
     """Collect from every configured drama subreddit. Returns total new stories.
 
-    A single failing subreddit doesn't fail the run (logged and skipped —
-    same resilience philosophy as the rest of this codebase). But if EVERY
-    subreddit call raises — a systemic failure like a total network outage,
-    not "just found nothing new today" — this raises RuntimeError instead of
-    silently returning 0. That distinction matters to the caller: __main__
-    only calls collector_health.record_success() after this returns
-    normally, so a fully-failed run correctly stays unrecorded and the 2-day
-    staleness alert can eventually catch it.
+    A single failing subreddit doesn't fail the run (logged and skipped — same
+    resilience philosophy as the rest of this codebase). But if EVERY subreddit
+    call raises — a systemic failure like a total network outage, not "just
+    found nothing new today" — this raises RuntimeError instead of silently
+    returning 0. That distinction matters to the caller: __main__ only calls
+    collector_health.record_success() after this returns normally, so a
+    fully-failed run correctly stays unrecorded and the 2-day staleness alert
+    can eventually catch it.
+
+    NOTE: a 403 block (issue #78) makes reddit_client.get_json return None, so
+    collect_subreddit returns 0 — that path is a quiet "0 stories", NOT a raise.
+    A persistent block therefore surfaces via the staleness alert (no new
+    stories for 2 days), which is the right signal for "the source went dark".
     """
     total = 0
     failures = 0
@@ -285,6 +218,6 @@ if __name__ == "__main__":
     migrate_up()  # idempotent — ensures stories.title/metadata + track columns exist
     collect_all_drama()
     # Completing without an uncaught exception IS the "success" the 2-day
-    # staleness alert (storage/collector_health.py) checks for — 0 new
-    # stories on a given day is normal, not a failure.
+    # staleness alert (storage/collector_health.py) checks for — 0 new stories
+    # on a given day is normal, not a failure.
     record_success("reddit_drama")

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -14,6 +14,35 @@ TELEGRAM_TIKTOK_CHAT_ID = os.getenv("TELEGRAM_TIKTOK_CHAT_ID", "")
 TWITTER_BEARER_TOKEN = os.getenv("TWITTER_BEARER_TOKEN", "")
 PRODUCTHUNT_API_TOKEN = os.getenv("PRODUCTHUNT_API_TOKEN", "")
 
+# --- Reddit API (issue #78) ---
+# Root cause of #78: unauthenticated requests to www.reddit.com/*.json and
+# .rss are aggressively rate-limited (429) and blocked (403), especially from
+# datacenter IPs. Reddit's supported path is OAuth2. When a client id/secret is
+# configured, collectors/reddit_client.py uses the app-only (client_credentials)
+# grant against oauth.reddit.com — a documented ~100 req/min budget that bypasses
+# the block. With no credentials it falls back to unauthenticated www.reddit.com
+# (best-effort, still may be throttled) so the pipeline keeps running.
+#
+# Create an app at https://www.reddit.com/prefs/apps (type: "script") to get
+# these. The User-Agent MUST be unique and descriptive per Reddit's API rules —
+# a generic/placeholder UA (the old "contact: admin@example.com") is itself a
+# block trigger. Format: <platform>:<app id>:<version> (by /u/<your-username>).
+REDDIT_CLIENT_ID = os.getenv("REDDIT_CLIENT_ID", "")
+REDDIT_CLIENT_SECRET = os.getenv("REDDIT_CLIENT_SECRET", "")
+REDDIT_USER_AGENT = os.getenv(
+    "REDDIT_USER_AGENT",
+    "python:ai5phut-content-pipeline:1.1 (by /u/ai5phut_bot)",
+)
+REDDIT_TIMEOUT = int(os.getenv("REDDIT_TIMEOUT", "15"))          # per-request socket timeout (s)
+REDDIT_MAX_RETRIES = int(os.getenv("REDDIT_MAX_RETRIES", "3"))   # retries for 429/5xx/network
+REDDIT_RETRY_BACKOFF = int(os.getenv("REDDIT_RETRY_BACKOFF", "2"))  # backoff base (s): 2, 4, 8...
+# Minimum spacing between Reddit calls. With OAuth the budget is ~100 req/min
+# so 1s is plenty; without OAuth we go slower to avoid tripping the throttle.
+REDDIT_MIN_INTERVAL = float(os.getenv("REDDIT_MIN_INTERVAL", "1.0"))
+# Cap how long a 429 Retry-After may park the run — Reddit usually returns a few
+# seconds, but we never want a pathological value to stall the whole cron window.
+REDDIT_RETRY_AFTER_CAP = float(os.getenv("REDDIT_RETRY_AFTER_CAP", "60"))
+
 # RSS Feeds
 RSS_FEEDS = [
     # AI Newsletters
@@ -25,9 +54,10 @@ RSS_FEEDS = [
     "https://arstechnica.com/ai/feed/",                       # Ars Technica AI
     # Vietnamese tech news
     "https://vnexpress.net/rss/khoa-hoc-cong-nghe.rss",      # VnExpress Công nghệ
-    # Reddit
-    "https://www.reddit.com/r/ChatGPT/.rss",                 # Reddit r/ChatGPT
-    "https://www.reddit.com/r/artificial/.rss",               # Reddit r/artificial
+    # NOTE: Reddit r/ChatGPT + r/artificial are collected by
+    # collectors/reddit_collector.py via the authenticated JSON API (issue #78),
+    # NOT here — the www.reddit.com/*.rss endpoints are blocked (403/429) for
+    # unauthenticated clients and duplicated those two subreddits anyway.
 ]
 
 # Twitter accounts to follow

--- a/content-pipeline/tests/test_reddit_client.py
+++ b/content-pipeline/tests/test_reddit_client.py
@@ -1,0 +1,189 @@
+"""Tests for collectors/reddit_client.py (issue #78 — Reddit OAuth/HTTP client)."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import collectors.reddit_client as rc
+
+
+def _http_error(code, headers=None):
+    from urllib.error import HTTPError
+    return HTTPError(
+        url="https://oauth.reddit.com/x", code=code, msg="err",
+        hdrs=headers or {}, fp=io.BytesIO(b""),
+    )
+
+
+def _ok_response(payload):
+    """A context-manager stand-in for urlopen() returning JSON bytes."""
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = json.dumps(payload).encode("utf-8")
+    cm.__exit__.return_value = False
+    return cm
+
+
+class RedditClientBase(unittest.TestCase):
+    def setUp(self):
+        rc.reset_state()
+        # No real sleeping in tests.
+        self._sleep = patch.object(rc.time, "sleep", return_value=None)
+        self._sleep.start()
+
+    def tearDown(self):
+        self._sleep.stop()
+        rc.reset_state()
+
+
+class TestHasCredentials(RedditClientBase):
+    def test_true_when_both_set(self):
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", "id"), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"):
+            self.assertTrue(rc.has_oauth_credentials())
+
+    def test_false_when_missing(self):
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"):
+            self.assertFalse(rc.has_oauth_credentials())
+
+
+class TestUnauthenticatedFallback(RedditClientBase):
+    def test_hits_public_json_url_without_credentials(self):
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc, "urlopen", return_value=_ok_response({"ok": 1})) as mock_open:
+            result = rc.get_json("/r/AskReddit/top", {"t": "day"})
+        self.assertEqual(result, {"ok": 1})
+        req = mock_open.call_args[0][0]
+        self.assertTrue(req.full_url.startswith("https://www.reddit.com/r/AskReddit/top.json"))
+        self.assertIn("t=day", req.full_url)
+        # Compliant, non-placeholder User-Agent is always sent.
+        self.assertEqual(req.get_header("User-agent"), rc.config.REDDIT_USER_AGENT)
+        self.assertIsNone(req.get_header("Authorization"))
+
+
+class TestOAuthFlow(RedditClientBase):
+    def test_uses_bearer_token_and_oauth_host(self):
+        token_resp = _ok_response({"access_token": "TOK", "expires_in": 3600})
+        data_resp = _ok_response({"data": {"children": []}})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", "id"), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"), \
+             patch.object(rc, "urlopen", side_effect=[token_resp, data_resp]) as mock_open:
+            result = rc.get_json("/r/ChatGPT/hot", {"limit": 5})
+        self.assertEqual(result, {"data": {"children": []}})
+        # Second call is the data request against oauth.reddit.com with a bearer.
+        data_req = mock_open.call_args_list[1][0][0]
+        self.assertTrue(data_req.full_url.startswith("https://oauth.reddit.com/r/ChatGPT/hot"))
+        self.assertEqual(data_req.get_header("Authorization"), "Bearer TOK")
+        # raw_json=1 auto-added on the OAuth path.
+        self.assertIn("raw_json=1", data_req.full_url)
+
+    def test_token_is_cached_across_calls(self):
+        token_resp = _ok_response({"access_token": "TOK", "expires_in": 3600})
+        d1 = _ok_response({"n": 1})
+        d2 = _ok_response({"n": 2})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", "id"), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"), \
+             patch.object(rc, "urlopen", side_effect=[token_resp, d1, d2]) as mock_open:
+            rc.get_json("/r/a/hot")
+            rc.get_json("/r/b/hot")
+        # 3 calls total: 1 token + 2 data (token fetched once, then cached).
+        self.assertEqual(mock_open.call_count, 3)
+
+    def test_falls_back_to_public_when_token_fetch_fails(self):
+        # Token endpoint 500s → get_json should degrade to public JSON, not die.
+        data_resp = _ok_response({"public": True})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", "id"), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"), \
+             patch.object(rc, "urlopen", side_effect=[_http_error(500), data_resp]) as mock_open:
+            result = rc.get_json("/r/a/top")
+        self.assertEqual(result, {"public": True})
+        data_req = mock_open.call_args_list[1][0][0]
+        self.assertTrue(data_req.full_url.startswith("https://www.reddit.com/"))
+
+
+class TestErrorHandling(RedditClientBase):
+    def test_403_is_not_retried(self):
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc, "urlopen", side_effect=_http_error(403)) as mock_open:
+            result = rc.get_json("/r/a/top")
+        self.assertIsNone(result)
+        self.assertEqual(mock_open.call_count, 1)  # no retry on a hard block
+
+    def test_429_retries_then_gives_up(self):
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc.config, "REDDIT_MAX_RETRIES", 3), \
+             patch.object(rc, "urlopen", side_effect=_http_error(429)) as mock_open:
+            result = rc.get_json("/r/a/top")
+        self.assertIsNone(result)
+        self.assertEqual(mock_open.call_count, 3)
+
+    def test_429_honours_retry_after_header(self):
+        # _throttle() also sleeps (to space out calls), so collect ALL sleeps
+        # and assert the Retry-After value is among them.
+        sleeps = []
+        resp = _ok_response({"ok": 1})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc.config, "REDDIT_RETRY_AFTER_CAP", 60), \
+             patch.object(rc.time, "sleep", side_effect=sleeps.append), \
+             patch.object(rc, "urlopen", side_effect=[_http_error(429, {"Retry-After": "7"}), resp]):
+            result = rc.get_json("/r/a/top")
+        self.assertEqual(result, {"ok": 1})
+        self.assertIn(7.0, sleeps)
+
+    def test_retry_after_is_capped(self):
+        sleeps = []
+        resp = _ok_response({"ok": 1})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc.config, "REDDIT_RETRY_AFTER_CAP", 30), \
+             patch.object(rc.time, "sleep", side_effect=sleeps.append), \
+             patch.object(rc, "urlopen", side_effect=[_http_error(429, {"Retry-After": "9999"}), resp]):
+            rc.get_json("/r/a/top")
+        self.assertIn(30.0, sleeps)  # capped, not 9999
+
+    def test_401_refreshes_token_once(self):
+        token1 = _ok_response({"access_token": "T1", "expires_in": 3600})
+        token2 = _ok_response({"access_token": "T2", "expires_in": 3600})
+        data_resp = _ok_response({"ok": 1})
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", "id"), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", "secret"), \
+             patch.object(rc, "urlopen",
+                          side_effect=[token1, _http_error(401), token2, data_resp]) as mock_open:
+            result = rc.get_json("/r/a/hot")
+        self.assertEqual(result, {"ok": 1})
+        # A fresh token was fetched after the 401.
+        self.assertEqual(mock_open.call_count, 4)
+
+    def test_network_error_returns_none_after_retries(self):
+        from urllib.error import URLError
+        with patch.object(rc.config, "REDDIT_CLIENT_ID", ""), \
+             patch.object(rc.config, "REDDIT_CLIENT_SECRET", ""), \
+             patch.object(rc.config, "REDDIT_MAX_RETRIES", 2), \
+             patch.object(rc, "urlopen", side_effect=URLError("boom")) as mock_open:
+            result = rc.get_json("/r/a/top")
+        self.assertIsNone(result)
+        self.assertEqual(mock_open.call_count, 2)
+
+
+class TestRetryAfterParsing(RedditClientBase):
+    def test_non_numeric_retry_after_ignored(self):
+        with patch.object(rc.config, "REDDIT_RETRY_AFTER_CAP", 60):
+            err = _http_error(429, {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})
+            self.assertIsNone(rc._parse_retry_after(err))
+
+    def test_missing_header_returns_none(self):
+        self.assertIsNone(rc._parse_retry_after(_http_error(429, {})))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_reddit_drama_collector.py
+++ b/content-pipeline/tests/test_reddit_drama_collector.py
@@ -160,10 +160,21 @@ class TestCollectSubreddit(_DramaDBTest):
             {s["source_id"] for s in stories.get_pending(track="drama")}, {"reddit_zzz"}
         )
 
-    def test_blocked_source_returns_zero_not_crash(self):
-        # get_json returns None on a 403 block — collector must treat it as
-        # "0 stories", not raise.
+    def test_blocked_source_raises_fetch_error(self):
+        # get_json returns None on a 403 block. collect_subreddit must NOT
+        # collapse that to a quiet "0 stories" — it raises RedditFetchError so
+        # a total block can be told apart from a genuinely empty day (which
+        # would otherwise keep record_success() alive and hide the outage).
         with patch.object(drama_collector.reddit_client, "get_json", return_value=None):
+            with self.assertRaises(drama_collector.RedditFetchError):
+                drama_collector.collect_subreddit(
+                    {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+                )
+
+    def test_empty_but_fetched_listing_returns_zero(self):
+        # A successfully-fetched-but-empty listing is a real 0, not a failure.
+        empty = {"data": {"children": []}}
+        with patch.object(drama_collector.reddit_client, "get_json", return_value=empty):
             count = drama_collector.collect_subreddit(
                 {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
             )
@@ -199,12 +210,30 @@ class TestCollectAllDrama(_DramaDBTest):
             total = drama_collector.collect_all_drama()
         self.assertEqual(total, 0)
 
-    def test_all_blocked_returns_zero_without_raising(self):
-        # A 403 block makes every collect_subreddit return 0 (not raise), so
-        # collect_all_drama returns 0 and the staleness alert catches the outage
-        # — it must NOT raise here (raise is reserved for exceptions, not blocks).
+    def test_all_blocked_raises_so_success_is_not_recorded(self):
+        # A 403 block makes every subreddit fetch raise RedditFetchError, so
+        # collect_all_drama sees a TOTAL failure and raises RuntimeError. That's
+        # what keeps __main__ from calling record_success() on a blocked run —
+        # otherwise last_success refreshes daily and the staleness alert never
+        # fires (Codex review on PR #79).
         with patch.object(drama_collector.reddit_client, "get_json", return_value=None):
-            total = drama_collector.collect_all_drama()
+            with self.assertRaises(RuntimeError):
+                drama_collector.collect_all_drama()
+
+    def test_partial_block_still_records_success(self):
+        # If only SOME subreddits are blocked, the run still collected from the
+        # rest — that's a partial degradation, not a total outage, so it must
+        # NOT raise (record_success stays valid; staleness alert is for total
+        # outage only).
+        blocked = {"AmItheAsshole"}
+
+        def fake_fetch(subreddit, period="day"):
+            if subreddit in blocked:
+                raise drama_collector.RedditFetchError("blocked")
+            return []
+
+        with patch.object(drama_collector, "fetch_subreddit_top", side_effect=fake_fetch):
+            total = drama_collector.collect_all_drama()  # must not raise
         self.assertEqual(total, 0)
 
 

--- a/content-pipeline/tests/test_reddit_drama_collector.py
+++ b/content-pipeline/tests/test_reddit_drama_collector.py
@@ -1,10 +1,9 @@
-"""Tests for collectors/reddit_drama_collector.py (Phase 2 — Drama Source Layer)."""
+"""Tests for collectors/reddit_drama_collector.py (Phase 2 + issue #78 rework)."""
 from __future__ import annotations
 
 import os
 import sys
 import tempfile
-import time
 import unittest
 from unittest.mock import patch
 
@@ -15,105 +14,75 @@ import storage.database as db
 import storage.migrate as migrate
 import storage.stories as stories
 
-FIXTURE_RSS = """<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>reddit: the front page of the internet</title>
-  <entry>
-    <id>t3_abc111</id>
-    <link href="https://www.reddit.com/r/AskReddit/comments/abc111/some_title_here/"/>
-    <title>AITA for refusing to pay for the wedding?</title>
-    <summary>Some summary text here.</summary>
-  </entry>
-  <entry>
-    <id>t3_abc222</id>
-    <link href="https://www.reddit.com/r/AskReddit/comments/abc222/another_post/"/>
-    <title>My coworker took credit for my work</title>
-    <summary>Another summary.</summary>
-  </entry>
-  <entry>
-    <title>Entry with no resolvable post id</title>
-    <link href="https://www.reddit.com/r/AskReddit/weird_url_format/"/>
-  </entry>
-</feed>
-"""
+
+def _listing(*posts) -> dict:
+    """Build a Reddit /top listing JSON body from (post_id, **overrides) specs."""
+    children = []
+    for spec in posts:
+        data = {
+            "id": spec["post_id"],
+            "title": spec.get("title", f"Title {spec['post_id']}"),
+            "permalink": spec.get("permalink", f"/r/AskReddit/comments/{spec['post_id']}/slug/"),
+            "selftext": spec.get("selftext", "A real story body long enough."),
+            "score": spec.get("score", 6000),
+            "over_18": spec.get("over_18", False),
+            "stickied": spec.get("stickied", False),
+        }
+        children.append({"kind": "t3", "data": data})
+    return {"kind": "Listing", "data": {"children": children}}
 
 
-def _detail_json(selftext="Full story body.", ups=6000, over_18=False):
-    return [
-        {
-            "data": {
-                "children": [
-                    {"data": {"selftext": selftext, "score": ups, "over_18": over_18}}
-                ]
-            }
-        },
-        {"data": {"children": []}},
-    ]
+class TestPermalinkUrl(unittest.TestCase):
+    def test_relative_path_becomes_absolute(self):
+        self.assertEqual(
+            drama_collector._permalink_url("/r/x/comments/abc/slug/"),
+            "https://www.reddit.com/r/x/comments/abc/slug/",
+        )
+
+    def test_absolute_url_passthrough(self):
+        self.assertEqual(
+            drama_collector._permalink_url("https://redd.it/abc"), "https://redd.it/abc"
+        )
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(drama_collector._permalink_url(""), "")
 
 
-class TestExtractPostId(unittest.TestCase):
-    def test_extracts_from_comments_link(self):
-        entry = {"link": "https://www.reddit.com/r/AskReddit/comments/abc123/title_slug/"}
-        self.assertEqual(drama_collector._extract_post_id(entry), "abc123")
+class TestParseListing(unittest.TestCase):
+    def test_parses_all_fields(self):
+        raw = _listing({"post_id": "abc111", "title": "AITA?", "selftext": "Body", "score": 7000})
+        posts = drama_collector.parse_listing(raw)
+        self.assertEqual(len(posts), 1)
+        p = posts[0]
+        self.assertEqual(p["post_id"], "abc111")
+        self.assertEqual(p["title"], "AITA?")
+        self.assertEqual(p["selftext"], "Body")
+        self.assertEqual(p["ups"], 7000)
+        self.assertFalse(p["over_18"])
+        self.assertIn("abc111", p["link"])
 
-    def test_extracts_from_fullname_id(self):
-        entry = {"id": "t3_xyz789", "link": ""}
-        self.assertEqual(drama_collector._extract_post_id(entry), "xyz789")
+    def test_skips_children_without_id(self):
+        raw = {"data": {"children": [{"data": {"title": "no id"}}]}}
+        self.assertEqual(drama_collector.parse_listing(raw), [])
 
-    def test_returns_none_when_unresolvable(self):
-        entry = {"link": "https://www.reddit.com/r/AskReddit/weird/", "id": "not-a-fullname"}
-        self.assertIsNone(drama_collector._extract_post_id(entry))
+    def test_malformed_shape_returns_empty(self):
+        self.assertEqual(drama_collector.parse_listing({"unexpected": True}), [])
+        self.assertEqual(drama_collector.parse_listing([]), [])
+        self.assertEqual(drama_collector.parse_listing(None), [])
 
-
-class TestParseRssEntries(unittest.TestCase):
-    def test_parses_valid_entries(self):
-        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
-        self.assertEqual(len(entries), 2)
-        self.assertEqual(entries[0]["post_id"], "abc111")
-        self.assertEqual(entries[1]["post_id"], "abc222")
-
-    def test_skips_entries_without_resolvable_post_id(self):
-        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
-        titles = [e["title"] for e in entries]
-        self.assertNotIn("Entry with no resolvable post id", titles)
-
-    def test_title_and_link_captured(self):
-        entries = drama_collector.parse_rss_entries(FIXTURE_RSS)
-        self.assertEqual(entries[0]["title"], "AITA for refusing to pay for the wedding?")
-        self.assertIn("abc111", entries[0]["link"])
-
-
-class TestParsePostDetail(unittest.TestCase):
-    def test_extracts_fields(self):
-        detail = drama_collector.parse_post_detail(_detail_json(selftext="Body", ups=7000))
-        self.assertEqual(detail["selftext"], "Body")
-        self.assertEqual(detail["ups"], 7000)
-        self.assertFalse(detail["over_18"])
-
-    def test_over_18_flag(self):
-        detail = drama_collector.parse_post_detail(_detail_json(over_18=True))
-        self.assertTrue(detail["over_18"])
-
-    def test_malformed_response_returns_none(self):
-        self.assertIsNone(drama_collector.parse_post_detail({"unexpected": "shape"}))
-
-    def test_empty_list_returns_none(self):
-        self.assertIsNone(drama_collector.parse_post_detail([]))
+    def test_over_18_and_stickied_flags(self):
+        raw = _listing(
+            {"post_id": "nsfw1", "over_18": True},
+            {"post_id": "pin1", "stickied": True},
+        )
+        posts = drama_collector.parse_listing(raw)
+        by_id = {p["post_id"]: p for p in posts}
+        self.assertTrue(by_id["nsfw1"]["over_18"])
+        self.assertTrue(by_id["pin1"]["stickied"])
 
 
-class TestRateLimiter(unittest.TestCase):
-    def test_second_call_waits_min_interval(self):
-        limiter = drama_collector._RateLimiter(min_interval=0.05)
-        start = time.monotonic()
-        limiter.wait()
-        limiter.wait()
-        elapsed = time.monotonic() - start
-        self.assertGreaterEqual(elapsed, 0.04)  # small tolerance for scheduler jitter
-
-
-class TestCollectSubreddit(unittest.TestCase):
-    """Integration-ish test: mocks the two network calls, exercises the real
-    dedupe + insert path against a temp DB."""
+class _DramaDBTest(unittest.TestCase):
+    """Base: fresh temp DB per test with migrations applied."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -123,138 +92,85 @@ class TestCollectSubreddit(unittest.TestCase):
         db.init_db()
         migrate.migrate_up()
 
-        self._rss_patch = patch.object(
-            drama_collector, "fetch_subreddit_rss",
-            return_value=[
-                {"post_id": "aaa", "title": "Story A", "link": "https://x/aaa", "summary": ""},
-                {"post_id": "bbb", "title": "Story B", "link": "https://x/bbb", "summary": ""},
-                {"post_id": "ccc", "title": "Story C (nsfw)", "link": "https://x/ccc", "summary": ""},
-                {"post_id": "ddd", "title": "Story D (low score)", "link": "https://x/ddd", "summary": ""},
-            ],
-        )
-        self._rss_patch.start()
-
-        def fake_detail(subreddit, post_id):
-            # Return the RAW reddit JSON shape (list of 2 listings), same as
-            # the real _fetch_post_json — exercises the real parse_post_detail()
-            # call inside collect_subreddit() instead of bypassing it.
-            raw = {
-                "aaa": _detail_json(selftext="Body A", ups=6000, over_18=False),
-                "bbb": _detail_json(selftext="Body B", ups=8000, over_18=False),
-                "ccc": _detail_json(selftext="Body C", ups=9000, over_18=True),
-                "ddd": _detail_json(selftext="Body D", ups=10, over_18=False),
-            }[post_id]
-            return raw
-
-        self._detail_patch = patch.object(drama_collector, "_fetch_post_json", side_effect=fake_detail)
-        self._detail_patch.start()
-
     def tearDown(self):
-        self._detail_patch.stop()
-        self._rss_patch.stop()
         self._patch.stop()
 
+
+class TestCollectSubreddit(_DramaDBTest):
+    def _run(self, posts, min_upvotes=5000, weight=1.0):
+        with patch.object(drama_collector, "fetch_subreddit_top", return_value=posts):
+            return drama_collector.collect_subreddit(
+                {"name": "AskReddit", "min_upvotes": min_upvotes, "weight": weight}
+            )
+
     def test_inserts_only_eligible_posts(self):
-        count = drama_collector.collect_subreddit(
-            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
-        )
-        self.assertEqual(count, 2)  # aaa + bbb; ccc is nsfw, ddd is below threshold
+        posts = drama_collector.parse_listing(_listing(
+            {"post_id": "aaa", "score": 6000},
+            {"post_id": "bbb", "score": 8000},
+            {"post_id": "ccc", "score": 9000, "over_18": True},   # nsfw
+            {"post_id": "ddd", "score": 10},                       # below threshold
+            {"post_id": "eee", "score": 9000, "stickied": True},   # pinned
+            {"post_id": "fff", "score": 9000, "selftext": "[removed]"},
+        ))
+        count = self._run(posts)
+        self.assertEqual(count, 2)  # aaa + bbb only
         pending = stories.get_pending(track="drama")
-        source_ids = {s["source_id"] for s in pending}
-        self.assertEqual(source_ids, {"reddit_aaa", "reddit_bbb"})
+        self.assertEqual({s["source_id"] for s in pending}, {"reddit_aaa", "reddit_bbb"})
 
     def test_metadata_stored(self):
-        drama_collector.collect_subreddit(
-            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.2}
-        )
-        pending = stories.get_pending(track="drama")
-        story = next(s for s in pending if s["source_id"] == "reddit_aaa")
+        posts = drama_collector.parse_listing(_listing({"post_id": "aaa", "score": 6000}))
+        self._run(posts, weight=1.2)
+        story = stories.get_pending(track="drama")[0]
         self.assertEqual(story["metadata"]["subreddit"], "AskReddit")
         self.assertEqual(story["metadata"]["upvotes"], 6000)
         self.assertEqual(story["metadata"]["weight"], 1.2)
+        self.assertIn("aaa", story["metadata"]["url"])
 
     def test_second_run_skips_duplicates(self):
-        first = drama_collector.collect_subreddit(
-            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
-        )
-        second = drama_collector.collect_subreddit(
-            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
-        )
+        posts = drama_collector.parse_listing(_listing(
+            {"post_id": "aaa", "score": 6000}, {"post_id": "bbb", "score": 8000},
+        ))
+        first = self._run(posts)
+        second = self._run(posts)
         self.assertEqual(first, 2)
         self.assertEqual(second, 0)
 
-    def test_fetch_post_json_raw_shape_is_actually_parsed(self):
-        # Regression test: _fetch_post_json returns Reddit's RAW JSON shape
-        # (a list of 2 listings), not a pre-parsed dict. collect_subreddit()
-        # must run it through parse_post_detail() itself — a prior version
-        # skipped that step and crashed with "list indices must be integers"
-        # on any real (non-mocked-as-a-dict) response.
-        with patch.object(
-            drama_collector, "_fetch_post_json",
-            return_value=_detail_json(selftext="Real body", ups=6000, over_18=False),
-        ):
+    def test_removed_and_deleted_bodies_skipped(self):
+        posts = drama_collector.parse_listing(_listing(
+            {"post_id": "r1", "score": 6000, "selftext": "[removed]"},
+            {"post_id": "d1", "score": 6000, "selftext": "[deleted]"},
+            {"post_id": "ok1", "score": 6000, "selftext": "Real body"},
+        ))
+        count = self._run(posts)
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            {s["source_id"] for s in stories.get_pending(track="drama")}, {"reddit_ok1"}
+        )
+
+    def test_end_to_end_through_client(self):
+        # Exercise the real fetch_subreddit_top → reddit_client.get_json path,
+        # mocking only the network boundary.
+        raw = _listing({"post_id": "zzz", "score": 6000, "selftext": "Body"})
+        with patch.object(drama_collector.reddit_client, "get_json", return_value=raw):
             count = drama_collector.collect_subreddit(
                 {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
             )
-        self.assertGreater(count, 0)
-
-
-class TestCollectSubredditRemovedPosts(unittest.TestCase):
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.dbpath = os.path.join(self.tmp, "test.db")
-        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
-        self._patch.start()
-        db.init_db()
-        migrate.migrate_up()
-
-        self._rss_patch = patch.object(
-            drama_collector, "fetch_subreddit_rss",
-            return_value=[
-                {"post_id": "removed1", "title": "Removed post", "link": "https://x/r1", "summary": ""},
-                {"post_id": "deleted1", "title": "Deleted post", "link": "https://x/d1", "summary": ""},
-                {"post_id": "ok1", "title": "Fine post", "link": "https://x/ok1", "summary": ""},
-            ],
-        )
-        self._rss_patch.start()
-
-        def fake_detail(subreddit, post_id):
-            selftext = {
-                "removed1": "[removed]",
-                "deleted1": "[deleted]",
-                "ok1": "A real story body",
-            }[post_id]
-            return _detail_json(selftext=selftext, ups=6000, over_18=False)
-
-        self._detail_patch = patch.object(drama_collector, "_fetch_post_json", side_effect=fake_detail)
-        self._detail_patch.start()
-
-    def tearDown(self):
-        self._detail_patch.stop()
-        self._rss_patch.stop()
-        self._patch.stop()
-
-    def test_removed_and_deleted_bodies_are_skipped(self):
-        count = drama_collector.collect_subreddit(
-            {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
-        )
         self.assertEqual(count, 1)
-        pending = stories.get_pending(track="drama")
-        self.assertEqual({s["source_id"] for s in pending}, {"reddit_ok1"})
+        self.assertEqual(
+            {s["source_id"] for s in stories.get_pending(track="drama")}, {"reddit_zzz"}
+        )
+
+    def test_blocked_source_returns_zero_not_crash(self):
+        # get_json returns None on a 403 block — collector must treat it as
+        # "0 stories", not raise.
+        with patch.object(drama_collector.reddit_client, "get_json", return_value=None):
+            count = drama_collector.collect_subreddit(
+                {"name": "AskReddit", "min_upvotes": 5000, "weight": 1.0}
+            )
+        self.assertEqual(count, 0)
 
 
-class TestCollectAllDrama(unittest.TestCase):
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.dbpath = os.path.join(self.tmp, "test.db")
-        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
-        self._patch.start()
-        db.init_db()
-        migrate.migrate_up()
-
-    def tearDown(self):
-        self._patch.stop()
-
+class TestCollectAllDrama(_DramaDBTest):
     def test_continues_after_one_subreddit_errors(self):
         def fake_collect(sub_config):
             if sub_config["name"] == "AmItheAsshole":
@@ -263,14 +179,9 @@ class TestCollectAllDrama(unittest.TestCase):
 
         with patch.object(drama_collector, "collect_subreddit", side_effect=fake_collect):
             total = drama_collector.collect_all_drama()
-        # 4 of 5 subreddits succeed with 1 each; AmItheAsshole raises and is skipped.
         self.assertEqual(total, 4)
 
     def test_raises_when_every_subreddit_fails(self):
-        # Regression test: a total outage (every subreddit call raises) must
-        # NOT look like a quiet "0 new stories" success — the caller (see
-        # __main__) only records collector_health success after this
-        # function returns normally, so this has to actually raise.
         with patch.object(
             drama_collector, "collect_subreddit",
             side_effect=RuntimeError("network blew up"),
@@ -285,7 +196,15 @@ class TestCollectAllDrama(unittest.TestCase):
             return 0
 
         with patch.object(drama_collector, "collect_subreddit", side_effect=fake_collect):
-            total = drama_collector.collect_all_drama()  # must not raise
+            total = drama_collector.collect_all_drama()
+        self.assertEqual(total, 0)
+
+    def test_all_blocked_returns_zero_without_raising(self):
+        # A 403 block makes every collect_subreddit return 0 (not raise), so
+        # collect_all_drama returns 0 and the staleness alert catches the outage
+        # — it must NOT raise here (raise is reserved for exceptions, not blocks).
+        with patch.object(drama_collector.reddit_client, "get_json", return_value=None):
+            total = drama_collector.collect_all_drama()
         self.assertEqual(total, 0)
 
 


### PR DESCRIPTION
Closes #78.

## Root cause

Reddit chặn quyết liệt mọi request **không xác thực** tới `www.reddit.com/*.json` và `.rss` (429/403), đặc biệt từ IP datacenter — chính sách của Reddit từ giữa 2023, không phải bug tạm thời. Triệu chứng trong issue (403 trên JSON detail, 429 trên RSS, ảnh hưởng cả track Drama lẫn track AI) đều là biểu hiện của việc này. User-Agent generic (`contact: admin@example.com`) càng làm tăng khả năng bị chặn vì Reddit yêu cầu UA duy nhất, mô tả rõ.

Con đường Reddit **chính thức hỗ trợ** là OAuth2 — nên fix đúng gốc là xác thực, không phải chỉ đổi header/thêm delay.

## Thay đổi

- **`collectors/reddit_client.py` (mới)** — single source of truth cho mọi truy cập Reddit, dùng chung bởi cả 2 collector:
  - OAuth app-only (`client_credentials` grant → `oauth.reddit.com`, ~100 req/phút) khi có `REDDIT_CLIENT_ID`/`SECRET`; fallback `www.reddit.com/<path>.json` khi chưa cấu hình (best-effort, cảnh báo 1 lần kèm hướng dẫn).
  - Token cache tới ~1 phút trước hạn, rate-limiter chung, User-Agent tuân thủ format Reddit.
  - Xử lý lỗi phân biệt: **429 tôn trọng `Retry-After`** (cap để giá trị điên không treo cron), **403 = chặn cứng không retry**, 401 refresh token 1 lần, 5xx/mạng backoff + retry.
  - Chỉ dùng stdlib — **không thêm dependency mới**.
- **`reddit_collector.py` (AI)** + **`reddit_drama_collector.py` (Drama)** đều route qua client.
- **Drama collector đổi kiến trúc:** thay RSS + N call detail cho từng post bằng **1 JSON `top` listing/subreddit** (score/selftext/over_18 có sẵn trong listing) → nhanh hơn nhiều, ít bị throttle, bỏ phụ thuộc `feedparser` ở collector này. Thêm skip post `stickied`.
- **`config.RSS_FEEDS`:** gỡ 2 feed reddit `.rss` trùng lặp (đã được `reddit_collector` cover qua đường JSON đã xác thực).
- Cấu hình mới trong `config.py` + `.env.example`, cập nhật `CLAUDE.md`.

## Consistency / Performance / Security

- **Consistency:** cả 2 track dùng chung 1 client (1 UA, 1 token cache, 1 rate limiter) — đúng nguyên tắc "single source of truth" của codebase.
- **Performance:** Drama collector từ 1-RSS-cộng-N-detail (~250s/run do rate-limit 2s/detail) → 1 request/subreddit.
- **Security:** credentials chỉ qua env var (không hardcode), Basic auth trên HTTPS TLS verify, không thêm dependency.

## Testing

- `tests/test_reddit_client.py` (mới): OAuth flow, token cache, fallback, 403 không retry, 429 + Retry-After (cả cap), 401 refresh, lỗi mạng.
- `tests/test_reddit_drama_collector.py` (viết lại): parse listing, lọc nsfw/stickied/removed/low-score/dedupe, end-to-end qua client, block trả 0 không crash.
- Toàn bộ 31 test Reddit pass. Các lỗi còn lại trong suite là do môi trường thiếu SDK `anthropic` (không liên quan thay đổi này).

## Lưu ý vận hành

Để bật OAuth: tạo app kiểu "script" tại https://www.reddit.com/prefs/apps rồi đặt `REDDIT_CLIENT_ID`/`REDDIT_CLIENT_SECRET` (+ tuỳ chọn `REDDIT_USER_AGENT` với username thật) trong `.env`. Không cấu hình thì pipeline vẫn chạy fallback nhưng vẫn có thể bị throttle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)