### PR TITLE
fix(#86): unblock drama pipeline — two over-strict gates rendered 0 videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,10 +246,19 @@ phạm vi: TTS/render video thật (Phase 4).
 - **`processors/drama_rewriter.py`** — module quan trọng nhất: Việt hoá story
   bằng Sonnet (đổi tên/địa điểm sang VN, thêm `vn_commentary` ≥20% thời
   lượng). `validate_rewrite()` là heuristic gate độc lập với prompt (word
-  count 800-1200, `vn_commentary` ≥200 từ, hook ngắn — proxy cho cấu trúc
-  "Hook 3s", chặn tên/từ văn hoá Mỹ lọt qua). Rewrite hợp lệ →
+  count, `vn_commentary` ≥200 từ, hook ngắn — proxy cho cấu trúc "Hook 3s",
+  chặn tên/từ văn hoá Mỹ lọt qua). Rewrite hợp lệ →
   `status='approved'`; không hợp lệ → `status='needs_review'` + alert
   Telegram (nhưng output vẫn được lưu để người xem lại, không bị huỷ).
+  **Word count 2 dải (issue #86):** prompt vẫn nhắm 800-1200 từ, nhưng LLM
+  không bao giờ trúng chính xác — story #2 ra 733 từ (script hoàn chỉnh, chỉ
+  thiếu 67 từ) bị reject y như stub gãy → cả run render **0 video**. Fix: tách
+  "đích lý tưởng" khỏi "sàn reject". `_script_length_verdict()` phân loại:
+  `[HARD_MIN, HARD_MAX]` (mặc định 600-1500) = **chấp nhận**; ngoài dải lý
+  tưởng `[SOFT_MIN, SOFT_MAX]` (800-1200) nhưng còn trong dải chấp nhận →
+  approve + log note (quan sát model có hay ngắn/dài không); chỉ dưới `HARD_MIN`
+  (stub/cắt cụt) hoặc trên `HARD_MAX` (runaway/lặp) mới block. Cả 4 ngưỡng
+  env-overridable (`DRAMA_SCRIPT_{SOFT,HARD}_{MIN,MAX}_WORDS`).
   **Cải tiến so với tài liệu gốc:** 2 rule phòng rủi ro mà tài liệu liệt kê
   ở mục "Rủi ro" (tên thuần Việt 2-3 từ, không nhắc văn hoá Mỹ) được đưa
   thẳng vào prompt v1 luôn, không đợi tune sang v2 — xem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,19 @@ phạm vi: TTS/render video thật (Phase 4).
   LOCALIZABLE, COMMENT_BAIT, SAFE) bằng Haiku. `total` LUÔN được tính lại từ
   6 field boolean phía server — không tin số `total` model tự báo cáo (LLM
   occasionally tính sai tổng). `safe=0` luôn bị loại (`status='rejected'`) dù
-  `total` cao. Story đạt ngưỡng (`config.DRAMA_SCORE_THRESHOLD`, mặc định 5/6)
+  `total` cao. Story đạt ngưỡng (`config.DRAMA_SCORE_THRESHOLD`, mặc định **4/6**)
   giữ nguyên `status='pending'`, sẵn sàng cho rewriter.
+  **Nới ngưỡng + tinh chỉnh rubric (issue #86 follow-up):** ở 5/6, vì `safe=1`
+  bắt buộc, story phải trúng 4/5 tiêu chí nội dung — nhưng drama Lemmy thật
+  (relationship_advice/aita/asklemmy) hiếm khi có TWIST kiểu phim nên đa số kẹt
+  ở 4/6 → cả batch ~4 story/ngày ra 0 pass → 0 video. Fix: (1) hạ mặc định
+  xuống **4/6** (= safe + 3 tín hiệu nội dung, còn hạ được xuống 3 qua env ngày
+  nguồn quá mỏng); (2) prompt rubric nới **TWIST** (chấp nhận leo thang/tiết lộ
+  đẩy cảm xúc, không bắt buộc cú lật kiểu phim) và định nghĩa lại **SAFE** để
+  chặn *mô tả trần trụi/đồ hoạ* chứ không chặn *chủ đề* nhạy cảm (ngoại tình/ly
+  hôn/mâu thuẫn gia đình VẪN an toàn — đó là chất liệu drama). Review gate người
+  thật (`review_bot`) vẫn đứng giữa đây và publish nên nới bộ lọc không đồng
+  nghĩa đăng bừa.
 - **`processors/drama_rewriter.py`** — module quan trọng nhất: Việt hoá story
   bằng Sonnet (đổi tên/địa điểm sang VN, thêm `vn_commentary` ≥20% thời
   lượng). `validate_rewrite()` là heuristic gate độc lập với prompt (word

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -288,7 +288,18 @@ PROMPT_VERSION = os.getenv("PROMPT_VERSION", "v1")
 
 # Drama rubric scoring threshold (out of 6 criteria) — story must score
 # >= this AND safe=1 to proceed to the rewriter.
-DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "5"))
+#
+# Lowered 5 -> 4 (issue #86 follow-up): at 5/6, since safe=1 is mandatory, a
+# story had to hit 4 of the 5 *content* criteria (hook/stakes/twist/localizable/
+# comment_bait). Real Lemmy drama (relationship_advice/aita/asklemmy) rarely has
+# a cinematic TWIST, so most stories capped at 4/6 and the whole day's ~4-story
+# batch scored 0 passes -> 0 videos. 4/6 = safe + any 3 content signals, a
+# realistic bar for genuine drama. The rubric prompt was also re-tuned so TWIST
+# accepts an escalation/reveal (not only a plot reversal) and SAFE gates graphic
+# *depiction*, not conflict *themes* (see prompts/drama/scorer.v1.txt). Drop to 3
+# via env on a very thin source day; raise back to 5 if quality dips. A human
+# review gate (review_bot) still stands between here and publish.
+DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "4"))
 
 # Output token ceiling for drama_rewriter's Sonnet call (issue #82). The
 # rewriter must emit an 800-1200 word Vietnamese script + a >=200 word

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -301,6 +301,28 @@ DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "5"))
 # escalates from here (x1.5, x2) if a run still truncates.
 DRAMA_REWRITER_MAX_TOKENS = int(os.getenv("DRAMA_REWRITER_MAX_TOKENS", "4096"))
 
+# Drama rewriter script word-count validation (issue #86). The prompt asks
+# Sonnet for an 800-1200 word script, but an LLM never hits an exact target —
+# story #2 came back at 733 words (a complete, substantial script, just 67 words
+# shy) and was hard-rejected identically to a broken stub, so the whole run
+# rendered 0 videos. The fix separates the "ideal target" from the "reject
+# floor": validation now uses two bands.
+#   - [SOFT_MIN, SOFT_MAX]                    ideal → approve cleanly
+#   - [HARD_MIN, SOFT_MIN) or (SOFT_MAX, HARD_MAX]
+#                                             short/long of ideal but still a
+#                                             real, complete script → approve
+#                                             with a logged note (observability)
+#   - < HARD_MIN or > HARD_MAX                genuinely broken (truncated stub /
+#                                             runaway or looping output) → reject
+# Short-form drama runs ~45-90s TTS, so 600 words is a sane floor for a complete
+# script; 1500 caps runaway output before the video budget blows out. The prompt
+# keeps aiming for 800-1200 (aspirational) — we only widen what we'll *accept*.
+# All env-overridable so the bands can be tuned without a code change.
+DRAMA_SCRIPT_SOFT_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MIN_WORDS", "800"))
+DRAMA_SCRIPT_SOFT_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MAX_WORDS", "1200"))
+DRAMA_SCRIPT_HARD_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MIN_WORDS", "600"))
+DRAMA_SCRIPT_HARD_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MAX_WORDS", "1500"))
+
 # --- Lemmy (issue #78 follow-up: Reddit-alternative source for Drama) ---
 # Lemmy is a federated, open Reddit alternative with a public read API (no
 # OAuth, no approval — unlike Reddit post-Nov-2025). Drama stories come out in

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -49,8 +49,6 @@ _RESPONSE_SNIPPET_CHARS = 600
 _JSON_PREFILL = "{"
 
 _REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
-_SCRIPT_MIN_WORDS = 800
-_SCRIPT_MAX_WORDS = 1200
 _VN_COMMENTARY_MIN_WORDS = 200
 # Structure heuristic ("Hook 3s → Setup → Escalation → Twist → Reflection"):
 # a real 3-second hook is one short punchy line, not a paragraph. Can't
@@ -71,14 +69,58 @@ _WESTERN_NAME_FRAGMENTS = (
 )
 
 
+def _script_length_verdict(word_count: int) -> tuple[str | None, str | None]:
+    """Classify a script's word count against the two validation bands (issue #86).
+
+    Pure function. Returns ``(blocking_issue, soft_note)`` where at most one is
+    non-None:
+    - ``blocking_issue``: below ``HARD_MIN`` or above ``HARD_MAX`` — a truncated
+      stub or runaway/looping output. The caller rejects it to 'needs_review'.
+    - ``soft_note``: inside the accept range but outside the ideal ``SOFT`` band.
+      The caller still approves (it's a complete, real script) but logs the note
+      so a persistently-short model is visible for prompt/threshold tuning.
+    - both None: inside the ideal band.
+
+    Reading the bounds from ``config`` (not module constants) keeps them
+    env-overridable, matching DRAMA_REWRITER_MAX_TOKENS / DRAMA_SCORE_THRESHOLD.
+    """
+    hard_min = config.DRAMA_SCRIPT_HARD_MIN_WORDS
+    hard_max = config.DRAMA_SCRIPT_HARD_MAX_WORDS
+    soft_min = config.DRAMA_SCRIPT_SOFT_MIN_WORDS
+    soft_max = config.DRAMA_SCRIPT_SOFT_MAX_WORDS
+
+    if word_count < hard_min:
+        return (
+            f"script word count {word_count} below hard minimum {hard_min} "
+            f"(likely a truncated/stub script, not a full story)",
+            None,
+        )
+    if word_count > hard_max:
+        return (
+            f"script word count {word_count} above hard maximum {hard_max} "
+            f"(likely runaway/looping output)",
+            None,
+        )
+    if not (soft_min <= word_count <= soft_max):
+        return (
+            None,
+            f"script word count {word_count} outside ideal {soft_min}-{soft_max} "
+            f"but within accepted {hard_min}-{hard_max} — approving",
+        )
+    return (None, None)
+
+
 def validate_rewrite(result: dict) -> list[str]:
     """Heuristic quality gate for a rewriter JSON result.
 
-    Pure function, no network — returns a list of human-readable issues;
-    an empty list means the rewrite passes. Checked (per phase-3-detailed.md
-    EPIC #3.2 "Validation post-rewrite"):
+    Pure function, no network — returns a list of human-readable *blocking*
+    issues; an empty list means the rewrite passes. Checked (per
+    phase-3-detailed.md EPIC #3.2 "Validation post-rewrite"):
     - all required fields present and non-empty
-    - `script` word count in [800, 1200]
+    - `script` word count within the accepted band [HARD_MIN, HARD_MAX]
+      (issue #86: the ideal is [SOFT_MIN, SOFT_MAX] = 800-1200, but a script
+      merely short/long of ideal is accepted, not blocked — see
+      `_script_length_verdict`)
     - `vn_commentary` >= 200 words
     - `hook` is a short punchy line, not a paragraph (structure heuristic)
     - no common Western name fragments / US-culture terms leaking through
@@ -91,12 +133,9 @@ def validate_rewrite(result: dict) -> list[str]:
         return issues  # other checks need these fields to make sense
 
     script = result["script"]
-    word_count = len(script.split())
-    if not (_SCRIPT_MIN_WORDS <= word_count <= _SCRIPT_MAX_WORDS):
-        issues.append(
-            f"script word count {word_count} outside "
-            f"{_SCRIPT_MIN_WORDS}-{_SCRIPT_MAX_WORDS}"
-        )
+    blocking, _soft = _script_length_verdict(len(script.split()))
+    if blocking:
+        issues.append(blocking)
 
     hook_word_count = len(result["hook"].split())
     if hook_word_count > _HOOK_MAX_WORDS:
@@ -339,6 +378,12 @@ def rewrite_story(story_id: int) -> dict | None:
         logger.warning("Story %d rewrite failed validation: %s", story_id, issues)
         _alert_validation_failure(story_id, issues)
     else:
+        # Passed the gate. If the script is short/long of the ideal band (but
+        # still within the accepted range), surface it — a model that keeps
+        # landing here is a signal to tune the prompt or thresholds (issue #86).
+        _, soft_note = _script_length_verdict(len(result["script"].split()))
+        if soft_note:
+            logger.info("Story %d approved with note: %s", story_id, soft_note)
         update_status(story_id, "approved", rewritten_content=rewritten_json)
         logger.info("Story %d rewritten and validated OK", story_id)
 

--- a/content-pipeline/prompts/drama/scorer.v1.txt
+++ b/content-pipeline/prompts/drama/scorer.v1.txt
@@ -3,10 +3,10 @@ Chấm story sau theo 6 tiêu chí (mỗi tiêu chí 0 hoặc 1):
 
 1. HOOK_3S: Có thể tóm tắt mâu thuẫn trong 1 câu khiến người xem khựng lại không?
 2. STAKES: Nhân vật đang mất gì rõ ràng? (tiền, danh dự, mối quan hệ, công việc)
-3. TWIST: Có khoảnh khắc 'À HÓA RA' hoặc cú lật ngược không?
+3. TWIST: Có khoảnh khắc 'À HÓA RA', cú lật ngược, HOẶC một diễn biến/tiết lộ đẩy cảm xúc lên cao trào không? (không bắt buộc phải là cú twist kiểu phim - một câu chuyện leo thang căng thẳng rồi vỡ oà cũng tính)
 4. LOCALIZABLE: Có thể chuyển sang bối cảnh Việt Nam tự nhiên không?
 5. COMMENT_BAIT: Khán giả có lý do để bình luận phân định ai sai/đúng không?
-6. SAFE: Không có sex/tự sát/bạo lực cụ thể/hate speech?
+6. SAFE: KHÔNG chứa mô tả tình dục chi tiết, hướng dẫn/cổ vũ tự sát, bạo lực đồ hoạ (máu me, tra tấn), hay hate speech? (Lưu ý: các CHỦ ĐỀ nhạy cảm như ngoại tình, ly hôn, mâu thuẫn gia đình, bị phản bội VẪN an toàn - đây là chất liệu chính của drama; chỉ chấm 0 khi có nội dung mô tả TRẦN TRỤI/ĐỒ HOẠ đúng nghĩa)
 
 STORY:
 {{RAW_CONTENT}}

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -71,11 +71,48 @@ class TestValidateRewrite(unittest.TestCase):
         self.assertTrue(any("missing/empty" in i for i in issues))
 
     def test_script_too_short_flagged(self):
+        # Below the hard floor (600) — a stub, still a blocking issue.
         issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=100))
         self.assertTrue(any("word count" in i for i in issues))
 
     def test_script_too_long_flagged(self):
+        # Above the hard ceiling (1500) — runaway output, still blocked.
         issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=2000))
+        self.assertTrue(any("word count" in i for i in issues))
+
+    def test_script_below_ideal_but_above_hard_min_passes(self):
+        # Issue #86: a complete 733-word script (short of the 800 ideal but well
+        # above the 600 floor) must NOT be rejected — that was the whole bug.
+        self.assertEqual(drama_rewriter.validate_rewrite(_good_rewrite(word_count=733)), [])
+
+    def test_script_at_hard_min_boundary_passes(self):
+        self.assertEqual(
+            drama_rewriter.validate_rewrite(
+                _good_rewrite(word_count=drama_rewriter.config.DRAMA_SCRIPT_HARD_MIN_WORDS)
+            ),
+            [],
+        )
+
+    def test_script_just_below_hard_min_flagged(self):
+        issues = drama_rewriter.validate_rewrite(
+            _good_rewrite(word_count=drama_rewriter.config.DRAMA_SCRIPT_HARD_MIN_WORDS - 1)
+        )
+        self.assertTrue(any("word count" in i for i in issues))
+
+    def test_script_above_ideal_but_below_hard_max_passes(self):
+        # Symmetric to the min side: a complete script slightly over the 1200
+        # ideal is accepted, not rejected like genuinely runaway output.
+        self.assertEqual(
+            drama_rewriter.validate_rewrite(
+                _good_rewrite(word_count=drama_rewriter.config.DRAMA_SCRIPT_SOFT_MAX_WORDS + 100)
+            ),
+            [],
+        )
+
+    def test_script_just_above_hard_max_flagged(self):
+        issues = drama_rewriter.validate_rewrite(
+            _good_rewrite(word_count=drama_rewriter.config.DRAMA_SCRIPT_HARD_MAX_WORDS + 1)
+        )
         self.assertTrue(any("word count" in i for i in issues))
 
     def test_short_vn_commentary_flagged(self):
@@ -229,6 +266,18 @@ class TestRewriteStory(RewriterTestBase):
         story = stories.get_story(self.story_id)
         self.assertEqual(story["status"], "approved")
         self.assertIn("Sếp bắt", story["rewritten_content"])
+
+    def test_below_ideal_script_still_approved(self):
+        # Issue #86 end-to-end: a 733-word rewrite (short of the 800 ideal but
+        # above the 600 floor) must be APPROVED and produce a video, not sent to
+        # needs_review. Regression for "pipeline rendered 0 videos".
+        with _mock_anthropic(_good_rewrite(word_count=733)), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            result = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(result)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+        alert.assert_not_called()  # accepted scripts must not spam the alert
 
     def test_invalid_rewrite_sets_needs_review_and_alerts(self):
         bad = _good_rewrite(word_count=50)

--- a/content-pipeline/tests/test_drama_scorer.py
+++ b/content-pipeline/tests/test_drama_scorer.py
@@ -1,6 +1,7 @@
 """Tests for processors/drama_scorer.py (Phase 3 — Drama Generation Layer)."""
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
@@ -89,6 +90,30 @@ class TestScoreStory(ScorerTestBase):
             drama_scorer.score_story(self.story_id)
         story = stories.get_story(self.story_id)
         self.assertEqual(story["status"], "rejected")
+
+    def test_story_without_twist_still_passes_at_lowered_threshold(self):
+        # Issue #86 follow-up: a realistic drama story that lacks a cinematic
+        # TWIST but is otherwise strong (safe + hook + stakes + localizable +
+        # comment_bait = 5/6, twist=0) must pass. It also passes at total=4;
+        # this fixture is 5/6 to document that dropping only TWIST is fine now.
+        json_text = ('{"hook_3s":1,"stakes":1,"twist":0,"localizable":1,'
+                     '"comment_bait":1,"safe":1,"reason":"no twist but gripping"}')
+        with _mock_anthropic(json_text):
+            result = drama_scorer.score_story(self.story_id)
+        self.assertEqual(result["total"], 5)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "pending")
+
+    def test_story_at_exactly_threshold_passes(self):
+        # safe=1 plus just enough content criteria to reach the threshold.
+        thr = drama_scorer.config.DRAMA_SCORE_THRESHOLD
+        content = ["hook_3s", "stakes", "twist", "localizable", "comment_bait"]
+        vals = {k: (1 if i < thr - 1 else 0) for i, k in enumerate(content)}
+        vals["safe"] = 1
+        with _mock_anthropic(json.dumps(vals)):
+            result = drama_scorer.score_story(self.story_id)
+        self.assertEqual(result["total"], thr)
+        self.assertEqual(stories.get_story(self.story_id)["status"], "pending")
 
     def test_unsafe_story_rejected_even_with_high_total(self):
         json_text = ('{"hook_3s":1,"stakes":1,"twist":1,"localizable":1,'


### PR DESCRIPTION
Fixes #86.

The drama pipeline was running to completion but rendering **0 videos**. Two independent over-strict gates each stop stories cold; this PR fixes both.

---

## Gate 1 — rewriter word-count validation (the original #86)

`validate_rewrite()` rejected any script outside `[800, 1200]` words, and 800 is the *exact* number the prompt asks Sonnet to produce. LLMs never hit an exact target, so a complete **733-word** script (92% of target) was treated *identically to a broken 50-word stub* → `needs_review`. Same cliff existed on the max side.

**Fix — two-band gate** (`_script_length_verdict()`):

| Word count | Verdict |
|---|---|
| `[HARD_MIN, HARD_MAX]` = 600–1500 | Accepted |
| Outside ideal 800–1200 but inside accept band | Approved + logged note, no alert |
| `< 600` (stub) or `> 1500` (runaway) | Blocked → `needs_review` + alert |

Keeps stub/runaway detection, symmetric, observable, env-overridable (`DRAMA_SCRIPT_{SOFT,HARD}_{MIN,MAX}_WORDS`). Prompt still aims 800–1200; only the *accepted* range widens.

## Gate 2 — scorer rubric too strict for real drama (follow-up)

With `DRAMA_SCORE_THRESHOLD=5/6` and `safe=1` mandatory, a story needed **4 of 5** content criteria. Real Lemmy drama (relationship_advice / aita / asklemmy) rarely has a cinematic **TWIST**, so most stories capped at 4/6 → a whole ~4-story day scored **0 passes**. Two structural over-rejectors:

- **TWIST** demanded a plot reversal → broadened to accept escalation/reveal (a tension-then-payoff story counts, not only a movie twist).
- **SAFE** vetoed on sensitive *themes* (infidelity, breakups, family conflict — the raw material of drama) → re-scoped to gate graphic *depiction* (explicit sex, self-harm promotion, gore, hate speech), not themes.

Plus `DRAMA_SCORE_THRESHOLD` default **5 → 4** (= safe + any 3 content signals), env-tunable to 3 for very thin source days. A human review gate (`review_bot`) still stands between scoring and publish, so the looser filter doesn't mean auto-publishing.

---

## Changes

- `config.py` — word-count bands + lowered score threshold, both with rationale.
- `processors/drama_rewriter.py` — `_script_length_verdict()`; hard-band-only reject; soft-band note on approve.
- `prompts/drama/scorer.v1.txt` — TWIST + SAFE re-tuned.
- `tests/` — regression tests for both gates (733 approves; stub/runaway reject; no-twist and at-threshold stories pass).
- `CLAUDE.md` — documents both changes.

## Verification

Full drama suite green — 85 tests (`test_drama_rewriter`, `test_drama_quality`, `test_drama_scorer`, `test_main_drama`), plus band-boundary spot checks.

## Follow-up idea (not in this PR)

For a thin source (~4 stories/day), *any* fixed absolute bar risks 0 output on a slow day and junk on a rich day. A **top-K relative selection** — rank the day's safe candidates and take the best K above a low floor — would guarantee output whenever raw material exists while still preferring the best. It's a larger change to the score→reject→rewrite flow; happy to do it as a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2a5s5PZjY4VVVE3sC8Siv