### PR TITLE
fix(#82): drama_rewriter — raise max_tokens + truncation-aware error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,24 @@ phạm vi: TTS/render video thật (Phase 4).
   ở mục "Rủi ro" (tên thuần Việt 2-3 từ, không nhắc văn hoá Mỹ) được đưa
   thẳng vào prompt v1 luôn, không đợi tune sang v2 — xem
   `docs/current/prompts-decisions.md`.
+  **Xử lý lỗi output JSON (issue #82):** root cause = `max_tokens` cũ (2000)
+  quá thấp cho output bắt buộc (script 800-1200 từ + `vn_commentary` ≥200 từ +
+  JSON wrapper). Tiếng Việt token hoá ~2 token/từ (dấu) nên ngay cả output
+  ngắn nhất cũng ~2500+ token → Sonnet bị cắt GIỮA JSON (`stop_reason='max_
+  tokens'`), thiếu dấu `}` đóng → regex `\{.*\}` không match → lỗi lệch hướng
+  "No JSON object found"; 3 retry cùng tham số cắt y hệt → 0 video. Fix:
+  (1) `config.DRAMA_REWRITER_MAX_TOKENS` mặc định **4096** (khớp
+  `drama_compiler`), env-overridable; (2) phân biệt cắt-cụt (`stop_reason=
+  max_tokens`) với từ-chối/prose (`end_turn`) — cắt-cụt thì **tăng `max_tokens`
+  ×1.5 mỗi retry** (4096→6144→9216) để story dài bất thường vẫn xong thay vì
+  cắt lặp; (3) LOG cả `stop_reason` + đoạn đầu reply thật (trước đây vứt đi
+  reply nên không phân biệt được 3 giả thuyết); (4) hết retry mà model CÓ trả
+  lời nhưng không parse được (từ chối/cắt-cụt dai dẳng) → `status='needs_
+  review'` + lưu raw reply vào `rewritten_content` (envelope `{_rewrite_error,
+  _stop_reason, _raw_reply}`) + alert, thay vì để `pending` nã token Sonnet mỗi
+  ngày; chỉ lỗi API thật (chưa chạm được model) mới giữ `pending` để retry.
+  `_alert_validation_failure` best-effort (nuốt lỗi notifier, không phá cả
+  batch).
 - **`processors/drama_compiler.py`** — gom 3-5 story cùng theme (`status=
   'produced'`, đã qua Phase 4) thành 1 script long-form 8-15 phút + chapter
   markers. `detect_theme()` (Sonnet, weekly) tìm theme xuất hiện ≥3 story;

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -290,6 +290,17 @@ PROMPT_VERSION = os.getenv("PROMPT_VERSION", "v1")
 # >= this AND safe=1 to proceed to the rewriter.
 DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "5"))
 
+# Output token ceiling for drama_rewriter's Sonnet call (issue #82). The
+# rewriter must emit an 800-1200 word Vietnamese script + a >=200 word
+# vn_commentary + title/hook/thumbnail_prompt/tags, all inside a JSON wrapper.
+# Vietnamese tokenizes at roughly ~2 tokens/word (diacritics), so even the
+# shortest valid output runs ~2500+ tokens — the old 2000 ceiling truncated
+# the JSON mid-generation (stop_reason='max_tokens'), leaving no closing brace
+# and yielding the misleading "No JSON object found". 4096 gives headroom over
+# the ~3300-token worst case and matches drama_compiler's ceiling. The rewriter
+# escalates from here (x1.5, x2) if a run still truncates.
+DRAMA_REWRITER_MAX_TOKENS = int(os.getenv("DRAMA_REWRITER_MAX_TOKENS", "4096"))
+
 # --- Lemmy (issue #78 follow-up: Reddit-alternative source for Drama) ---
 # Lemmy is a federated, open Reddit alternative with a public read API (no
 # OAuth, no approval — unlike Reddit post-Nov-2025). Drama stories come out in

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -25,6 +25,14 @@ from storage.stories import get_pending, update_status, get_story
 
 logger = logging.getLogger(__name__)
 
+_MAX_ATTEMPTS = 3
+# How much of the model's actual reply to keep in logs / needs_review payloads
+# when parsing fails. The old code discarded the response entirely, so a failure
+# was indistinguishable between "truncated JSON", "model refused", and "model
+# returned prose" (issue #82's three competing hypotheses) — keep a snippet so
+# the real cause is visible without re-running.
+_RESPONSE_SNIPPET_CHARS = 600
+
 _REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
 _SCRIPT_MIN_WORDS = 800
 _SCRIPT_MAX_WORDS = 1200
@@ -105,6 +113,93 @@ def validate_rewrite(result: dict) -> list[str]:
     return issues
 
 
+class _RewriteParseError(Exception):
+    """The model replied, but the reply held no usable rewrite JSON.
+
+    Distinct from anthropic.APIError (never reached the model) — this means we
+    DID get text back but couldn't turn it into a dict, so the caller looks at
+    the reply's ``stop_reason`` to tell truncation from a refusal/off-format
+    answer.
+    """
+
+
+def _reply_text(message) -> str:
+    """Return the first text block of a message, stripped ('' if none).
+
+    Sturdier than ``message.content[0].text``: a leading non-text block or an
+    empty ``content`` list (possible when a reply is truncated to nothing)
+    would otherwise raise IndexError/AttributeError instead of failing as a
+    plain parse error.
+    """
+    for block in getattr(message, "content", None) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            return text.strip()
+    return ""
+
+
+def _extract_json(text: str) -> dict:
+    """Pull the rewrite JSON object out of a model reply.
+
+    Handles raw JSON, ```json``-fenced JSON, and JSON trailed by prose. Raises
+    ``_RewriteParseError`` when there is no complete object — notably a reply
+    truncated before its closing brace (issue #82), which the caller then
+    attributes to ``stop_reason == 'max_tokens'``.
+    """
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group())
+        except json.JSONDecodeError:
+            pass  # greedy match may have swept up unbalanced trailing prose
+    start = text.find("{")
+    if start != -1:
+        try:
+            obj, _ = json.JSONDecoder().raw_decode(text[start:])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+    raise _RewriteParseError("no complete JSON object in reply")
+
+
+def _handle_unparseable(story_id: int, got_reply: bool, stop_reason,
+                        snippet: str) -> None:
+    """Decide what to do with a story that never yielded a valid rewrite.
+
+    - No model reply at all (transient API/rate errors): leave the story
+      untouched and return None so a later run retries it.
+    - Model replied but we never got valid JSON (truncation that survived
+      escalation, a refusal, or persistent prose): mark it 'needs_review' with
+      the raw reply saved + a Telegram alert, rather than silently re-burning
+      Sonnet tokens on the same poison story every single day.
+    """
+    if not got_reply:
+        logger.error(
+            "Failed to rewrite story %d after %d attempts (no usable model reply)",
+            story_id, _MAX_ATTEMPTS,
+        )
+        return None
+
+    if stop_reason == "max_tokens":
+        reason = ("model output kept hitting max_tokens (script too long or "
+                  "model looping) — reply truncated before valid JSON")
+    else:
+        reason = (f"model reply was not valid JSON (stop_reason={stop_reason}) "
+                  f"— likely a refusal or off-format answer")
+    logger.error(
+        "Failed to rewrite story %d after %d attempts: %s. Reply head: %r",
+        story_id, _MAX_ATTEMPTS, reason, snippet[:200],
+    )
+    envelope = json.dumps(
+        {"_rewrite_error": reason, "_stop_reason": stop_reason, "_raw_reply": snippet},
+        ensure_ascii=False,
+    )
+    update_status(story_id, "needs_review", rewritten_content=envelope)
+    _alert_validation_failure(story_id, [reason])
+    return None
+
+
 def rewrite_story(story_id: int) -> dict | None:
     """Rewrite one story into a Vietnamese script via Claude Sonnet.
 
@@ -114,8 +209,10 @@ def rewrite_story(story_id: int) -> dict | None:
     - 'needs_review' — failed validate_rewrite(); the (still-saved) output
       needs a human look. A Telegram alert is sent with the specific issues.
 
-    Returns the parsed rewrite dict, or None on failure (story left
-    untouched so a later run can retry).
+    On failure: a story the model never answered for is left untouched (returns
+    None) so a later run retries it; a story the model answered but never
+    parsed into valid JSON is flagged 'needs_review' (also returns None) — see
+    `_handle_unparseable`.
     """
     story = get_story(story_id)
     if not story:
@@ -127,26 +224,46 @@ def rewrite_story(story_id: int) -> dict | None:
 
     client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)
     result = None
+    max_tokens = config.DRAMA_REWRITER_MAX_TOKENS
+    got_reply = False       # did the model ever answer? (transient error vs. bad content)
+    last_stop_reason = None
+    last_snippet = ""
 
-    for attempt in range(3):
+    for attempt in range(_MAX_ATTEMPTS):
         try:
             message = client.messages.create(
                 model="claude-sonnet-4-5",
-                max_tokens=2000,
+                max_tokens=max_tokens,
                 messages=[{"role": "user", "content": prompt}],
             )
             log_token_usage("drama_rewriter", story_id, message)
-            response_text = message.content[0].text.strip()
-            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
-            if not json_match:
-                raise json.JSONDecodeError("No JSON object found", response_text, 0)
-            result = json.loads(json_match.group())
+            got_reply = True
+            last_stop_reason = getattr(message, "stop_reason", None)
+            response_text = _reply_text(message)
+            last_snippet = response_text[:_RESPONSE_SNIPPET_CHARS]
+            result = _extract_json(response_text)
             break
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.warning(
-                "Attempt %d/3: failed to parse rewrite for story %d: %s",
-                attempt + 1, story_id, e,
-            )
+        except _RewriteParseError as e:
+            if last_stop_reason == "max_tokens":
+                # Truncated mid-JSON: the reply was cut off before its closing
+                # brace. Retrying at the same size just truncates identically
+                # (the exact 3x-identical-failure of issue #82), so escalate
+                # the ceiling before the next attempt.
+                boosted = int(max_tokens * 1.5)
+                logger.warning(
+                    "Attempt %d/%d: rewrite for story %d truncated at max_tokens=%d; "
+                    "raising to %d and retrying. Reply head: %r",
+                    attempt + 1, _MAX_ATTEMPTS, story_id, max_tokens, boosted,
+                    last_snippet[:200],
+                )
+                max_tokens = boosted
+            else:
+                logger.warning(
+                    "Attempt %d/%d: failed to parse rewrite for story %d "
+                    "(stop_reason=%s): %s. Reply head: %r",
+                    attempt + 1, _MAX_ATTEMPTS, story_id, last_stop_reason, e,
+                    last_snippet[:200],
+                )
             continue
         except anthropic.RateLimitError:
             wait = 2 ** (attempt + 1)
@@ -158,8 +275,7 @@ def rewrite_story(story_id: int) -> dict | None:
             return None
 
     if result is None:
-        logger.error("Failed to rewrite story %d after 3 attempts", story_id)
-        return None
+        return _handle_unparseable(story_id, got_reply, last_stop_reason, last_snippet)
 
     issues = validate_rewrite(result)
     rewritten_json = json.dumps(result, ensure_ascii=False)
@@ -176,9 +292,17 @@ def rewrite_story(story_id: int) -> dict | None:
 
 
 def _alert_validation_failure(story_id: int, issues: list[str]) -> None:
-    from notifier.telegram_bot import send_alert
+    """Best-effort Telegram alert — a notifier hiccup must not crash the batch.
+
+    rewrite_all_scored() loops over stories; letting a failed alert raise here
+    would abort every remaining story, so swallow and log instead.
+    """
     lines = "\n".join(f"  • {i}" for i in issues)
-    send_alert(f"⚠️ Story #{story_id} rewrite cần review thủ công:\n{lines}")
+    try:
+        from notifier.telegram_bot import send_alert
+        send_alert(f"⚠️ Story #{story_id} rewrite cần review thủ công:\n{lines}")
+    except Exception as e:  # noqa: BLE001 — notifier is non-critical
+        logger.warning("Failed to send review alert for story %d: %s", story_id, e)
 
 
 def rewrite_all_scored(limit: int = 10) -> int:

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -27,17 +27,37 @@ def _good_rewrite(word_count: int = 900, commentary_words: int = 220) -> dict:
     }
 
 
-def _fake_message(json_dict: dict):
+def _text_message(text: str, stop_reason: str = "end_turn"):
+    """A fake anthropic message carrying arbitrary reply text."""
     msg = MagicMock()
     msg.usage = None
-    msg.content = [MagicMock(text=json.dumps(json_dict, ensure_ascii=False))]
+    msg.stop_reason = stop_reason
+    msg.content = [MagicMock(text=text)]
     return msg
+
+
+def _fake_message(json_dict: dict, stop_reason: str = "end_turn"):
+    return _text_message(json.dumps(json_dict, ensure_ascii=False), stop_reason)
 
 
 def _mock_anthropic(json_dict: dict):
     fake_client = MagicMock()
     fake_client.messages.create.return_value = _fake_message(json_dict)
     return patch.object(drama_rewriter.anthropic, "Anthropic", return_value=fake_client)
+
+
+def _mock_anthropic_sequence(*messages):
+    """Patch so consecutive .messages.create(...) calls return these in order."""
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = list(messages)
+    return patch.object(drama_rewriter.anthropic, "Anthropic", return_value=fake_client)
+
+
+class _FakeAPIError(drama_rewriter.anthropic.APIError):
+    """anthropic.APIError instance without the version-specific __init__ args."""
+
+    def __init__(self):  # noqa: D107 — bypass parent's request/body requirement
+        pass
 
 
 class TestValidateRewrite(unittest.TestCase):
@@ -108,6 +128,48 @@ class TestValidateRewrite(unittest.TestCase):
         self.assertTrue(any("john" in i for i in issues))
 
 
+class TestExtractJson(unittest.TestCase):
+    def test_raw_json(self):
+        self.assertEqual(drama_rewriter._extract_json('{"a": 1}'), {"a": 1})
+
+    def test_fenced_json(self):
+        text = '```json\n{"a": 1}\n```'
+        self.assertEqual(drama_rewriter._extract_json(text), {"a": 1})
+
+    def test_json_with_trailing_prose(self):
+        text = '{"a": 1}\n\nHy vọng bản dịch này phù hợp!'
+        self.assertEqual(drama_rewriter._extract_json(text), {"a": 1})
+
+    def test_json_with_leading_prose(self):
+        text = 'Đây là kết quả:\n{"a": 1}'
+        self.assertEqual(drama_rewriter._extract_json(text), {"a": 1})
+
+    def test_truncated_json_raises(self):
+        # Cut off before the closing brace — the issue #82 shape.
+        with self.assertRaises(drama_rewriter._RewriteParseError):
+            drama_rewriter._extract_json('{"title": "abc", "script": "một câu chuyện')
+
+    def test_no_json_raises(self):
+        with self.assertRaises(drama_rewriter._RewriteParseError):
+            drama_rewriter._extract_json("Xin lỗi, tôi không thể giúp việc này.")
+
+
+class TestReplyText(unittest.TestCase):
+    def test_first_text_block(self):
+        self.assertEqual(drama_rewriter._reply_text(_text_message("hello")), "hello")
+
+    def test_empty_content_returns_empty_string(self):
+        msg = MagicMock()
+        msg.content = []
+        self.assertEqual(drama_rewriter._reply_text(msg), "")
+
+    def test_skips_leading_non_text_block(self):
+        msg = MagicMock()
+        non_text = MagicMock(spec=[])  # no .text attribute
+        msg.content = [non_text, MagicMock(text="real")]
+        self.assertEqual(drama_rewriter._reply_text(msg), "real")
+
+
 class RewriterTestBase(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -150,18 +212,69 @@ class TestRewriteStory(RewriterTestBase):
     def test_missing_story_returns_none(self):
         self.assertIsNone(drama_rewriter.rewrite_story(999999))
 
-    def test_malformed_json_leaves_story_untouched(self):
+    def test_non_json_reply_flags_needs_review_and_saves_raw(self):
+        # A model that replies with prose (e.g. a refusal) rather than JSON is
+        # flagged for human review with the raw reply saved — not silently
+        # retried forever (issue #82: persistent parse failure must be visible).
+        refusal = "Xin lỗi, tôi không thể viết lại câu chuyện này."
+        with _mock_anthropic_sequence(*([_text_message(refusal)] * 3)), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "needs_review")
+        saved = json.loads(story["rewritten_content"])
+        self.assertIn(refusal, saved["_raw_reply"])
+        self.assertIn("not valid JSON", saved["_rewrite_error"])
+        alert.assert_called_once()
+
+    def test_truncated_json_escalates_max_tokens_then_succeeds(self):
+        # First reply is cut off mid-JSON (stop_reason='max_tokens'); the retry
+        # must raise the ceiling and then succeed instead of truncating again.
+        truncated = _text_message('{"title": "abc", "script": "', stop_reason="max_tokens")
+        good = _fake_message(_good_rewrite())
+        with _mock_anthropic_sequence(truncated, good) as p:
+            fake_client = p.return_value
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+        # Second call must use a larger max_tokens than the first.
+        calls = fake_client.messages.create.call_args_list
+        self.assertGreater(calls[1].kwargs["max_tokens"], calls[0].kwargs["max_tokens"])
+
+    def test_persistent_truncation_flags_needs_review(self):
+        truncated = _text_message('{"title": "abc"', stop_reason="max_tokens")
+        with _mock_anthropic_sequence(*([truncated] * 3)), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "needs_review")
+        saved = json.loads(story["rewritten_content"])
+        self.assertEqual(saved["_stop_reason"], "max_tokens")
+        alert.assert_called_once()
+
+    def test_api_error_leaves_story_untouched_for_retry(self):
+        # The model was never reached — leave the story 'pending' so a later
+        # run retries it (transient), rather than flagging needs_review.
         fake_client = MagicMock()
-        bad_message = MagicMock()
-        bad_message.usage = None
-        bad_message.content = [MagicMock(text="not json")]
-        fake_client.messages.create.return_value = bad_message
+        fake_client.messages.create.side_effect = _FakeAPIError()
         with patch.object(drama_rewriter.anthropic, "Anthropic", return_value=fake_client):
             result = drama_rewriter.rewrite_story(self.story_id)
         self.assertIsNone(result)
         story = stories.get_story(self.story_id)
         self.assertEqual(story["status"], "pending")
         self.assertIsNone(story["rewritten_content"])
+
+    def test_uses_configured_max_tokens(self):
+        with _mock_anthropic(_good_rewrite()) as p:
+            fake_client = p.return_value
+            drama_rewriter.rewrite_story(self.story_id)
+        first_call = fake_client.messages.create.call_args_list[0]
+        self.assertEqual(
+            first_call.kwargs["max_tokens"], drama_rewriter.config.DRAMA_REWRITER_MAX_TOKENS
+        )
 
 
 class TestRewriteAllScored(RewriterTestBase):


### PR DESCRIPTION
Closes #82

## Root cause

`processors/drama_rewriter.py` called Sonnet with `max_tokens=2000`, but the rewriter's required output is large: an **800–1200 word** Vietnamese script + a **≥200 word** `vn_commentary` + `title`/`hook`/`thumbnail_prompt`/`tags`, all inside a JSON wrapper. Vietnamese tokenizes at ~2 tokens/word (diacritics), so even the *shortest valid* output runs ~2500+ tokens and overran the 2000 ceiling.

Claude generated until it hit the ceiling and was **truncated mid-JSON** (`stop_reason="max_tokens"`), leaving an opening `{` but no closing `}`. The greedy `\{.*\}` regex requires a closing brace, so it found no match → the misleading `JSONDecodeError("No JSON object found")`. All 3 retries used identical params → identical truncation → **0 videos**.

The **~48s per attempt** in the reported log (vs. seconds for a refusal) confirmed full-length generation hitting the ceiling — i.e. truncation, not the "refusal" or "Q&A format" hypotheses. The sibling `drama_compiler.py` already used `max_tokens=4000` for a comparable script, confirming 2000 was simply under-set.

## Changes

- **Root fix:** `config.DRAMA_REWRITER_MAX_TOKENS` (default **4096**, matching `drama_compiler`), env-overridable.
- **Truncation-aware retry:** distinguish truncation (`stop_reason=max_tokens`) from a refusal/off-format reply (`end_turn`). On truncation, **escalate `max_tokens` ×1.5 per retry** (4096→6144→9216) so an unusually long story still completes instead of truncating identically 3×.
- **Observability:** log `stop_reason` + a snippet of the *actual* model reply on parse failure. The old code discarded the reply, which is exactly why the issue's three competing hypotheses couldn't be told apart.
- **No silent cost-bleed:** after exhausting retries on a reply the model *gave* but we couldn't parse (persistent truncation / refusal), flag the story `needs_review` with the raw reply saved (`{_rewrite_error, _stop_reason, _raw_reply}` envelope) + Telegram alert — instead of leaving it `pending` to re-burn Sonnet tokens every run. Only genuine API errors (model never reached) keep `pending` for auto-retry.
- **Robustness:** `_reply_text` handles empty/non-text content blocks; `_extract_json` handles fenced and trailing-prose JSON via a `raw_decode` fallback. `_alert_validation_failure` is now best-effort so a notifier hiccup can't abort the whole batch.

## Tests

`tests/test_drama_rewriter.py` extended: truncation→escalation→success, persistent truncation→needs_review, non-JSON refusal→needs_review with raw reply saved, API error→left pending for retry, configured/escalated `max_tokens` assertions, plus `_extract_json`/`_reply_text` unit tests. Full suite: **829 passed** (21 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)