### PR TITLE
fix(#84): force JSON output in drama_rewriter via assistant prefill

### DIFF
--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -26,12 +26,27 @@ from storage.stories import get_pending, update_status, get_story
 logger = logging.getLogger(__name__)
 
 _MAX_ATTEMPTS = 3
-# How much of the model's actual reply to keep in logs / needs_review payloads
-# when parsing fails. The old code discarded the response entirely, so a failure
-# was indistinguishable between "truncated JSON", "model refused", and "model
-# returned prose" (issue #82's three competing hypotheses) — keep a snippet so
-# the real cause is visible without re-running.
+# How much of the model's actual reply to keep in the needs_review DB payload
+# when parsing fails (issue #82). Kept bounded so a runaway reply can't bloat
+# the row. The FULL reply is still emitted to logs (DEBUG per attempt, and in
+# the final error) so operators can see exactly what Sonnet returned without
+# re-running — issue #84 flagged that the old `[:200]` snippet hid the cause.
 _RESPONSE_SNIPPET_CHARS = 600
+
+# Assistant-turn prefill: we seed the assistant reply with a single "{" so the
+# model is forced to continue from an open JSON object (issue #84 root cause).
+# The prompt already says "reply with JSON only", but Sonnet occasionally still
+# emits a prose preamble ("Đây là kịch bản...") or wraps the JSON in commentary
+# — a 200-token HTTP-200 reply that carries no parseable object, so all 3
+# retries fail identically and the story yields 0 video. Prefilling makes a
+# preamble structurally impossible: the first token the model can emit is the
+# JSON body. This is the canonical Anthropic technique for guaranteed-JSON
+# output and is supported on claude-sonnet-4-5. The "{" is NOT echoed back in
+# the response content, so we prepend it before parsing (see rewrite_story).
+# It composes with the #82 truncation handling untouched: a reply cut off at
+# max_tokens still lacks its closing brace, so _extract_json raises and the
+# ×1.5 escalation kicks in exactly as before.
+_JSON_PREFILL = "{"
 
 _REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
 _SCRIPT_MIN_WORDS = 800
@@ -188,8 +203,8 @@ def _handle_unparseable(story_id: int, got_reply: bool, stop_reason,
         reason = (f"model reply was not valid JSON (stop_reason={stop_reason}) "
                   f"— likely a refusal or off-format answer")
     logger.error(
-        "Failed to rewrite story %d after %d attempts: %s. Reply head: %r",
-        story_id, _MAX_ATTEMPTS, reason, snippet[:200],
+        "Failed to rewrite story %d after %d attempts: %s. Reply: %r",
+        story_id, _MAX_ATTEMPTS, reason, snippet,
     )
     envelope = json.dumps(
         {"_rewrite_error": reason, "_stop_reason": stop_reason, "_raw_reply": snippet},
@@ -234,13 +249,29 @@ def rewrite_story(story_id: int) -> dict | None:
             message = client.messages.create(
                 model="claude-sonnet-4-5",
                 max_tokens=max_tokens,
-                messages=[{"role": "user", "content": prompt}],
+                messages=[
+                    {"role": "user", "content": prompt},
+                    # Prefill "{" — forces a pure-JSON continuation (issue #84).
+                    {"role": "assistant", "content": _JSON_PREFILL},
+                ],
             )
             log_token_usage("drama_rewriter", story_id, message)
             got_reply = True
             last_stop_reason = getattr(message, "stop_reason", None)
+            # The prefill "{" is not part of the returned content — put it back
+            # so we parse the whole object. Guard against a model (or future
+            # provider) that does echo it, to avoid a doubled "{{".
             response_text = _reply_text(message)
+            if not response_text.startswith(_JSON_PREFILL):
+                response_text = _JSON_PREFILL + response_text
             last_snippet = response_text[:_RESPONSE_SNIPPET_CHARS]
+            # Full reply at DEBUG so the actual model output is recoverable
+            # without a re-run (issue #84 #3). Kept off the default INFO path so
+            # a healthy 800-1200 word script doesn't spam the log every run.
+            logger.debug(
+                "Story %d attempt %d/%d raw reply (stop_reason=%s): %r",
+                story_id, attempt + 1, _MAX_ATTEMPTS, last_stop_reason, response_text,
+            )
             result = _extract_json(response_text)
             break
         except _RewriteParseError as e:
@@ -252,17 +283,17 @@ def rewrite_story(story_id: int) -> dict | None:
                 boosted = int(max_tokens * 1.5)
                 logger.warning(
                     "Attempt %d/%d: rewrite for story %d truncated at max_tokens=%d; "
-                    "raising to %d and retrying. Reply head: %r",
+                    "raising to %d and retrying. Reply: %r",
                     attempt + 1, _MAX_ATTEMPTS, story_id, max_tokens, boosted,
-                    last_snippet[:200],
+                    last_snippet,
                 )
                 max_tokens = boosted
             else:
                 logger.warning(
                     "Attempt %d/%d: failed to parse rewrite for story %d "
-                    "(stop_reason=%s): %s. Reply head: %r",
+                    "(stop_reason=%s): %s. Reply: %r",
                     attempt + 1, _MAX_ATTEMPTS, story_id, last_stop_reason, e,
-                    last_snippet[:200],
+                    last_snippet,
                 )
             continue
         except anthropic.RateLimitError:

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -178,6 +178,30 @@ def _extract_json(text: str) -> dict:
     raise _RewriteParseError("no complete JSON object in reply")
 
 
+def _extract_rewrite_json(reply: str) -> dict:
+    """Parse the rewrite object from a (possibly prefill-continued) reply.
+
+    We seed the assistant turn with ``{`` (see ``_JSON_PREFILL`` /
+    ``rewrite_story``); the API does not echo that prefill back, so the honored
+    case is a reply that is the JSON *body* with no leading brace (e.g.
+    ``"title": ...}``). But the prefill isn't guaranteed to be honored — a reply
+    may still arrive as a complete object, possibly behind a prose preamble or a
+    ```json fence, which ``_extract_json`` already handles.
+
+    So try the reply as-is first (covers the prefill-ignored / full-object
+    cases), then fall back to prepending the ``{`` (the honored-prefill case).
+    Prepending unconditionally would corrupt a full-object-behind-a-prefix reply
+    — the synthetic ``{`` makes ``raw_decode`` start on invalid input — which
+    reintroduces the issue #84 failure in that very fallback path.
+    """
+    try:
+        return _extract_json(reply)
+    except _RewriteParseError:
+        if reply.startswith(_JSON_PREFILL):
+            raise  # already brace-led; prepending would only double it
+        return _extract_json(_JSON_PREFILL + reply)
+
+
 def _handle_unparseable(story_id: int, got_reply: bool, stop_reason,
                         snippet: str) -> None:
     """Decide what to do with a story that never yielded a valid rewrite.
@@ -258,21 +282,20 @@ def rewrite_story(story_id: int) -> dict | None:
             log_token_usage("drama_rewriter", story_id, message)
             got_reply = True
             last_stop_reason = getattr(message, "stop_reason", None)
-            # The prefill "{" is not part of the returned content — put it back
-            # so we parse the whole object. Guard against a model (or future
-            # provider) that does echo it, to avoid a doubled "{{".
-            response_text = _reply_text(message)
-            if not response_text.startswith(_JSON_PREFILL):
-                response_text = _JSON_PREFILL + response_text
-            last_snippet = response_text[:_RESPONSE_SNIPPET_CHARS]
+            # Log/save the RAW reply (what the model actually returned), not a
+            # reconstructed variant — that's the truthful record for debugging.
+            raw_reply = _reply_text(message)
+            last_snippet = raw_reply[:_RESPONSE_SNIPPET_CHARS]
             # Full reply at DEBUG so the actual model output is recoverable
             # without a re-run (issue #84 #3). Kept off the default INFO path so
             # a healthy 800-1200 word script doesn't spam the log every run.
             logger.debug(
                 "Story %d attempt %d/%d raw reply (stop_reason=%s): %r",
-                story_id, attempt + 1, _MAX_ATTEMPTS, last_stop_reason, response_text,
+                story_id, attempt + 1, _MAX_ATTEMPTS, last_stop_reason, raw_reply,
             )
-            result = _extract_json(response_text)
+            # Reconstruct the "{" the prefill dropped, but only as a fallback so
+            # a full object behind a prefix still parses (see _extract_rewrite_json).
+            result = _extract_rewrite_json(raw_reply)
             break
         except _RewriteParseError as e:
             if last_stop_reason == "max_tokens":

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -154,6 +154,40 @@ class TestExtractJson(unittest.TestCase):
             drama_rewriter._extract_json("Xin lỗi, tôi không thể giúp việc này.")
 
 
+class TestExtractRewriteJson(unittest.TestCase):
+    def test_honored_prefill_body_without_leading_brace(self):
+        # The prefill "{" was consumed, so the reply is the body only.
+        self.assertEqual(
+            drama_rewriter._extract_rewrite_json('"a": 1, "b": 2}'), {"a": 1, "b": 2}
+        )
+
+    def test_full_object_as_is(self):
+        self.assertEqual(drama_rewriter._extract_rewrite_json('{"a": 1}'), {"a": 1})
+
+    def test_full_object_behind_prose_prefix(self):
+        # Prefill ignored: a complete object behind prose must parse as-is,
+        # NOT get a "{" prepended (which would corrupt it).
+        self.assertEqual(
+            drama_rewriter._extract_rewrite_json('Đây là:\n{"a": 1}'), {"a": 1}
+        )
+
+    def test_full_object_in_fence(self):
+        self.assertEqual(
+            drama_rewriter._extract_rewrite_json('```json\n{"a": 1}\n```'), {"a": 1}
+        )
+
+    def test_brace_led_but_unparseable_reraises(self):
+        # Already brace-led and still broken (truncated) — do not double-prepend.
+        with self.assertRaises(drama_rewriter._RewriteParseError):
+            drama_rewriter._extract_rewrite_json('{"a": ')
+
+    def test_bodyless_truncation_reraises(self):
+        # Honored prefill + truncated body: neither the raw nor the "{"+raw
+        # form yields a complete object.
+        with self.assertRaises(drama_rewriter._RewriteParseError):
+            drama_rewriter._extract_rewrite_json('"a": "unclosed')
+
+
 class TestReplyText(unittest.TestCase):
     def test_first_text_block(self):
         self.assertEqual(drama_rewriter._reply_text(_text_message("hello")), "hello")
@@ -300,13 +334,25 @@ class TestRewriteStory(RewriterTestBase):
         story = stories.get_story(self.story_id)
         self.assertEqual(story["status"], "approved")
 
-    def test_prose_preamble_before_brace_still_parses(self):
-        # Defense in depth: even if a reply slips a preamble in before the JSON
-        # (prefill not honored for some reason), _extract_json recovers the
-        # object rather than failing outright — the reconstructed "{" + text
-        # keeps the object balanced.
-        prefilled_reply = "\n  " + json.dumps(_good_rewrite(), ensure_ascii=False)[1:]
-        with _mock_anthropic_sequence(_text_message(prefilled_reply)), \
+    def test_full_object_behind_prose_prefix_still_parses(self):
+        # Regression for the prefill-not-honored fallback (Codex P2 on PR #85):
+        # if the model ignores the prefill and returns a COMPLETE object behind
+        # a prose preamble, we must parse it as-is. Blindly prepending "{" would
+        # corrupt it (synthetic brace makes raw_decode start on invalid input),
+        # reintroducing the #84 failure in exactly this fallback path.
+        reply = "Đây là kết quả:\n" + json.dumps(_good_rewrite(), ensure_ascii=False)
+        with _mock_anthropic_sequence(_text_message(reply)), \
+             patch("notifier.telegram_bot.send_alert"):
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        self.assertEqual(stories.get_story(self.story_id)["status"], "approved")
+
+    def test_full_object_in_json_fence_still_parses(self):
+        # Same fallback, ```json-fenced form: a complete object wrapped in a
+        # fence (prefill ignored) must still parse without the "{" prepend
+        # breaking it.
+        reply = "```json\n" + json.dumps(_good_rewrite(), ensure_ascii=False) + "\n```"
+        with _mock_anthropic_sequence(_text_message(reply)), \
              patch("notifier.telegram_bot.send_alert"):
             result = drama_rewriter.rewrite_story(self.story_id)
         self.assertIsNotNone(result)

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -276,6 +276,42 @@ class TestRewriteStory(RewriterTestBase):
             first_call.kwargs["max_tokens"], drama_rewriter.config.DRAMA_REWRITER_MAX_TOKENS
         )
 
+    def test_sends_assistant_prefill_to_force_json(self):
+        # Issue #84: the request must seed the assistant turn with "{" so the
+        # model can only continue as a JSON object (no prose preamble).
+        with _mock_anthropic(_good_rewrite()) as p:
+            fake_client = p.return_value
+            drama_rewriter.rewrite_story(self.story_id)
+        msgs = fake_client.messages.create.call_args_list[0].kwargs["messages"]
+        self.assertEqual(msgs[0]["role"], "user")
+        self.assertEqual(msgs[-1]["role"], "assistant")
+        self.assertEqual(msgs[-1]["content"], drama_rewriter._JSON_PREFILL)
+
+    def test_reply_without_leading_brace_is_reconstructed(self):
+        # A real prefilled call returns content WITHOUT the leading "{" (the API
+        # does not echo the prefill). The code must prepend it before parsing.
+        body = json.dumps(_good_rewrite(), ensure_ascii=False)
+        self.assertTrue(body.startswith("{"))
+        prefilled_reply = body[1:]  # what the model actually returns after "{"
+        with _mock_anthropic_sequence(_text_message(prefilled_reply)), \
+             patch("notifier.telegram_bot.send_alert"):
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+
+    def test_prose_preamble_before_brace_still_parses(self):
+        # Defense in depth: even if a reply slips a preamble in before the JSON
+        # (prefill not honored for some reason), _extract_json recovers the
+        # object rather than failing outright — the reconstructed "{" + text
+        # keeps the object balanced.
+        prefilled_reply = "\n  " + json.dumps(_good_rewrite(), ensure_ascii=False)[1:]
+        with _mock_anthropic_sequence(_text_message(prefilled_reply)), \
+             patch("notifier.telegram_bot.send_alert"):
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        self.assertEqual(stories.get_story(self.story_id)["status"], "approved")
+
 
 class TestRewriteAllScored(RewriterTestBase):
     def test_skips_stories_without_rubric_score(self):
@@ -295,6 +331,20 @@ class TestRewriteAllScored(RewriterTestBase):
         with _mock_anthropic(_good_rewrite()):
             count = drama_rewriter.rewrite_all_scored()
         self.assertEqual(count, 1)
+
+    def test_skips_needs_review_story(self):
+        # Issue #84 #2: a story already flagged 'needs_review' (a prior
+        # unparseable rewrite) must NOT be picked up again — otherwise the same
+        # poison story re-burns Sonnet tokens on every run. It is excluded on
+        # two counts: status != 'pending' AND rewritten_content is set.
+        stories.update_status(
+            self.story_id, "needs_review",
+            rewritten_content='{"_rewrite_error": "prior failure"}',
+        )
+        with patch.object(drama_rewriter, "rewrite_story") as mocked:
+            count = drama_rewriter.rewrite_all_scored()
+        mocked.assert_not_called()
+        self.assertEqual(count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #84

## Nguyên nhân gốc

Drama pipeline thu thập được story từ Lemmy nhưng `drama_rewriter` fail parse JSON ở `story_id=2` — cả 3 attempts đều lỗi dù Claude trả **HTTP 200 + đủ tokens**. Đây KHÔNG phải lỗi cắt-cụt `max_tokens` (đã xử ở #82) mà là: prompt *yêu cầu* JSON nhưng không có gì *ép* JSON. Sonnet thi thoảng trả về reply mở đầu bằng văn xuôi ("Đây là kịch bản...") hoặc bọc JSON trong lời bình — không có object nào parse được, nên 3 retry cùng tham số fail y hệt → 0 video.

## Thay đổi (ánh xạ 3 vấn đề trong issue)

**1. Đảm bảo JSON — assistant prefill `{` (`processors/drama_rewriter.py`)**
Seed lượt trả lời của assistant bằng đúng một dấu `{`. Model buộc phải tiếp nối thành JSON object → preamble văn xuôi trở nên **bất khả thi về mặt cấu trúc**. Đây là kỹ thuật chuẩn của Anthropic cho "guaranteed JSON output", hỗ trợ trên `claude-sonnet-4-5`, rẻ và nhanh (không đốt 3 retry vô ích). Dấu `{` không được echo lại trong response nên được prepend trước khi parse (có guard chống `{{`). **Ghép nguyên vẹn với logic escalation `max_tokens` của #82**: reply bị cắt vẫn thiếu `}` đóng → `_extract_json` raise → tăng `max_tokens` ×1.5 như cũ.

Đã cân nhắc forced tool-use (đảm bảo schema mạnh nhất) nhưng loại: không chắc chạy trên Sonnet 4.5, phá toàn bộ luồng xử lý `stop_reason`/text mà #82 dựa vào, và vẫn có thể chạm `max_tokens` với script 800–1200 từ — blast radius lớn hơn nhiều mà không lợi gì so với prefill.

**2. Không retry story đã `needs_review`**
Log trong issue có trước khi #82 (PR #83) merge. Code hiện tại **đã** skip: `_handle_unparseable` set `needs_review`, còn `rewrite_all_scored` chỉ lấy `status='pending'` + lọc `rewritten_content`. Đã khóa hành vi này bằng regression test thay vì thêm code thừa.

**3. Logging nội dung response thực tế**
Thay `[:200]` snippet cũ (che mất nguyên nhân) bằng: log **toàn bộ** reply ở DEBUG mỗi attempt, và log full snippet trong error cuối. Giữ DB envelope bounded ở 600 ký tự để reply điên không phình row.

## Test

`python -m unittest tests.test_drama_rewriter` — 36 passed. Thêm coverage: prefill message shape, tái dựng reply thiếu `{` đầu, recovery khi có preamble, và skip story `needs_review`. `tests.test_main_drama` + `tests.test_drama_quality` — 22 passed (không hồi quy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDhdPBSShVoXbsXLTpNjV3