### PR TITLE
feat(#78): daily fresh HuggingFace import for timely drama stories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,10 +167,14 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   name=...&sort=TopDay` (một request/community, cùng shape parse như reddit
   drama). Lọc `nsfw`/`featured_*` (stickied)/`removed`/score < `LEMMY_MIN_SCORE`;
   `source_id` hash từ `ap_id` (dedupe xuyên instance). Story tiếng Anh → được
-  `drama_rewriter` Việt hoá như cũ. Bật mặc định (`LEMMY_ENABLED=1`); community
-  cấu hình qua `LEMMY_COMMUNITIES` ("name@instance", phẩy). Total outage raise
-  (như `collect_all_drama`). Chỉ stdlib. Chạy vào bước collect của `main_drama`
-  (cùng Reddit nếu bật).
+  `drama_rewriter` Việt hoá như cũ. Bật mặc định (`LEMMY_ENABLED=1`); mặc định
+  cào 3 community active `relationship_advice`/`aita`/`asklemmy`@lemmy.world (Lemmy
+  lưu lượng thấp hơn Reddit nhiều nên cào nhiều community để đủ story tươi), cấu
+  hình qua `LEMMY_COMMUNITIES` ("name@instance", phẩy); community 404 chỉ log +
+  bỏ qua (không fatal). Total outage (MỌI community fail) mới raise (như
+  `collect_all_drama`). Chỉ stdlib. **Lemmy là nguồn TƯƠI DUY NHẤT đáng tin** sau
+  khi Reddit đóng — không có dataset HF nào còn cập nhật (xem dưới). Chạy vào
+  bước collect của `main_drama`.
 - **`collectors/hf_drama_importer.py`** — nạp story từ dataset AITA công khai trên
   HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
   length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,17 +175,17 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
   length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override
   `HF_TITLE_FIELD`/`HF_BODY_FIELD`), phân trang ≤100 dòng/request, `source_id` từ
-  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **Hai chế độ:**
-  (1) **Daily FRESH** — `import_dataset(newest=True)` lấy các dòng MỚI NHẤT (đuôi
-  dataset: `offset = num_rows_total − limit`) từ dataset cập-nhật-mỗi-giờ (mặc
-  định `derek-thomas/dataset-creator-reddit-amitheasshole`); được gọi trong bước
-  collect của `main_drama` mỗi ngày (`HF_DRAMA_DAILY_ENABLED=1`, `HF_DAILY_LIMIT=30`)
-  cho tính "thời sự". Vì selector lấy story theo `created_at DESC` (mới-insert
-  trước), các dòng fresh này luôn được xử lý trước backlog cũ. Poll mỗi giờ vô
-  ích (kênh ~2 video/ngày, scorer ~20/ngày) nên chỉ chạy mỗi ngày. (2) **Deep
-  backfill** — CHẠY TAY cho kho tĩnh lớn: `python -m collectors.hf_drama_importer
-  --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500` (270K bài, 2013–2023).
-  *License:* dataset tái phân phối nội dung Reddit — kiểm tra terms từng dataset.
+  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **Vai trò HF =
+  BACKFILL số lượng, KHÔNG phải thời sự** — nguồn tươi là Lemmy (API sống). Đa số
+  dataset AITA "tự cập nhật" đã chết (vd `derek-thomas/...-amitheasshole` dừng ở
+  2023-12-04 ~2.5k dòng — Codex bắt ở PR #81), nên đừng trông cậy HF cho freshness.
+  **Deep backfill (chính):** `python -m collectors.hf_drama_importer --dataset
+  OsamaBsher/AITA-Reddit-Dataset --limit 500` (270K bài, 2013–2023). **`--newest`
+  (`import_dataset(newest=True)`):** lấy dòng MỚI NHẤT (đuôi: `offset =
+  num_rows_total − limit`) — dùng trong bước collect `main_drama` **nếu**
+  `HF_DRAMA_DAILY_ENABLED=1` (mặc định **0**, chỉ bật khi trỏ tới dataset ĐÃ xác
+  nhận còn cập nhật; không thì chỉ re-poll đuôi cũ). *License:* dataset tái phân
+  phối nội dung Reddit — kiểm tra terms từng dataset.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
@@ -375,11 +375,12 @@ multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
 - **`main_drama.py`** — orchestrator: collect → score → rewrite → render
   (TTS voice drama + `compose_drama_video`) → push review. **Bước collect (follow-up
   #78) gọi nhiều nguồn độc lập, best-effort (một nguồn lỗi không kéo cả bước):
-  Reddit (tắt mặc định), Lemmy (`collect_all_lemmy`), và HF daily-fresh
-  (`import_dataset(newest=True)` nếu `HF_DRAMA_DAILY_ENABLED`). Seed thủ công
-  (`seed_bot`) vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.**
-  Chọn story theo `created_at DESC` nên nội dung fresh (Lemmy/HF-newest hôm nay)
-  luôn được ưu tiên trước backlog cũ. Resume: trạng
+  Reddit (tắt mặc định), Lemmy (`collect_all_lemmy` — nguồn TƯƠI chính), và HF
+  `--newest` (`import_dataset(newest=True)` CHỈ khi `HF_DRAMA_DAILY_ENABLED=1`,
+  mặc định off; HF là backfill, không phải thời sự). Seed thủ công (`seed_bot`)
+  vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.** Chọn story
+  theo `created_at DESC` nên nội dung tươi (Lemmy hôm nay) luôn được ưu tiên
+  trước backlog cũ. Resume: trạng
   thái nằm hết trong DB; video row được insert TRƯỚC khi render (gắn
   `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
   row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,15 +171,21 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   cấu hình qua `LEMMY_COMMUNITIES` ("name@instance", phẩy). Total outage raise
   (như `collect_all_drama`). Chỉ stdlib. Chạy vào bước collect của `main_drama`
   (cùng Reddit nếu bật).
-- **`collectors/hf_drama_importer.py`** — nạp BULK từ dataset AITA công khai trên
-  HuggingFace (vd `OsamaBsher/AITA-Reddit-Dataset` 270K bài) qua **datasets-server
-  REST API** (`/rows?dataset&config&split&offset&length`, stdlib — không cần lib
-  `datasets`). Tự dò cột title/body (override `HF_TITLE_FIELD`/`HF_BODY_FIELD`),
-  phân trang ≤100 dòng/request, `source_id` từ id dataset hoặc hash title+body
-  (idempotent, re-run bỏ trùng). **Công cụ CHẠY TAY** (không cron — 270K dòng
-  không nạp mỗi ngày): `python -m collectors.hf_drama_importer --limit 200`.
-  *License:* dataset tái phân phối nội dung Reddit — pipeline biến đổi mạnh thì
-  ổn, nhưng kiểm tra terms từng dataset.
+- **`collectors/hf_drama_importer.py`** — nạp story từ dataset AITA công khai trên
+  HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
+  length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override
+  `HF_TITLE_FIELD`/`HF_BODY_FIELD`), phân trang ≤100 dòng/request, `source_id` từ
+  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **Hai chế độ:**
+  (1) **Daily FRESH** — `import_dataset(newest=True)` lấy các dòng MỚI NHẤT (đuôi
+  dataset: `offset = num_rows_total − limit`) từ dataset cập-nhật-mỗi-giờ (mặc
+  định `derek-thomas/dataset-creator-reddit-amitheasshole`); được gọi trong bước
+  collect của `main_drama` mỗi ngày (`HF_DRAMA_DAILY_ENABLED=1`, `HF_DAILY_LIMIT=30`)
+  cho tính "thời sự". Vì selector lấy story theo `created_at DESC` (mới-insert
+  trước), các dòng fresh này luôn được xử lý trước backlog cũ. Poll mỗi giờ vô
+  ích (kênh ~2 video/ngày, scorer ~20/ngày) nên chỉ chạy mỗi ngày. (2) **Deep
+  backfill** — CHẠY TAY cho kho tĩnh lớn: `python -m collectors.hf_drama_importer
+  --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500` (270K bài, 2013–2023).
+  *License:* dataset tái phân phối nội dung Reddit — kiểm tra terms từng dataset.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
@@ -367,10 +373,13 @@ multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
   đường dẫn. `publisher/tiktok_manual.export_for_manual_upload` giờ chỉ là
   fallback lưu file gốc, không còn là đường chính.
 - **`main_drama.py`** — orchestrator: collect → score → rewrite → render
-  (TTS voice drama + `compose_drama_video`) → push review. **Bước collect nguồn
-  chính là seed thủ công (follow-up #78): Reddit tắt mặc định nên `collect` trả
-  0 an toàn — score/rewrite/render đọc thẳng bảng `stories` nên seed từ
-  `seed_bot` (/seed_vn, /seed_url) chảy qua nguyên vẹn.** Resume: trạng
+  (TTS voice drama + `compose_drama_video`) → push review. **Bước collect (follow-up
+  #78) gọi nhiều nguồn độc lập, best-effort (một nguồn lỗi không kéo cả bước):
+  Reddit (tắt mặc định), Lemmy (`collect_all_lemmy`), và HF daily-fresh
+  (`import_dataset(newest=True)` nếu `HF_DRAMA_DAILY_ENABLED`). Seed thủ công
+  (`seed_bot`) vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.**
+  Chọn story theo `created_at DESC` nên nội dung fresh (Lemmy/HF-newest hôm nay)
+  luôn được ưu tiên trước backlog cũ. Resume: trạng
   thái nằm hết trong DB; video row được insert TRƯỚC khi render (gắn
   `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
   row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,15 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   lưu lượng thấp hơn Reddit nhiều nên cào nhiều community để đủ story tươi), cấu
   hình qua `LEMMY_COMMUNITIES` ("name@instance", phẩy); community 404 chỉ log +
   bỏ qua (không fatal). Total outage (MỌI community fail) mới raise (như
-  `collect_all_drama`). Chỉ stdlib. **Lemmy là nguồn TƯƠI DUY NHẤT đáng tin** sau
-  khi Reddit đóng — không có dataset HF nào còn cập nhật (xem dưới). Chạy vào
-  bước collect của `main_drama`.
+  `collect_all_drama`). **Hai chế độ:** (1) *body-story* (mặc định, `relationship_
+  advice`/`aita`) — body bài LÀ story; (2) *Q&A / AskReddit-style* (community
+  trong `LEMMY_QA_COMMUNITIES`, mặc định `asklemmy`) — giá trị nằm ở COMMENTS, nên
+  gọi thêm `/api/v3/comment/list?sort=Top&max_depth=1`, ghép "câu hỏi + top câu
+  trả lời" thành story (`metadata.format='qa'`); lọc comment theo score/độ dài,
+  cần ≥`LEMMY_QA_MIN_COMMENTS`, cap `_MAX_QA_POSTS_PER_RUN` post/community để giới
+  hạn số request. Chỉ stdlib. **Lemmy là nguồn TƯƠI DUY NHẤT đáng tin** sau khi
+  Reddit đóng — không có dataset HF nào còn cập nhật (xem dưới). Chạy vào bước
+  collect của `main_drama`.
 - **`collectors/hf_drama_importer.py`** — nạp story từ dataset AITA công khai trên
   HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
   length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -45,6 +45,13 @@ LEMMY_INSTANCE=https://lemmy.world
 # Curated active drama/story communities; add/trim freely ("name@instance").
 LEMMY_COMMUNITIES=relationship_advice@lemmy.world,aita@lemmy.world,asklemmy@lemmy.world
 LEMMY_MIN_SCORE=10
+# AskReddit-style communities: the collector builds "question + top answers"
+# stories from these (the answers are the content, not the post body).
+LEMMY_QA_COMMUNITIES=asklemmy@lemmy.world
+LEMMY_QA_TOP_COMMENTS=6       # answers included per story
+LEMMY_QA_MIN_COMMENTS=2       # min good answers to keep a story
+LEMMY_QA_MIN_COMMENT_SCORE=3
+LEMMY_QA_MIN_COMMENT_CHARS=30
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---
 # Seeds the stories table from a public AITA/relationship dataset via the HF

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -47,23 +47,25 @@ LEMMY_MIN_SCORE=10
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---
 # Seeds the stories table from a public AITA/relationship dataset via the HF
-# datasets-server REST API (stdlib only). Two modes:
-#  * Daily FRESH (default): main_drama pulls the newest HF_DAILY_LIMIT rows each
-#    run from the ~hourly-updated dataset below — for timeliness ("thời sự").
-#    Hourly polling is pointless; daily is plenty (~2 videos/day are produced).
-#  * One-off DEEP backfill (manual): a big static cushion, e.g.
-#      python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
-# Verify a new dataset once (columns auto-detect; a 404 means wrong config/split):
+# datasets-server REST API (stdlib only). HF's reliable role is VOLUME/backfill,
+# NOT timeliness — timely stories come from Lemmy (a live API). Most
+# "auto-updating" AITA datasets have gone stale, so don't rely on HF for freshness.
+#
+# Typical use = one-off DEEP backfill cushion:
+#   python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
+# Verify a dataset once (columns auto-detect; a 404 means wrong config/split):
 #   python -m collectors.hf_drama_importer --limit 3
 # LICENSE: these redistribute Reddit content — check the dataset's terms.
-HF_DRAMA_DATASET=derek-thomas/dataset-creator-reddit-amitheasshole
+HF_DRAMA_DATASET=OsamaBsher/AITA-Reddit-Dataset
 HF_DRAMA_CONFIG=default
 HF_DRAMA_SPLIT=train
 HF_IMPORT_LIMIT=200
 # HF_TITLE_FIELD=      # leave empty to auto-detect
 # HF_BODY_FIELD=       # leave empty to auto-detect
-# Daily fresh auto-import inside main_drama's collect step (newest rows):
-HF_DRAMA_DAILY_ENABLED=1
+# Optional daily `--newest` auto-import in main_drama's collect step. OFF by
+# default — enable ONLY if HF_DRAMA_DATASET points at a dataset you've confirmed
+# is still updating (else it re-polls a stale tail). Timeliness = Lemmy, not this.
+HF_DRAMA_DAILY_ENABLED=0
 HF_DAILY_LIMIT=30
 
 # --- Pexels (free stock video backgrounds) ---

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -42,7 +42,8 @@ DRAMA_BACKLOG_MIN=3
 # Communities are "name@instance", comma-separated; add more for volume.
 LEMMY_ENABLED=1
 LEMMY_INSTANCE=https://lemmy.world
-LEMMY_COMMUNITIES=relationship_advice@lemmy.world
+# Curated active drama/story communities; add/trim freely ("name@instance").
+LEMMY_COMMUNITIES=relationship_advice@lemmy.world,aita@lemmy.world,asklemmy@lemmy.world
 LEMMY_MIN_SCORE=10
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -46,17 +46,25 @@ LEMMY_COMMUNITIES=relationship_advice@lemmy.world
 LEMMY_MIN_SCORE=10
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---
-# One-off bulk seeding from a public AITA/relationship dataset via the HF
-# datasets-server REST API (stdlib only). Run MANUALLY, not on a cron:
-#   python -m collectors.hf_drama_importer --limit 200
-# Title/body columns auto-detect; override only if a dataset uses odd names.
+# Seeds the stories table from a public AITA/relationship dataset via the HF
+# datasets-server REST API (stdlib only). Two modes:
+#  * Daily FRESH (default): main_drama pulls the newest HF_DAILY_LIMIT rows each
+#    run from the ~hourly-updated dataset below — for timeliness ("thời sự").
+#    Hourly polling is pointless; daily is plenty (~2 videos/day are produced).
+#  * One-off DEEP backfill (manual): a big static cushion, e.g.
+#      python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
+# Verify a new dataset once (columns auto-detect; a 404 means wrong config/split):
+#   python -m collectors.hf_drama_importer --limit 3
 # LICENSE: these redistribute Reddit content — check the dataset's terms.
-HF_DRAMA_DATASET=OsamaBsher/AITA-Reddit-Dataset
+HF_DRAMA_DATASET=derek-thomas/dataset-creator-reddit-amitheasshole
 HF_DRAMA_CONFIG=default
 HF_DRAMA_SPLIT=train
 HF_IMPORT_LIMIT=200
 # HF_TITLE_FIELD=      # leave empty to auto-detect
 # HF_BODY_FIELD=       # leave empty to auto-detect
+# Daily fresh auto-import inside main_drama's collect step (newest rows):
+HF_DRAMA_DAILY_ENABLED=1
+HF_DAILY_LIMIT=30
 
 # --- Pexels (free stock video backgrounds) ---
 PEXELS_API_KEY=...

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -93,6 +93,12 @@ def _fetch_rows(dataset: str, cfg: str, split: str, offset: int, length: int) ->
     raise HFImportError(f"failed to fetch rows at offset {offset}: {last_error}")
 
 
+def _dataset_size(dataset: str, cfg: str, split: str) -> int:
+    """Total row count of a dataset split (a tiny 1-row probe). 0 if unknown."""
+    page = _fetch_rows(dataset, cfg, split, 0, 1)
+    return int(page.get("num_rows_total") or 0)
+
+
 def _pick_column(columns: list[str], override: str, candidates: list[str]) -> str | None:
     """Choose a column: explicit override if valid, else first present candidate."""
     if override:
@@ -121,12 +127,24 @@ def _row_source_id(dataset: str, row: dict, id_field: str | None, title: str, bo
 
 def import_dataset(dataset: str | None = None, config_name: str | None = None,
                    split: str | None = None, limit: int | None = None,
-                   offset: int = 0) -> int:
-    """Import up to `limit` rows into `stories` (track='drama'). Returns new count."""
+                   offset: int = 0, newest: bool = False) -> int:
+    """Import up to `limit` rows into `stories` (track='drama'). Returns new count.
+
+    newest=True pulls from the TAIL of the dataset (offset = num_rows_total -
+    limit) instead of the head — for append-updated datasets (e.g. the hourly
+    AITA dataset) the tail is the freshest content, which is what "thời sự"
+    wants. It costs one extra 1-row probe to learn the size.
+    """
     dataset = dataset or config.HF_DRAMA_DATASET
     cfg = config_name or config.HF_DRAMA_CONFIG
     split = split or config.HF_DRAMA_SPLIT
     limit = config.HF_IMPORT_LIMIT if limit is None else limit
+
+    if newest:
+        total = _dataset_size(dataset, cfg, split)
+        offset = max(0, total - limit)
+        logger.info("HF --newest: %s has %d rows → importing from offset %d",
+                    dataset, total, offset)
 
     first = _fetch_rows(dataset, cfg, split, offset, min(_PAGE, limit))
     columns = [f["name"] for f in first.get("features", []) if isinstance(f, dict) and "name" in f]
@@ -200,6 +218,8 @@ if __name__ == "__main__":
     parser.add_argument("--split", default=None, help="dataset split (default train)")
     parser.add_argument("--limit", type=int, default=None, help="max rows to import")
     parser.add_argument("--offset", type=int, default=0, help="start row offset")
+    parser.add_argument("--newest", action="store_true",
+                        help="import the newest rows (tail) instead of from --offset")
     args = parser.parse_args()
 
     from storage.database import init_db
@@ -207,4 +227,5 @@ if __name__ == "__main__":
     init_db()
     migrate_up()
     import_dataset(dataset=args.dataset, config_name=args.config_name,
-                   split=args.split, limit=args.limit, offset=args.offset)
+                   split=args.split, limit=args.limit, offset=args.offset,
+                   newest=args.newest)

--- a/content-pipeline/collectors/lemmy_drama_collector.py
+++ b/content-pipeline/collectors/lemmy_drama_collector.py
@@ -105,15 +105,16 @@ def parse_listing(raw_json) -> list[dict]:
     return posts
 
 
-def _fetch_community(community: str, sort: str = "TopDay") -> dict | None:
-    """GET one community's listing. Returns parsed JSON, or None after retries."""
-    query = urlencode({
-        "community_name": community,
-        "sort": sort,
-        "limit": LISTING_LIMIT,
-        "type_": "All",
-    })
-    url = f"{config.LEMMY_INSTANCE}/api/v3/post/list?{query}"
+# Cap how many posts per Q&A community we fetch comments for (bounds requests —
+# each Q&A post costs one extra comment-list call).
+_MAX_QA_POSTS_PER_RUN = 20
+
+
+def _get_json(url: str, label: str) -> dict | None:
+    """GET a Lemmy JSON endpoint with retry. Returns parsed JSON, or None.
+
+    404 (community/post gone) returns None without burning retries.
+    """
     last_error = None
     for attempt in range(config.LEMMY_MAX_RETRIES):
         req = Request(url)
@@ -124,22 +125,93 @@ def _fetch_community(community: str, sort: str = "TopDay") -> dict | None:
                 return json.loads(resp.read().decode("utf-8", errors="replace"))
         except HTTPError as e:
             last_error = e
-            # 404 = community doesn't exist on this instance — retrying won't help.
             if e.code == 404:
-                logger.warning("Lemmy community %s not found (404) on %s",
-                               community, config.LEMMY_INSTANCE)
+                logger.warning("Lemmy 404 for %s on %s", label, config.LEMMY_INSTANCE)
                 return None
             logger.warning("Lemmy HTTP %s for %s (attempt %d/%d)",
-                           e.code, community, attempt + 1, config.LEMMY_MAX_RETRIES)
+                           e.code, label, attempt + 1, config.LEMMY_MAX_RETRIES)
         except (URLError, TimeoutError, json.JSONDecodeError) as e:
             last_error = e
             logger.warning("Lemmy request error for %s (attempt %d/%d): %s",
-                           community, attempt + 1, config.LEMMY_MAX_RETRIES, e)
+                           label, attempt + 1, config.LEMMY_MAX_RETRIES, e)
         if attempt < config.LEMMY_MAX_RETRIES - 1:
             time.sleep(2 ** (attempt + 1))
     logger.error("Lemmy fetch failed for %s after %d attempts: %s",
-                 community, config.LEMMY_MAX_RETRIES, last_error)
+                 label, config.LEMMY_MAX_RETRIES, last_error)
     return None
+
+
+def _fetch_community(community: str, sort: str = "TopDay") -> dict | None:
+    """GET one community's listing. Returns parsed JSON, or None after retries."""
+    query = urlencode({
+        "community_name": community, "sort": sort,
+        "limit": LISTING_LIMIT, "type_": "All",
+    })
+    return _get_json(f"{config.LEMMY_INSTANCE}/api/v3/post/list?{query}", f"community {community}")
+
+
+def _fetch_comments(post_id) -> dict | None:
+    """GET a post's top-level comments (max_depth=1, sorted Top). None on failure."""
+    query = urlencode({
+        "post_id": post_id, "sort": "Top",
+        "limit": config.LEMMY_QA_TOP_COMMENTS * 3, "max_depth": 1, "type_": "All",
+    })
+    return _get_json(f"{config.LEMMY_INSTANCE}/api/v3/comment/list?{query}", f"comments {post_id}")
+
+
+def parse_comments(raw_json) -> list[dict]:
+    """Extract {content, score, removed} from a /comment/list response. Pure."""
+    try:
+        raw = raw_json["comments"]
+    except (KeyError, TypeError):
+        return []
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for cv in raw:
+        if not isinstance(cv, dict):
+            continue
+        c = cv.get("comment", {}) or {}
+        counts = cv.get("counts", {}) or {}
+        out.append({
+            "content": (c.get("content") or "").strip(),
+            "score": counts.get("score", 0) or 0,
+            "removed": bool(c.get("removed", False) or c.get("deleted", False)),
+        })
+    return out
+
+
+def fetch_top_comments(post_id) -> list[str] | None:
+    """Top answers for a post: filtered, best-first. None if the fetch failed.
+
+    Comments come Top-sorted from the API, so the first ones that pass the
+    quality filters are the highest-scored.
+    """
+    raw = _fetch_comments(post_id)
+    if raw is None:
+        return None
+    good: list[str] = []
+    for c in parse_comments(raw):
+        if c["removed"] or c["content"] in _REMOVED_SENTINELS:
+            continue
+        if c["score"] < config.LEMMY_QA_MIN_COMMENT_SCORE:
+            continue
+        if len(c["content"]) < config.LEMMY_QA_MIN_COMMENT_CHARS:
+            continue
+        good.append(c["content"])
+        if len(good) >= config.LEMMY_QA_TOP_COMMENTS:
+            break
+    return good
+
+
+def _build_qa_content(title: str, body: str, answers: list[str]) -> str:
+    """Assemble "question (+ optional body) + selected answers" into raw content."""
+    parts = [title.strip()]
+    body = body.strip()
+    if body and body not in _REMOVED_SENTINELS:
+        parts.append(body)
+    parts.extend(answers)
+    return "\n\n".join(p for p in parts if p)
 
 
 def fetch_community_top(community: str) -> list[dict]:
@@ -156,9 +228,25 @@ def fetch_community_top(community: str) -> list[dict]:
     return posts
 
 
+def _is_qa_community(community: str) -> bool:
+    """True if `community` is an AskReddit-style (comments-are-the-story) source."""
+    return community in config.LEMMY_QA_COMMUNITIES
+
+
 def collect_community(community: str) -> int:
-    """Collect eligible posts from one community into `stories`. Returns new count."""
+    """Collect eligible posts from one community into `stories`. Returns new count.
+
+    AskReddit-style communities (config.LEMMY_QA_COMMUNITIES) go through the Q&A
+    path (question + top comments); everything else is body-story mode.
+    """
     posts = fetch_community_top(community)
+    if _is_qa_community(community):
+        return _collect_qa(community, posts)
+    return _collect_stories(community, posts)
+
+
+def _collect_stories(community: str, posts: list[dict]) -> int:
+    """Body-story mode: the post body IS the story (relationship_advice, aita)."""
     count = 0
     skipped_dup = skipped_nsfw = skipped_low = skipped_removed = skipped_stickied = skipped_empty = 0
 
@@ -174,8 +262,8 @@ def collect_community(community: str) -> int:
             continue
         body = post["body"].strip()
         if not body or body in _REMOVED_SENTINELS or post["removed"]:
-            # Lemmy relationship/story posts live in the body; a link-only or
-            # removed post has nothing to narrate.
+            # Story posts live in the body; a link-only or removed post has
+            # nothing to narrate.
             skipped_removed += 1 if (body in _REMOVED_SENTINELS or post["removed"]) else 0
             skipped_empty += 1 if not body else 0
             continue
@@ -184,16 +272,9 @@ def collect_community(community: str) -> int:
             continue
 
         insert_story(
-            source="lemmy",
-            source_id=post["source_id"],
-            raw_content=body,
-            track="drama",
-            title=post["title"],
-            metadata={
-                "community": community,
-                "score": post["score"],
-                "url": post["url"],
-            },
+            source="lemmy", source_id=post["source_id"], raw_content=body,
+            track="drama", title=post["title"],
+            metadata={"community": community, "score": post["score"], "url": post["url"]},
         )
         count += 1
 
@@ -205,6 +286,61 @@ def collect_community(community: str) -> int:
             skipped_removed, skipped_stickied, skipped_empty,
         )
     logger.info("Collected %d new drama stories from Lemmy %s", count, community)
+    return count
+
+
+def _collect_qa(community: str, posts: list[dict]) -> int:
+    """Q&A mode: assemble question + top comments (AskReddit-style)."""
+    count = 0
+    processed = 0
+    skipped_dup = skipped_nsfw = skipped_low = skipped_stickied = skipped_thin = 0
+
+    for post in posts:
+        if processed >= _MAX_QA_POSTS_PER_RUN:
+            break
+        if post["stickied"]:
+            skipped_stickied += 1
+            continue
+        if post["nsfw"]:
+            skipped_nsfw += 1
+            continue
+        if post["score"] < config.LEMMY_MIN_SCORE:
+            skipped_low += 1
+            continue
+        if dedupe_check(post["source_id"]):
+            skipped_dup += 1
+            continue
+
+        # Q&A posts don't need a body — the answers are the content.
+        answers = fetch_top_comments(post["id"])
+        processed += 1
+        if answers is None:
+            continue  # comment fetch failed for this post; skip, keep going
+        if len(answers) < config.LEMMY_QA_MIN_COMMENTS:
+            skipped_thin += 1  # not enough good answers to make a story
+            continue
+
+        insert_story(
+            source="lemmy",
+            source_id=post["source_id"],
+            raw_content=_build_qa_content(post["title"], post["body"], answers),
+            track="drama",
+            title=post["title"],
+            metadata={
+                "community": community, "score": post["score"], "url": post["url"],
+                "format": "qa", "num_answers": len(answers),
+            },
+        )
+        count += 1
+
+    if any((skipped_dup, skipped_nsfw, skipped_low, skipped_stickied, skipped_thin)):
+        logger.info(
+            "Lemmy %s (Q&A) skipped: %d dup, %d nsfw, %d below %d score, "
+            "%d stickied, %d too-few-answers",
+            community, skipped_dup, skipped_nsfw, skipped_low, config.LEMMY_MIN_SCORE,
+            skipped_stickied, skipped_thin,
+        )
+    logger.info("Collected %d new Q&A drama stories from Lemmy %s", count, community)
     return count
 
 

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -315,28 +315,26 @@ LEMMY_MAX_RETRIES = int(os.getenv("LEMMY_MAX_RETRIES", "3"))
 # datasets-server REST API (stdlib only, no `datasets` dependency). Title/body
 # columns are auto-detected; override if a dataset uses odd names.
 #
-# TWO use modes, one dataset knob:
-#  * Daily FRESH (timeliness): the default dataset is updated ~hourly, so a daily
-#    `--newest` pull (folded into main_drama's collect step, HF_DRAMA_DAILY_ENABLED)
-#    grabs the most recent stories — as close to "thời sự" as we get without
-#    Reddit approval. Because story selection is newest-inserted-first, these
-#    fresh rows are always processed ahead of any older backlog.
-#  * One-off DEEP backfill: for a big static cushion, run the tool manually
-#    against a large dump, e.g.
-#      python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
-HF_DRAMA_DATASET = os.getenv(
-    "HF_DRAMA_DATASET", "derek-thomas/dataset-creator-reddit-amitheasshole"
-)
+# HF's reliable role is VOLUME/backfill, NOT timeliness. Most "auto-updating"
+# AITA datasets have gone stale (e.g. derek-thomas/...-amitheasshole stopped at
+# 2023-12-04, ~2.5k rows — Codex review on PR #81), so a daily `--newest` poll of
+# them just re-imports the same old tail. Timeliness ("thời sự") comes from
+# Lemmy (a live API), not HF. Default here is therefore the big STATIC dump, used
+# for a one-off deep backfill cushion:
+#   python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
+HF_DRAMA_DATASET = os.getenv("HF_DRAMA_DATASET", "OsamaBsher/AITA-Reddit-Dataset")
 HF_DRAMA_CONFIG = os.getenv("HF_DRAMA_CONFIG", "default")
 HF_DRAMA_SPLIT = os.getenv("HF_DRAMA_SPLIT", "train")
 HF_IMPORT_LIMIT = int(os.getenv("HF_IMPORT_LIMIT", "200"))  # default for the manual tool
 HF_TITLE_FIELD = os.getenv("HF_TITLE_FIELD", "")   # "" = auto-detect
 HF_BODY_FIELD = os.getenv("HF_BODY_FIELD", "")     # "" = auto-detect
 HF_TIMEOUT = int(os.getenv("HF_TIMEOUT", "30"))
-# Daily fresh auto-import (runs inside main_drama's collect step). Pulls the
-# NEWEST HF_DAILY_LIMIT rows each day — hourly polling is pointless (the channel
-# makes ~2 videos/day and the scorer handles ~20/day), so daily is plenty.
-HF_DRAMA_DAILY_ENABLED = os.getenv("HF_DRAMA_DAILY_ENABLED", "1") == "1"
+# Optional daily `--newest` auto-import inside main_drama's collect step. OFF by
+# default: only worth enabling if you point HF_DRAMA_DATASET at a dataset you've
+# CONFIRMED is still being updated (otherwise it re-polls a stale tail and adds
+# nothing). Even then, daily is plenty — hourly polling is pointless (the channel
+# makes ~2 videos/day, the scorer handles ~20/day).
+HF_DRAMA_DAILY_ENABLED = os.getenv("HF_DRAMA_DAILY_ENABLED", "0") == "1"
 HF_DAILY_LIMIT = int(os.getenv("HF_DAILY_LIMIT", "30"))
 
 # Drama backlog alert (issue #78 follow-up). With Reddit off by default, the

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -316,6 +316,21 @@ LEMMY_USER_AGENT = os.getenv(
 )
 LEMMY_TIMEOUT = int(os.getenv("LEMMY_TIMEOUT", "15"))
 LEMMY_MAX_RETRIES = int(os.getenv("LEMMY_MAX_RETRIES", "3"))
+# AskReddit-style (Q&A) communities: here the value is in the TOP COMMENTS
+# (answers), not the post body — like the "câu hỏi + tuyển câu trả lời" threads
+# that VN pages repost. For a community in this set, the collector fetches a
+# post's top comments and assembles "question + selected answers" into a story;
+# other communities (relationship_advice/aita) stay body-story mode. asklemmy is
+# lower-traffic than r/AskReddit, so expect thinner volume.
+LEMMY_QA_COMMUNITIES = [
+    c.strip() for c in os.getenv(
+        "LEMMY_QA_COMMUNITIES", "asklemmy@lemmy.world"
+    ).split(",") if c.strip()
+]
+LEMMY_QA_TOP_COMMENTS = int(os.getenv("LEMMY_QA_TOP_COMMENTS", "6"))       # answers per story
+LEMMY_QA_MIN_COMMENTS = int(os.getenv("LEMMY_QA_MIN_COMMENTS", "2"))       # min answers to keep
+LEMMY_QA_MIN_COMMENT_SCORE = int(os.getenv("LEMMY_QA_MIN_COMMENT_SCORE", "3"))
+LEMMY_QA_MIN_COMMENT_CHARS = int(os.getenv("LEMMY_QA_MIN_COMMENT_CHARS", "30"))
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---
 # Seeds the stories table from a public AITA/relationship dataset via the HF

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -311,17 +311,33 @@ LEMMY_TIMEOUT = int(os.getenv("LEMMY_TIMEOUT", "15"))
 LEMMY_MAX_RETRIES = int(os.getenv("LEMMY_MAX_RETRIES", "3"))
 
 # --- HuggingFace drama dataset import (issue #78 follow-up) ---
-# One-off bulk seeding of the stories table from a public AITA/relationship
-# dataset via the HuggingFace datasets-server REST API (stdlib only, no
-# `datasets` dependency). Run manually: python -m collectors.hf_drama_importer.
-# Title/body columns are auto-detected; override if a dataset uses odd names.
-HF_DRAMA_DATASET = os.getenv("HF_DRAMA_DATASET", "OsamaBsher/AITA-Reddit-Dataset")
+# Seeds the stories table from a public AITA/relationship dataset via the HF
+# datasets-server REST API (stdlib only, no `datasets` dependency). Title/body
+# columns are auto-detected; override if a dataset uses odd names.
+#
+# TWO use modes, one dataset knob:
+#  * Daily FRESH (timeliness): the default dataset is updated ~hourly, so a daily
+#    `--newest` pull (folded into main_drama's collect step, HF_DRAMA_DAILY_ENABLED)
+#    grabs the most recent stories — as close to "thời sự" as we get without
+#    Reddit approval. Because story selection is newest-inserted-first, these
+#    fresh rows are always processed ahead of any older backlog.
+#  * One-off DEEP backfill: for a big static cushion, run the tool manually
+#    against a large dump, e.g.
+#      python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
+HF_DRAMA_DATASET = os.getenv(
+    "HF_DRAMA_DATASET", "derek-thomas/dataset-creator-reddit-amitheasshole"
+)
 HF_DRAMA_CONFIG = os.getenv("HF_DRAMA_CONFIG", "default")
 HF_DRAMA_SPLIT = os.getenv("HF_DRAMA_SPLIT", "train")
-HF_IMPORT_LIMIT = int(os.getenv("HF_IMPORT_LIMIT", "200"))
+HF_IMPORT_LIMIT = int(os.getenv("HF_IMPORT_LIMIT", "200"))  # default for the manual tool
 HF_TITLE_FIELD = os.getenv("HF_TITLE_FIELD", "")   # "" = auto-detect
 HF_BODY_FIELD = os.getenv("HF_BODY_FIELD", "")     # "" = auto-detect
 HF_TIMEOUT = int(os.getenv("HF_TIMEOUT", "30"))
+# Daily fresh auto-import (runs inside main_drama's collect step). Pulls the
+# NEWEST HF_DAILY_LIMIT rows each day — hourly polling is pointless (the channel
+# makes ~2 videos/day and the scorer handles ~20/day), so daily is plenty.
+HF_DRAMA_DAILY_ENABLED = os.getenv("HF_DRAMA_DAILY_ENABLED", "1") == "1"
+HF_DAILY_LIMIT = int(os.getenv("HF_DAILY_LIMIT", "30"))
 
 # Drama backlog alert (issue #78 follow-up). With Reddit off by default, the
 # Drama channel is fed by manual seeds — so the meaningful health signal is "not

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -298,9 +298,16 @@ DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "5"))
 # lower than Reddit, so the score bar is modest.
 LEMMY_ENABLED = os.getenv("LEMMY_ENABLED", "1") == "1"
 LEMMY_INSTANCE = os.getenv("LEMMY_INSTANCE", "https://lemmy.world").rstrip("/")
+# Curated set of active drama/story communities on lemmy.world. Lemmy volume is
+# far lower than Reddit, so we pull from several to keep enough fresh stories.
+# relationship_advice + aita carry story bodies; asklemmy is the highest-traffic
+# community (many posts are question-only and get skipped by the empty-body
+# filter, but its story-ish posts add variety). A community that 404s is logged
+# and skipped, not fatal — trim any that stay noisy in your logs.
 LEMMY_COMMUNITIES = [
     c.strip() for c in os.getenv(
-        "LEMMY_COMMUNITIES", "relationship_advice@lemmy.world"
+        "LEMMY_COMMUNITIES",
+        "relationship_advice@lemmy.world,aita@lemmy.world,asklemmy@lemmy.world",
     ).split(",") if c.strip()
 ]
 LEMMY_MIN_SCORE = int(os.getenv("LEMMY_MIN_SCORE", "10"))

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -285,10 +285,11 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
             except Exception as e:
                 logger.error("Collect (%s) failed: %s", name, e)
                 summary["errors"].append(f"collect[{name}]: {e}")
-        # Daily FRESH HuggingFace import (issue #78 follow-up): pull the newest
-        # HF_DAILY_LIMIT rows from the (hourly-updated) dataset for timeliness.
-        # Newest-inserted-first selection means these lead any older backlog.
-        # Best-effort; a deep one-off backfill is still the manual CLI tool.
+        # Optional daily `--newest` HuggingFace import (issue #78 follow-up).
+        # OFF by default — only useful when HF_DRAMA_DATASET points at a dataset
+        # that's actually still updating (most AITA dumps are stale, so this
+        # would just re-poll an old tail). Timeliness comes from Lemmy; HF's job
+        # is backfill volume. Best-effort; deep backfill is the manual CLI tool.
         if config.HF_DRAMA_DAILY_ENABLED:
             try:
                 from collectors.hf_drama_importer import import_dataset

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -275,8 +275,7 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
         collected = 0
         # Reddit (off by default, issue #78) + Lemmy (open Reddit-alternative).
         # Each source is independent: one failing doesn't sink the other or the
-        # rest of the pipeline. HuggingFace bulk import is a separate manual tool
-        # (collectors/hf_drama_importer.py), not part of the daily run.
+        # rest of the pipeline.
         for name, collector in (("reddit", "collectors.reddit_drama_collector"),
                                 ("lemmy", "collectors.lemmy_drama_collector")):
             try:
@@ -286,6 +285,17 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
             except Exception as e:
                 logger.error("Collect (%s) failed: %s", name, e)
                 summary["errors"].append(f"collect[{name}]: {e}")
+        # Daily FRESH HuggingFace import (issue #78 follow-up): pull the newest
+        # HF_DAILY_LIMIT rows from the (hourly-updated) dataset for timeliness.
+        # Newest-inserted-first selection means these lead any older backlog.
+        # Best-effort; a deep one-off backfill is still the manual CLI tool.
+        if config.HF_DRAMA_DAILY_ENABLED:
+            try:
+                from collectors.hf_drama_importer import import_dataset
+                collected += import_dataset(newest=True, limit=config.HF_DAILY_LIMIT)
+            except Exception as e:
+                logger.error("Collect (hf) failed: %s", e)
+                summary["errors"].append(f"collect[hf]: {e}")
         summary["collected"] = collected
 
     if "score" in steps:

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -108,6 +108,27 @@ class TestImportDataset(_HFDBTest):
         self.assertEqual(n, 1)
         self.assertEqual(stories.get_pending(track="drama")[0]["raw_content"], "the story")
 
+    def test_newest_pulls_from_tail(self):
+        # --newest: probe size (1000 rows), then import from offset 1000-30=970.
+        rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(970, 1000)]
+        probe = _page([{"title": "x", "body": "y", "id": "0"}], num_rows_total=1000)
+        page = _page(rows, num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]) as fetch:
+            n = hf.import_dataset(dataset="owner/ds", limit=30, newest=True)
+        self.assertEqual(n, 30)
+        # The real fetch (2nd call) started at offset 970, not 0.
+        second_call_offset = fetch.call_args_list[1][0][3]
+        self.assertEqual(second_call_offset, 970)
+
+    def test_newest_offset_clamped_when_dataset_smaller_than_limit(self):
+        probe = _page([{"title": "x", "body": "y", "id": "0"}], num_rows_total=5)
+        rows = [{"title": f"t{i}", "body": f"b{i}", "id": str(i)} for i in range(5)]
+        page = _page(rows, num_rows_total=5)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]) as fetch:
+            n = hf.import_dataset(dataset="owner/ds", limit=30, newest=True)
+        self.assertEqual(n, 5)
+        self.assertEqual(fetch.call_args_list[1][0][3], 0)  # offset clamped to 0
+
     def test_pagination_spans_pages(self):
         page1 = _page([{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(100)],
                       num_rows_total=150)

--- a/content-pipeline/tests/test_lemmy_drama_collector.py
+++ b/content-pipeline/tests/test_lemmy_drama_collector.py
@@ -123,6 +123,101 @@ class TestFetchCommunityTop(_LemmyDBTest):
             self.assertEqual(lemmy.fetch_community_top("x@y"), [])
 
 
+def _comments(*specs):
+    """Build a /comment/list response from (content, score) specs."""
+    return {"comments": [
+        {"comment": {"content": c, "removed": s.get("removed", False),
+                     "deleted": False},
+         "counts": {"score": s.get("score", 20)}}
+        for c, s in specs
+    ]}
+
+
+class TestParseComments(unittest.TestCase):
+    def test_parses_fields(self):
+        out = lemmy.parse_comments(_comments(("An answer", {"score": 42})))
+        self.assertEqual(out[0]["content"], "An answer")
+        self.assertEqual(out[0]["score"], 42)
+        self.assertFalse(out[0]["removed"])
+
+    def test_malformed_returns_empty(self):
+        self.assertEqual(lemmy.parse_comments({"x": 1}), [])
+        self.assertEqual(lemmy.parse_comments(None), [])
+
+
+class TestFetchTopComments(unittest.TestCase):
+    def test_filters_and_caps(self):
+        with patch.object(lemmy.config, "LEMMY_QA_TOP_COMMENTS", 2), \
+             patch.object(lemmy.config, "LEMMY_QA_MIN_COMMENT_SCORE", 5), \
+             patch.object(lemmy.config, "LEMMY_QA_MIN_COMMENT_CHARS", 10), \
+             patch.object(lemmy, "_fetch_comments", return_value=_comments(
+                 ("This is a good long answer number one", {"score": 90}),
+                 ("short", {"score": 90}),                       # too short
+                 ("Another sufficiently long answer here", {"score": 2}),   # low score
+                 ("A removed one that is long enough", {"score": 90, "removed": True}),
+                 ("Second good answer that is long enough", {"score": 50}),
+                 ("Third good answer but capped out here", {"score": 40}),
+             )):
+            answers = lemmy.fetch_top_comments(123)
+        self.assertEqual(answers, [
+            "This is a good long answer number one",
+            "Second good answer that is long enough",
+        ])  # top 2 that pass filters, best-first
+
+    def test_fetch_failure_returns_none(self):
+        with patch.object(lemmy, "_fetch_comments", return_value=None):
+            self.assertIsNone(lemmy.fetch_top_comments(123))
+
+
+class TestBuildQaContent(unittest.TestCase):
+    def test_joins_question_body_answers(self):
+        out = lemmy._build_qa_content("The question?", "extra body", ["a1", "a2"])
+        self.assertEqual(out, "The question?\n\nextra body\n\na1\n\na2")
+
+    def test_skips_empty_body(self):
+        out = lemmy._build_qa_content("Q?", "  ", ["a1"])
+        self.assertEqual(out, "Q?\n\na1")
+
+
+class TestCollectQa(_LemmyDBTest):
+    def _run(self, posts, answers_by_id):
+        with patch.object(lemmy.config, "LEMMY_QA_COMMUNITIES", ["asklemmy@lemmy.world"]), \
+             patch.object(lemmy.config, "LEMMY_QA_MIN_COMMENTS", 2), \
+             patch.object(lemmy.config, "LEMMY_MIN_SCORE", 10), \
+             patch.object(lemmy, "fetch_community_top",
+                          return_value=lemmy.parse_listing(_listing(*posts))), \
+             patch.object(lemmy, "fetch_top_comments",
+                          side_effect=lambda pid: answers_by_id.get(pid)):
+            return lemmy.collect_community("asklemmy@lemmy.world")
+
+    def test_assembles_qa_story(self):
+        # Question post (empty body) with enough answers → a Q&A story.
+        count = self._run(
+            [_post(1, title="Scariest thing?", body="", score=500)],
+            {1: ["Answer one is here", "Answer two is here"]},
+        )
+        self.assertEqual(count, 1)
+        story = stories.get_pending(track="drama")[0]
+        self.assertEqual(story["title"], "Scariest thing?")
+        self.assertEqual(story["metadata"]["format"], "qa")
+        self.assertEqual(story["metadata"]["num_answers"], 2)
+        self.assertIn("Answer one is here", story["raw_content"])
+
+    def test_skips_when_too_few_answers(self):
+        count = self._run(
+            [_post(1, title="Q?", body="", score=500)],
+            {1: ["only one answer"]},   # < LEMMY_QA_MIN_COMMENTS (2)
+        )
+        self.assertEqual(count, 0)
+
+    def test_skips_when_comment_fetch_fails(self):
+        count = self._run(
+            [_post(1, title="Q?", body="", score=500)],
+            {1: None},   # comment fetch returned None
+        )
+        self.assertEqual(count, 0)
+
+
 class TestCollectAllLemmy(_LemmyDBTest):
     def test_disabled_returns_zero(self):
         with patch.object(lemmy.config, "LEMMY_ENABLED", False):


### PR DESCRIPTION
Follow-up của #78 (PR #79, #80 đã merge). Bạn cần story **mang tính thời sự**. Vấn đề: kho tĩnh 270K là evergreen (2013–2023), không tươi. PR này thêm đường lấy **story mới nhất, mỗi ngày**.

## Bối cảnh chọn story (đã kiểm chứng trong code)
Pipeline chọn story theo `ORDER BY created_at DESC` (mới-insert-trước) ở cả 3 bước score/rewrite/render — **không** theo điểm rubric hay ngày gốc. Hệ quả tốt: **nội dung về sau luôn được xử lý trước backlog cũ**, nên nguồn fresh tự nhiên chen lên đầu.

## Thay đổi
- **`hf_drama_importer` thêm `--newest` / `newest=True`:** dò `num_rows_total` rồi lấy từ **đuôi** dataset (`offset = total − limit`) — với dataset nối-thêm-mỗi-giờ thì đuôi = mới nhất. (importer cũ lấy `offset=0` = **cũ nhất** — chính là cái bẫy làm mất tính thời sự.)
- **`main_drama` collect step:** khi `HF_DRAMA_DAILY_ENABLED` (mặc định bật), mỗi ngày kéo `HF_DAILY_LIMIT`=30 dòng mới nhất từ dataset cập-nhật-mỗi-giờ. Best-effort (lỗi không kéo cả pipeline). **Không cần chạy mỗi giờ:** kênh ~2 video/ngày, scorer ~20/ngày → daily là dư.
- **Đổi `HF_DRAMA_DATASET` mặc định** sang bản cập-nhật-mỗi-giờ (`derek-thomas/dataset-creator-reddit-amitheasshole`) cho tính thời sự; kho tĩnh 270K vẫn dùng được qua `--dataset OsamaBsher/...` khi muốn backfill sâu một lần.

## Testing
- Test mới: `--newest` lấy đúng đuôi (offset = total−limit) và clamp về 0 khi dataset nhỏ hơn limit.
- 13 test importer + 24 test 2 collector pass; 751 total (5 lỗi còn lại do môi trường thiếu SDK `anthropic`, không liên quan).

## Lưu ý vận hành
Sau merge, Drama track tự lấy story **tươi mỗi ngày** (Lemmy hôm nay + HF newest) — fresh luôn được ưu tiên trước backlog. **Verify dataset hourly một lần** (phòng khi config/split khác): `python -m collectors.hf_drama_importer --limit 3` — thấy import được là ổn; 404 nghĩa là chỉnh `HF_DRAMA_CONFIG`/`HF_DRAMA_SPLIT`. Muốn kho lớn ban đầu: `python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)