### PR TITLE
fix(#88) + auto-publish YouTube: unbreak review button + drop blocking ✅ gate for YouTube

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,17 +371,32 @@ gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
 ## Distribution Layer (Phase 5)
 
 Xem `docs/current/phase-5-detailed.md`/`phase-5-issues.md`. Đưa video đã
-render tới đúng kênh: review gate → duyệt → xếp lịch theo cadence → upload
-multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
+render tới đúng kênh: **tự phát hành** (`review_bot.auto_dispatch`) → YouTube xếp
+lịch theo cadence + tự upload, TikTok gửi Telegram đăng tay. Track Drama chạy
+end-to-end qua `main_drama.py`. (Review gate ✅/❌/✏️ vẫn còn cho duyệt tay video
+cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên dưới.)
 
-- **`notifier/review_bot.py`** — review gate với inline keyboard ✅/❌/✏️.
+- **`notifier/review_bot.py`** — routing + review handlers.
   **Khác với tài liệu thiết kế:** doc vẽ `review_bot.py` như bot mới; thực tế
   đây là các handler THUẦN được `telegram_bot._handle_update()` /
   `_handle_callback_query()` gọi trong CÙNG vòng long-polling — cùng lý do
-  seed_bot Phase 2 (2 process cùng token → 409 Conflict). ✅ Approve → xếp
-  lịch qua scheduler (KHÔNG publish ngay). **CẢ 2 track AI + Drama** đều đi
-  qua review gate + `post_scheduler` này (track AI không còn publish-ngay).
-  Kênh TikTok khi duyệt KHÔNG auto-schedule — video được gửi qua Telegram tới
+  seed_bot Phase 2 (2 process cùng token → 409 Conflict).
+  **TỰ PHÁT HÀNH — bỏ nút ✅ chặn cho YouTube (yêu cầu chủ kênh):** ban đầu
+  Phase 5 bắt CẢ 2 track AI + Drama qua review gate (bấm ✅ mới xếp lịch). Nhưng
+  chủ kênh đã có CADENCE tự đăng YouTube nên KHÔNG muốn duyệt tay YouTube — chỉ
+  muốn xem trước video TikTok để đăng tay. Nay `auto_dispatch(video_id)` thay
+  `push_review` ở bước render (main.py/main_drama.py): claim `ready`→`approved`
+  (idempotent, chống dispatch trùng khi resume) rồi route MỌI kênh qua
+  `_route_all` (dùng chung với `_approve`): **YouTube → `schedule_video` (CADENCE,
+  tick tự upload); TikTok → `send_tiktok_manual` (Telegram Bé MC đăng tay)** +
+  1 tin Telegram **FYI không nút chặn** (đính kèm preview NẾU video chưa tới
+  Telegram qua đường TikTok — tránh gửi trùng file; video long chỉ-YouTube thì
+  luôn kèm preview). `_send_dispatch_fyi` best-effort (nuốt lỗi notifier). Video
+  kẹt `ready` (dispatch lỗi) được `_dispatch_stuck_videos`/`_dispatch_ready_ai_videos`
+  thử lại lần chạy sau. **Review gate ✅/❌/✏️ (`_approve`/`_reject`/`handle_callback`)
+  GIỮ NGUYÊN** cho video cũ đang `pending_approval` + duyệt tay khi cần (vd
+  `needs_review`), chỉ không còn là đường mặc định của video mới.
+  Kênh TikTok KHÔNG auto-schedule — video được gửi qua Telegram tới
   kênh "Bé MC" (`telegram_bot.send_tiktok_manual`) để upload tay
   (`_route_to_channel`). ❌ Reject → hỏi lý do, lưu `videos.review_note`;
   ✏️ Edit → FSM chọn field (allowlist trong
@@ -436,7 +451,8 @@ multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
   đường dẫn. `publisher/tiktok_manual.export_for_manual_upload` giờ chỉ là
   fallback lưu file gốc, không còn là đường chính.
 - **`main_drama.py`** — orchestrator: collect → score → rewrite → render
-  (TTS voice drama + `compose_drama_video`) → push review. **Bước collect (follow-up
+  (TTS voice drama + `compose_drama_video`) → `auto_dispatch` (tự phát hành:
+  YouTube cadence + TikTok Telegram tay, không nút ✅). **Bước collect (follow-up
   #78) gọi nhiều nguồn độc lập, best-effort (một nguồn lỗi không kéo cả bước):
   Reddit (tắt mặc định), Lemmy (`collect_all_lemmy` — nguồn TƯƠI chính), và HF
   `--newest` (`import_dataset(newest=True)` CHỈ khi `HF_DRAMA_DAILY_ENABLED=1`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,21 @@ multi-channel. Track Drama chạy end-to-end qua `main_drama.py`.
   `video/preview.py`) thay vì bỏ qua như trước — file gốc không bị đụng;
   nén thất bại → fallback script-only review như cũ (issue #60). Flow duyệt
   cũ (`send_video_for_approval`, track AI) cũng dùng compressor này.
+  **Nút "Duyệt" không phản hồi (issue #88) — 3 root cause đã sửa trong
+  `telegram_bot.py`:** (1) *409 Conflict vĩnh viễn* — webhook tồn đọng loại
+  trừ long-poll nên MỌI `getUpdates` trả 409 bất kể số instance;
+  `run_bot` gọi `_delete_webhook()` (giữ pending) lúc khởi động, và `_get_updates`
+  tự chữa + lùi 5s khi gặp 409 thay vì nuốt lỗi rồi busy-loop nã API/spam log.
+  (2) *answerCallbackQuery 400 "query too old"* — `_handle_callback_query` **ack
+  callback TRƯỚC** khi chạy `handle_callback` (approve = ghi DB + xếp lịch + gửi
+  file mất vài giây, quá cửa sổ vài giây của Telegram) → nút nhả tức thì (toast
+  "⏳ Đang xử lý…"), việc nặng chạy sau, kết quả gửi bằng message riêng; 400 kiểu
+  này là LÀNH nên log `info` kèm `callback_id` + `description` thật (đọc body
+  HTTPError qua `_read_error_body`, `str()` giấu mất) thay vì ERROR. (3) *plist
+  deploy tay còn `/Users/YOU`* → launchd exec fail EX_CONFIG, bot không chạy:
+  `launchd/install.sh` render placeholder sẵn, nay thêm guard từ chối cài bản
+  còn sót placeholder / cảnh báo wrapper không tồn tại. Watchdog service kẹt
+  (issue #74/#75) đã có sẵn ở `storage/launchd_status.py`.
 - **`publisher/youtube_uploader.py`** — `upload_to_youtube(video_id,
   channel_key)`: token OAuth tra qua `channels.py[key]["oauth_token_env"]` →
   env var trỏ tới file token (đúng convention Phase 1/oauth-setup.md,

--- a/content-pipeline/launchd/install.sh
+++ b/content-pipeline/launchd/install.sh
@@ -55,18 +55,16 @@ bootstrap_one() {
 
     # Guard (issue #88): bot deploy tay từng để sót placeholder /Users/YOU →
     # launchd exec path không tồn tại → crash EX_CONFIG, bot không bao giờ chạy.
-    # Ở đây render tự động nên placeholder phải biến mất; nếu còn (biến thể
-    # placeholder lạ trong plist) hoặc wrapper đích không tồn tại thì báo to,
-    # không cài bản hỏng.
-    if grep -q "/Users/YOU" "$dst"; then
-        echo "  ⚠️  $label — còn sót '/Users/YOU' sau render, KHÔNG cài (sửa placeholder trong $src)." >&2
-        rm -f "$dst"
-        return 1
-    fi
+    # Chỉ soi ĐÚNG đường dẫn Program executable — KHÔNG grep cả file: các plist
+    # cố ý giữ câu chú thích "Replace /Users/YOU with your actual home directory
+    # path" mà sed (chỉ đổi placeholder ĐẦY ĐỦ) không đụng tới; grep cả file sẽ
+    # ăn nhầm comment đó và loại MỌI plist (Codex bắt ở PR #89). Wrapper đích
+    # không tồn tại/không executable (placeholder chưa render, repo sai chỗ) →
+    # cảnh báo to nhưng vẫn thử load để không chặn cứng như bản grep-cả-file.
     local prog
-    prog="$(sed -n 's|.*<string>\(.*/run_[a-z_]*\.sh\)</string>.*|\1|p' "$dst" | head -1)"
+    prog="$(sed -n 's|.*<string>\(/[^<]*run_[a-z_]*\.sh\)</string>.*|\1|p' "$dst" | head -1)"
     if [ -n "$prog" ] && [ ! -x "$prog" ]; then
-        echo "  ⚠️  $label — wrapper '$prog' không tồn tại/không executable; bot sẽ crash. Kiểm tra đường dẫn repo." >&2
+        echo "  ⚠️  $label — wrapper '$prog' không tồn tại/không executable; bot sẽ crash EX_CONFIG. Kiểm tra placeholder/đường dẫn repo trong $src." >&2
     fi
 
     # Idempotent: gỡ bản đang load (nếu có) rồi load bản vừa render. Đây chính

--- a/content-pipeline/launchd/install.sh
+++ b/content-pipeline/launchd/install.sh
@@ -53,6 +53,22 @@ bootstrap_one() {
     # Render placeholder → đường dẫn thật (repo giữ nguyên placeholder)
     sed "s|$PLACEHOLDER|$PIPELINE_DIR|g" "$src" > "$dst"
 
+    # Guard (issue #88): bot deploy tay từng để sót placeholder /Users/YOU →
+    # launchd exec path không tồn tại → crash EX_CONFIG, bot không bao giờ chạy.
+    # Ở đây render tự động nên placeholder phải biến mất; nếu còn (biến thể
+    # placeholder lạ trong plist) hoặc wrapper đích không tồn tại thì báo to,
+    # không cài bản hỏng.
+    if grep -q "/Users/YOU" "$dst"; then
+        echo "  ⚠️  $label — còn sót '/Users/YOU' sau render, KHÔNG cài (sửa placeholder trong $src)." >&2
+        rm -f "$dst"
+        return 1
+    fi
+    local prog
+    prog="$(sed -n 's|.*<string>\(.*/run_[a-z_]*\.sh\)</string>.*|\1|p' "$dst" | head -1)"
+    if [ -n "$prog" ] && [ ! -x "$prog" ]; then
+        echo "  ⚠️  $label — wrapper '$prog' không tồn tại/không executable; bot sẽ crash. Kiểm tra đường dẫn repo." >&2
+    fi
+
     # Idempotent: gỡ bản đang load (nếu có) rồi load bản vừa render. Đây chính
     # là thao tác "reload" khắc phục EX_CONFIG khi launchd giữ handle inode stale
     # (WorkingDirectory/StandardOutPath) sau rebuild venv/re-clone (issue #74/#75).

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -11,13 +11,14 @@ Pipeline hoàn chỉnh:
 5. Tạo script video (dài + ngắn)
 6. TTS → audio
 7. Subtitle + background → video
-8. Gửi Telegram để duyệt
-9. Approve → publish ngay lập tức
+8. Tự phát hành (review_bot.auto_dispatch): YouTube (AI Hôm Nay) tự đăng theo
+   CADENCE qua post_scheduler, TikTok gửi Telegram (Bé MC) đăng tay + 1 tin FYI.
+   KHÔNG còn nút ✅ chặn.
 
 2 entry point:
 - python main.py         → Chạy pipeline tạo video (launchd mỗi sáng 7:00)
 - python main.py --bot   → Chạy Telegram bot liên tục (launchd daemon)
-                            Bot lắng nghe /approve → publish ngay
+                            Bot xử lý callback review cũ + seed/analytics
 """
 
 import argparse
@@ -117,10 +118,10 @@ def run_pipeline(force_video: str | None = None):
     config.validate_flags(logger)
     errors = []
 
-    # Resume-safety: video AI đã render nhưng push review lỗi (Telegram down)
-    # kẹt ở 'ready'. Gửi lại trước khi tạo video mới — cùng cơ chế
-    # main_drama._repush_stuck_reviews cho track Drama.
-    _repush_ready_ai_videos()
+    # Resume-safety: video AI đã render nhưng auto_dispatch lỗi (Telegram/
+    # scheduler down) kẹt ở 'ready'. Dispatch lại trước khi tạo video mới —
+    # cùng cơ chế main_drama._dispatch_stuck_videos cho track Drama.
+    _dispatch_ready_ai_videos()
 
     # Watchdog issue #72: pipeline này là service được xác nhận chạy hằng ngày,
     # nên nó tự kiểm tra các service launchd còn lại (drama-pipeline,
@@ -253,23 +254,22 @@ def run_pipeline(force_video: str | None = None):
     logger.info("=== Pipeline completed ===")
 
 
-def _repush_ready_ai_videos() -> int:
-    """Gửi duyệt lại video AI kẹt 'ready' (push_review lỗi lần trước).
+def _dispatch_ready_ai_videos() -> int:
+    """Tự phát hành lại video AI kẹt 'ready' (auto_dispatch lỗi lần trước).
 
-    push_review() tự chuyển sang 'pending_approval' khi thành công nên không
-    bao giờ push trùng. Chỉ đụng track='ai' — track Drama do
-    main_drama._repush_stuck_reviews lo.
+    auto_dispatch() claim 'ready'→'approved' nên không bao giờ route trùng. Chỉ
+    đụng track='ai' — track Drama do main_drama._dispatch_stuck_videos lo.
     """
     from storage.database import get_videos_by_status
-    from notifier.review_bot import push_review
+    from notifier.review_bot import auto_dispatch
     count = 0
     for video in get_videos_by_status("ready"):
         if (video.get("track") or "ai") != "ai":
             continue
-        if push_review(video["id"]):
+        if auto_dispatch(video["id"]):
             count += 1
     if count:
-        logger.info("Re-pushed %d stuck 'ready' AI video(s) for review", count)
+        logger.info("Re-dispatched %d stuck 'ready' AI video(s)", count)
     return count
 
 
@@ -405,16 +405,17 @@ def _create_video(narrative: str, video_type: str, date_str: str,
     set_video_subtitles_burned(video_id, burn)
     update_video_status(video_id, "ready")
 
-    # Step 6: Đẩy vào review gate (nút ✅/❌/✏️). ✅ → xếp lịch qua
-    # post_scheduler theo cadence (Mon-Sat short / Sun long), KHÔNG publish
-    # ngay — thống nhất với track Drama. Push lỗi (Telegram down) để video
-    # kẹt 'ready'; _repush_ready_ai_videos() ở run_pipeline gửi lại lần sau.
-    from notifier.review_bot import push_review
-    if not push_review(video_id):
-        logger.error("Could not push AI video %d for review — stays 'ready', "
-                     "sẽ được gửi lại ở lần chạy sau", video_id)
+    # Step 6: Tự phát hành. YouTube (ai_youtube) tự đăng theo CADENCE qua
+    # post_scheduler (Mon-Sat short / Sun long), TikTok gửi Telegram đăng tay —
+    # KHÔNG còn nút ✅ chặn (thống nhất với track Drama). Dispatch lỗi (Telegram/
+    # scheduler down) để video kẹt 'ready'; _dispatch_ready_ai_videos() ở
+    # run_pipeline tự thử lại lần sau.
+    from notifier.review_bot import auto_dispatch
+    if not auto_dispatch(video_id):
+        logger.error("Could not auto-dispatch AI video %d — stays 'ready', "
+                     "sẽ được thử lại ở lần chạy sau", video_id)
 
-    logger.info("Video %d created and pushed for review", video_id)
+    logger.info("Video %d created and auto-dispatched", video_id)
     return video_id
 
 

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -12,12 +12,13 @@ Drama Track Orchestrator (Phase 5 EPIC #5.4) — pipeline end-to-end:
 2. Score    — rubric 6 tiêu chí bằng Haiku (Phase 3, processors/drama_scorer.py)
 3. Rewrite  — Việt hoá bằng Sonnet (Phase 3, processors/drama_rewriter.py)
 4. Render   — TTS + phụ đề + multi-scene composer (Phase 4, video/drama_composer.py)
-5. Review   — push preview + nút ✅/❌/✏️ (Phase 5, notifier/review_bot.py)
-6. Schedule — khi ✅, bot xếp lịch qua scheduler/post_scheduler.py (Phase 5)
+5. Dispatch — TỰ phát hành (review_bot.auto_dispatch): YouTube (Chuyện Đời) tự
+              đăng theo CADENCE qua scheduler/post_scheduler.py, TikTok gửi
+              Telegram (Bé MC) đăng tay + 1 tin FYI. KHÔNG còn nút ✅ chặn.
 
 Resume-from-crash: mỗi bước đọc trạng thái từ DB thay vì nhớ trong RAM —
 story đi 'pending' → (scored) → 'approved' → 'produced'; video đi 'draft' →
-'ready' → 'pending_approval' → 'approved' → 'published'. Chạy lại sau crash:
+'ready' → 'approved' → 'published'. Chạy lại sau crash:
 - collector dedupe theo source_id (Phase 2);
 - scorer/rewriter chỉ nhặt story chưa có rubric_score/rewritten_content;
 - render bỏ qua story đã có video row (videos.story_id, migration 006) — một
@@ -91,38 +92,38 @@ def build_narration(rewrite: dict) -> str:
     return "\n\n".join(parts)
 
 
-def _repush_stuck_reviews() -> int:
-    """Gửi duyệt lại video drama đã render xong nhưng chưa tới tay reviewer.
+def _dispatch_stuck_videos() -> int:
+    """Tự phát hành lại video drama đã render xong nhưng chưa dispatch được.
 
-    push_review() lỗi (Telegram down lúc render) để video kẹt 'ready' trong
-    khi story đã 'produced' — resume guard chặn render lại nên không gì tự
-    đẩy video đó vào flow duyệt nữa (finding của Codex review PR #70). Mỗi
-    lần chạy render, thử push lại các video như vậy; thành công thì
-    push_review tự chuyển 'pending_approval' nên không bao giờ push trùng.
+    auto_dispatch() lỗi (Telegram/scheduler down lúc render) để video kẹt
+    'ready' trong khi story đã 'produced' — resume guard chặn render lại nên
+    không gì tự đẩy video đó đi nữa (finding của Codex review PR #70). Mỗi lần
+    chạy render, thử dispatch lại; auto_dispatch claim 'ready'→'approved' nên
+    không bao giờ route trùng.
     """
     from storage.database import get_videos_by_status
-    from notifier.review_bot import push_review
+    from notifier.review_bot import auto_dispatch
     count = 0
     for video in get_videos_by_status("ready"):
         if video.get("track") != "drama":
             continue
-        if push_review(video["id"]):
+        if auto_dispatch(video["id"]):
             count += 1
         else:
-            logger.warning("Re-push review failed again for video %d", video["id"])
+            logger.warning("Re-dispatch failed again for video %d", video["id"])
     if count:
-        logger.info("Re-pushed %d stuck 'ready' drama video(s) for review", count)
+        logger.info("Re-dispatched %d stuck 'ready' drama video(s)", count)
     return count
 
 
 def render_approved_stories(limit: int | None = None) -> list[int]:
-    """Render các story 'approved' (đã Việt hoá) thành video + push review.
+    """Render các story 'approved' (đã Việt hoá) thành video + tự phát hành.
 
     Returns list video_id đã tạo. Story đã có video (resume guard) bị bỏ qua
     không tính vào limit.
     """
     limit = limit if limit is not None else config.DRAMA_VIDEOS_PER_RUN
-    _repush_stuck_reviews()
+    _dispatch_stuck_videos()
     stories = get_by_status("approved", limit=limit * 3, track="drama")
     created: list[int] = []
     for story in stories:
@@ -254,10 +255,13 @@ def _render_story(story: dict) -> int | None:
     update_status(story_id, "produced",
                   produced_at=datetime.now().isoformat(sep=" ", timespec="seconds"))
 
-    from notifier.review_bot import push_review
-    if not push_review(video_id):
-        logger.error("Could not push video %d for review — video stays 'ready'; "
-                     "_repush_stuck_reviews() sẽ tự gửi lại ở lần chạy render sau",
+    # Tự phát hành: YouTube auto theo CADENCE, TikTok gửi Telegram đăng tay
+    # (KHÔNG còn nút ✅ chặn). Dispatch lỗi để video kẹt 'ready';
+    # _dispatch_stuck_videos() tự thử lại lần chạy render sau.
+    from notifier.review_bot import auto_dispatch
+    if not auto_dispatch(video_id):
+        logger.error("Could not auto-dispatch video %d — video stays 'ready'; "
+                     "_dispatch_stuck_videos() sẽ tự thử lại ở lần chạy render sau",
                      video_id)
 
     logger.info("Story %d rendered → video %d (%.0fs audio)", story_id, video_id, duration)

--- a/content-pipeline/notifier/review_bot.py
+++ b/content-pipeline/notifier/review_bot.py
@@ -237,21 +237,20 @@ def handle_callback(data: str) -> tuple[str, dict | None]:
     return "⚠️ Callback không hợp lệ.", None
 
 
-def _approve(video_id: int) -> str:
-    """✅: claim pending_approval → approved, rồi xếp lịch/queue mọi kênh đích."""
-    video = get_video(video_id)
-    if not video:
-        return f"⚠️ Video {video_id} không tồn tại."
-    if not claim_video_status(video_id, "approved", "pending_approval"):
-        current = get_video(video_id)
-        return (f"⚠️ Video {video_id} không ở trạng thái chờ duyệt "
-                f"(status={current.get('status') if current else '?'}).")
+def _route_all(video: dict, header: str) -> str:
+    """Route video tới MỌI kênh đích và trả về tóm tắt từng kênh.
 
-    lines = [f"✅ Video {video_id} đã duyệt."]
+    Dùng chung cho duyệt tay (`_approve`) lẫn tự phát hành (`auto_dispatch`):
+    YouTube → xếp lịch CADENCE, TikTok → gửi Telegram (Bé MC) upload tay. Mỗi
+    kênh route độc lập — lỗi 1 kênh chỉ báo lại kèm lệnh xếp tay, không nổ cả
+    hàm (video đã claim 'approved' trước khi gọi).
+    """
+    video_id = video["id"]
+    lines = [header]
     for channel_key in _destinations_for(video):
         # get_channel nằm TRONG try: destination sai/cũ (không còn trong
         # registry) chỉ làm hỏng kênh đó và được báo lại kèm lệnh xếp lịch
-        # tay, không nổ cả handler sau khi video đã claim 'approved'.
+        # tay, không nổ cả hàm sau khi video đã claim 'approved'.
         try:
             channel = get_channel(channel_key)
             lines.append(_route_to_channel(video, channel_key, channel))
@@ -265,6 +264,96 @@ def _approve(video_id: int) -> str:
         lines.append("  ⚠️ Không xác định được kênh đích — xếp lịch tay: "
                      f"python -m scheduler.post_scheduler schedule {video_id} <channel_key>")
     return "\n".join(lines)
+
+
+def _approve(video_id: int) -> str:
+    """✅: claim pending_approval → approved, rồi xếp lịch/queue mọi kênh đích.
+
+    Từ khi bật tự phát hành (`auto_dispatch`), video MỚI không còn vào
+    'pending_approval' nữa — hàm này giữ lại cho video cũ đang chờ duyệt và cho
+    nút ✅ thủ công (vd duyệt lại video 'needs_review').
+    """
+    video = get_video(video_id)
+    if not video:
+        return f"⚠️ Video {video_id} không tồn tại."
+    if not claim_video_status(video_id, "approved", "pending_approval"):
+        current = get_video(video_id)
+        return (f"⚠️ Video {video_id} không ở trạng thái chờ duyệt "
+                f"(status={current.get('status') if current else '?'}).")
+    return _route_all(video, f"✅ Video {video_id} đã duyệt.")
+
+
+def _safe_platform(channel_key: str) -> str:
+    """Platform của kênh, "" nếu key lạ (không nổ khi dò destination cũ)."""
+    try:
+        return get_channel(channel_key)["platform"]
+    except Exception:
+        return ""
+
+
+def auto_dispatch(video_id: int) -> bool:
+    """Tự phát hành video vừa render — KHÔNG chờ duyệt tay.
+
+    Mô hình vận hành (theo yêu cầu chủ kênh): **YouTube tự đăng theo CADENCE**
+    (`post_scheduler`, tick tự upload), **TikTok gửi Telegram (Bé MC) đăng tay**.
+    Thay cho `push_review` (nút ✅ chặn) ở bước render của main.py/main_drama.py.
+
+    - Claim 'ready' → 'approved' (idempotent: chạy lại sau crash KHÔNG route
+      trùng vì video đã rời 'ready'; cũng chống re-dispatch bởi stuck-handler).
+    - Route mọi kênh đích qua `_route_all` (dùng chung với `_approve`).
+    - Gửi 1 tin Telegram **FYI (không nút chặn)**: đính kèm preview nếu video
+      CHƯA tới Telegram qua đường TikTok tay (tránh gửi trùng file nặng); còn
+      lại chỉ tóm tắt nơi đã route.
+
+    Returns True nếu vừa dispatch; False nếu video không ở 'ready' (đã dispatch
+    rồi / trạng thái khác) hoặc không tồn tại — caller không log nhầm là lỗi.
+    """
+    video = get_video(video_id)
+    if not video:
+        logger.error("auto_dispatch: video %d không tồn tại", video_id)
+        return False
+    if not claim_video_status(video_id, "approved", "ready"):
+        current = get_video(video_id)
+        logger.info("auto_dispatch: video %d không ở 'ready' (status=%s) — bỏ qua",
+                    video_id, current.get("status") if current else "?")
+        return False
+
+    dests = _destinations_for(video)
+    summary = _route_all(video, f"🚀 Video {video_id} đã tự phát hành:")
+    already_in_telegram = any(_safe_platform(k) == "tiktok" for k in dests)
+    _send_dispatch_fyi(video, summary, include_preview=not already_in_telegram)
+    logger.info("Video %d auto-dispatched (dests=%s)", video_id, dests)
+    return True
+
+
+def _send_dispatch_fyi(video: dict, summary: str, include_preview: bool) -> None:
+    """Gửi thông báo FYI sau khi tự phát hành (không nút bấm). Best-effort —
+    nuốt lỗi notifier để không phá bước render (video đã 'approved' + đã route).
+    """
+    from notifier import telegram_bot
+    try:
+        if not include_preview:
+            telegram_bot._send_text(summary)
+            return
+        video_path = video.get("video_path")
+        if not video_path or not os.path.exists(video_path):
+            telegram_bot._send_text(summary)
+            return
+        try:
+            from video.preview import compress_for_preview
+            preview_path = compress_for_preview(video_path)
+        except Exception:
+            preview_path = video_path
+        caption = summary
+        if preview_path and preview_path != video_path:
+            caption += "\nℹ️ Bản preview đã nén — file gốc dùng để upload."
+        msg_id = (telegram_bot._send_video_file(preview_path, caption)
+                  if preview_path else None)
+        if not msg_id:
+            telegram_bot._send_text(summary)
+    except Exception as e:
+        logger.warning("auto_dispatch FYI cho video %s lỗi (non-fatal): %s",
+                       video.get("id"), e)
 
 
 def _route_to_channel(video: dict, channel_key: str, channel: dict) -> str:

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -13,6 +13,7 @@ import logging
 import os
 import time
 from datetime import date
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 import sys
@@ -373,6 +374,11 @@ def run_bot(publish_callback):
     if not _acquire_bot_lock():
         return  # Another instance running — exit cleanly (no 409)
 
+    # Webhook tồn đọng khiến MỌI getUpdates trả 409 Conflict — xoá 1 lần lúc
+    # khởi động để long-polling dùng được (root cause #88). Giữ pending updates
+    # để callback approve vừa bấm vẫn tới.
+    _delete_webhook()
+
     logger.info("🤖 Telegram bot started — listening for approvals...")
     _send_text("🤖 Bot đã khởi động. Sẵn sàng nhận lệnh approve/reject.")
 
@@ -583,6 +589,12 @@ def _handle_callback_query(callback_query: dict):
         _answer_callback_query(callback_id)
         return
 
+    # ACK TRƯỚC, xử lý SAU: approve có thể mất vài giây (ghi DB + xếp lịch +
+    # gửi file), lâu hơn cửa sổ answerCallbackQuery của Telegram. Ack ngay để
+    # nút nhả tức thì (nút hiện toast "đang xử lý") và tránh 400 "query too old"
+    # (root cause #88). Kết quả gửi lại bằng message riêng bên dưới.
+    _answer_callback_query(callback_id, "⏳ Đang xử lý…")
+
     data = callback_query.get("data", "")
     try:
         from notifier import review_bot
@@ -591,7 +603,6 @@ def _handle_callback_query(callback_query: dict):
         logger.exception("Callback handling failed for %r", data)
         reply, keyboard = f"⚠️ Lỗi xử lý: {e}", None
 
-    _answer_callback_query(callback_id)
     if keyboard:
         send_message_with_keyboard(reply, keyboard)
     else:
@@ -757,8 +768,54 @@ def send_message_with_keyboard(text: str, keyboard: dict) -> bool:
         return False
 
 
+def _read_error_body(err: HTTPError) -> str:
+    """Đọc body JSON của HTTPError để lấy `description` Telegram trả về.
+
+    `str(HTTPError)` chỉ cho "HTTP Error 400: Bad Request" — giấu mất lý do
+    thật ("query is too old...", "Conflict: terminated by other getUpdates
+    request") nằm trong body. Đọc ra để log đúng chỗ cần sửa (issue #88).
+    """
+    try:
+        raw = err.read().decode("utf-8", "replace")
+    except Exception:
+        return str(err)
+    try:
+        return json.loads(raw).get("description", raw) or str(err)
+    except Exception:
+        return raw or str(err)
+
+
+def _delete_webhook(drop_pending: bool = False) -> bool:
+    """Xoá webhook (nếu có) để long-polling không bị 409 Conflict vĩnh viễn.
+
+    Webhook và getUpdates loại trừ nhau: chỉ cần bot còn cấu hình webhook là
+    MỌI getUpdates trả 409 bất kể có bao nhiêu instance (root cause #88). Gọi
+    1 lần lúc khởi động và tự chữa khi gặp 409. Mặc định KHÔNG drop pending
+    updates — callback approve người dùng vừa bấm vẫn cần được nhận.
+    """
+    if not config.TELEGRAM_BOT_TOKEN:
+        return False
+    url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/deleteWebhook"
+    payload = json.dumps({"drop_pending_updates": drop_pending}).encode("utf-8")
+    try:
+        req = Request(url, data=payload,
+                      headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req, timeout=10) as resp:
+            return resp.status == 200
+    except Exception as e:
+        logger.warning("deleteWebhook failed: %s", e)
+        return False
+
+
 def _answer_callback_query(callback_id: str, text: str = "") -> bool:
-    """Acknowledge một callback_query để nút inline hết trạng thái loading."""
+    """Acknowledge một callback_query để nút inline hết trạng thái loading.
+
+    Phải gọi CÀNG SỚM CÀNG TỐT: Telegram chỉ chấp nhận answerCallbackQuery
+    trong ~vài giây kể từ khi callback phát sinh. Nếu ack sau bước xử lý nặng
+    (approve = ghi DB + xếp lịch + gửi file) thì callback_id đã hết hạn → 400
+    "query is too old". 400 kiểu này là LÀNH (nút đã được bấm, hành động vẫn
+    chạy), nên log ở mức info + kèm callback_id để debug thay vì ERROR (issue #88).
+    """
     if not callback_id or not config.TELEGRAM_BOT_TOKEN:
         return False
     url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/answerCallbackQuery"
@@ -768,8 +825,16 @@ def _answer_callback_query(callback_id: str, text: str = "") -> bool:
                       headers={"Content-Type": "application/json"}, method="POST")
         with urlopen(req, timeout=10) as resp:
             return resp.status == 200
+    except HTTPError as e:
+        body = _read_error_body(e)
+        if e.code == 400:
+            logger.info("answerCallbackQuery bỏ qua (id=%s): %s", callback_id, body)
+        else:
+            logger.error("answerCallbackQuery failed (id=%s, code=%s): %s",
+                         callback_id, e.code, body)
+        return False
     except Exception as e:
-        logger.error("answerCallbackQuery failed: %s", e)
+        logger.error("answerCallbackQuery failed (id=%s): %s", callback_id, e)
         return False
 
 
@@ -874,6 +939,20 @@ def _get_updates(timeout: int = 30) -> list[dict]:
 
         return updates
 
+    except HTTPError as e:
+        body = _read_error_body(e)
+        if e.code == 409:
+            # 409 = webhook còn sống hoặc instance getUpdates khác đang chạy.
+            # deleteWebhook tự chữa nguyên nhân phổ biến (và vô hại nếu do
+            # instance khác); ngủ ngắn để KHÔNG busy-loop nã API + spam log —
+            # trước đây 409 bị nuốt, run_bot reset lỗi về 0 nên poll lại ngay
+            # lập tức (root cause #88).
+            logger.warning("getUpdates 409 Conflict — xoá webhook & lùi 5s: %s", body)
+            _delete_webhook()
+            time.sleep(5)
+        else:
+            logger.error("Telegram getUpdates failed (code=%s): %s", e.code, body)
+        return []
     except Exception as e:
         logger.error("Telegram getUpdates failed: %s", e)
         return []

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -133,7 +133,7 @@ class TestRenderHappyPath(RenderBase):
              patch("video.drama_composer.compose_drama_video",
                    side_effect=fake_compose) as compose, \
              patch("video.image_generator.generate_illustration", return_value=None), \
-             patch("notifier.review_bot.push_review", return_value=True) as push:
+             patch("notifier.review_bot.auto_dispatch", return_value=True) as dispatch:
             video_id = main_drama._render_story(story)
 
         self.assertIsNotNone(video_id)
@@ -153,7 +153,7 @@ class TestRenderHappyPath(RenderBase):
         self.assertEqual(get_story(story["id"])["status"], "produced")
         self.assertEqual(compose.call_args.kwargs.get("vn_commentary"),
                          rewrite["vn_commentary"])
-        push.assert_called_once_with(video_id)
+        dispatch.assert_called_once_with(video_id)
 
     def test_tts_failure_marks_video_failed_and_story_retryable(self):
         story = self._make_story(rewritten={"title": "t", "script": "nội dung"})
@@ -171,23 +171,23 @@ class TestRenderHappyPath(RenderBase):
         self.assertEqual(created, [42])
 
 
-class TestRepushStuckReviews(RenderBase):
-    def test_ready_drama_video_gets_repushed(self):
-        # push_review từng fail (Telegram down) → video kẹt 'ready', story đã
-        # 'produced' — render run sau phải tự push lại (finding Codex PR #70).
+class TestDispatchStuckVideos(RenderBase):
+    def test_ready_drama_video_gets_redispatched(self):
+        # auto_dispatch từng fail (Telegram/scheduler down) → video kẹt 'ready',
+        # story đã 'produced' — render run sau phải tự dispatch lại (Codex PR #70).
         video_id = db.insert_video(video_type="short", script_text="x",
                                    track="drama", destination="drama_youtube")
         db.update_video_status(video_id, "ready")
-        with patch("notifier.review_bot.push_review", return_value=True) as push:
+        with patch("notifier.review_bot.auto_dispatch", return_value=True) as dispatch:
             main_drama.render_approved_stories(limit=0)
-        push.assert_called_once_with(video_id)
+        dispatch.assert_called_once_with(video_id)
 
     def test_ai_ready_videos_not_touched(self):
         video_id = db.insert_video(video_type="short", script_text="x")  # track ai
         db.update_video_status(video_id, "ready")
-        with patch("notifier.review_bot.push_review") as push:
+        with patch("notifier.review_bot.auto_dispatch") as dispatch:
             main_drama.render_approved_stories(limit=0)
-        push.assert_not_called()
+        dispatch.assert_not_called()
 
 
 class TestRunDaily(RenderBase):

--- a/content-pipeline/tests/test_review_bot.py
+++ b/content-pipeline/tests/test_review_bot.py
@@ -80,6 +80,84 @@ class TestApprove(ReviewBotBase):
         self.assertIn("lỗi xếp lịch", reply)
 
 
+class TestAutoDispatch(ReviewBotBase):
+    """Tự phát hành (không nút ✅): YouTube auto CADENCE, TikTok gửi Telegram tay."""
+
+    def _make_ready_video(self, **overrides):
+        fields = dict(video_type="short", script_text="kịch bản", track="drama",
+                      destination="drama_youtube", youtube_title="Tiêu đề")
+        fields.update(overrides)
+        video_id = db.insert_video(**fields)
+        db.update_video_status(video_id, "ready")
+        return video_id
+
+    def test_ready_video_routed_and_approved(self):
+        video_id = self._make_ready_video()
+        with patch.object(rb, "_route_to_channel",
+                          side_effect=lambda v, k, c: f"  ok {k}") as route, \
+             patch.object(rb, "_send_dispatch_fyi") as fyi:
+            self.assertTrue(rb.auto_dispatch(video_id))
+        routed = [c.args[1] for c in route.call_args_list]
+        self.assertEqual(routed, ["drama_youtube", "tiktok_main"])
+        self.assertEqual(db.get_video(video_id)["status"], "approved")
+        fyi.assert_called_once()
+
+    def test_only_dispatches_ready_status(self):
+        # Video ở 'pending_approval' (không phải 'ready') → không dispatch.
+        video_id = self._make_ready_video()
+        db.update_video_status(video_id, "pending_approval")
+        with patch.object(rb, "_route_to_channel") as route, \
+             patch.object(rb, "_send_dispatch_fyi"):
+            self.assertFalse(rb.auto_dispatch(video_id))
+        route.assert_not_called()
+
+    def test_idempotent_no_double_route(self):
+        video_id = self._make_ready_video()
+        with patch.object(rb, "_route_to_channel", return_value="  ok"), \
+             patch.object(rb, "_send_dispatch_fyi"):
+            self.assertTrue(rb.auto_dispatch(video_id))   # claim ready→approved
+            self.assertFalse(rb.auto_dispatch(video_id))  # đã approved → bỏ qua
+
+    def test_missing_video_returns_false(self):
+        with patch.object(rb, "_send_dispatch_fyi") as fyi:
+            self.assertFalse(rb.auto_dispatch(99999))
+        fyi.assert_not_called()
+
+    def test_fyi_skips_preview_when_tiktok_destination(self):
+        # Short drama → dests gồm tiktok_main (file đã tới Telegram qua đường
+        # TikTok tay) → FYI KHÔNG đính kèm preview để khỏi gửi trùng file.
+        video_id = self._make_ready_video(video_type="short")
+        with patch.object(rb, "_route_to_channel", return_value="  ok"), \
+             patch.object(rb, "_send_dispatch_fyi") as fyi:
+            rb.auto_dispatch(video_id)
+        self.assertFalse(fyi.call_args.kwargs["include_preview"])
+
+    def test_fyi_includes_preview_for_youtube_only(self):
+        # Long video → chỉ lên YouTube (không tiktok) → FYI đính kèm preview.
+        video_id = self._make_ready_video(video_type="long")
+        with patch.object(rb, "_route_to_channel", return_value="  ok"), \
+             patch.object(rb, "_send_dispatch_fyi") as fyi:
+            rb.auto_dispatch(video_id)
+        self.assertTrue(fyi.call_args.kwargs["include_preview"])
+
+
+class TestSendDispatchFyi(ReviewBotBase):
+    def test_text_only_when_no_preview(self):
+        with patch("notifier.telegram_bot._send_text") as send_text, \
+             patch("notifier.telegram_bot._send_video_file") as send_video:
+            rb._send_dispatch_fyi({"id": 1, "video_path": None},
+                                  "tóm tắt", include_preview=False)
+        send_text.assert_called_once_with("tóm tắt")
+        send_video.assert_not_called()
+
+    def test_swallows_notifier_errors(self):
+        # Best-effort: notifier lỗi KHÔNG raise (video đã approved + đã route).
+        with patch("notifier.telegram_bot._send_text",
+                   side_effect=RuntimeError("telegram down")):
+            rb._send_dispatch_fyi({"id": 1, "video_path": None},
+                                  "tóm tắt", include_preview=False)
+
+
 class TestRouteToChannel(ReviewBotBase):
     def test_tiktok_routes_to_be_mc_telegram(self):
         # TikTok = gửi video qua Telegram (Bé MC), KHÔNG auto-schedule.

--- a/content-pipeline/tests/test_review_bot.py
+++ b/content-pipeline/tests/test_review_bot.py
@@ -299,7 +299,10 @@ class TestTelegramCallbackDispatch(ReviewBotBase):
              patch("notifier.review_bot.handle_callback",
                    return_value=("done", None)):
             tb._handle_callback_query(cq)
-        ans.assert_called_once_with("cb1")
+        # issue #88: ack ngay với toast "đang xử lý" TRƯỚC bước xử lý nặng để
+        # tránh 400 "query too old"; callback_id vẫn là đối số đầu.
+        ans.assert_called_once()
+        self.assertEqual(ans.call_args.args[0], "cb1")
         send.assert_called_once_with("done")
 
     def test_wrong_chat_ignored(self):

--- a/content-pipeline/tests/test_telegram_callback.py
+++ b/content-pipeline/tests/test_telegram_callback.py
@@ -1,0 +1,136 @@
+"""Tests for review-gate callback handling + long-poll resilience (issue #88).
+
+Ba lỗi khiến nút "Duyệt" trên Telegram không hoạt động:
+  1. answerCallbackQuery được gọi SAU bước xử lý nặng (approve) → callback_id
+     hết hạn → HTTP 400 "query is too old"; nút kẹt xoay, log đầy ERROR.
+  2. Webhook tồn đọng khiến MỌI getUpdates trả 409 Conflict; code cũ nuốt 409
+     nên run_bot busy-loop nã API.
+  3. HTTPError bị str() giấu mất `description` thật nên không debug được.
+
+Các test dưới pin hành vi đã sửa: ack TRƯỚC khi xử lý, 400 là info (không phải
+ERROR), 409 tự gọi deleteWebhook + không raise.
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import notifier.telegram_bot as tb
+
+
+def _http_error(code: int, description: str) -> HTTPError:
+    body = ('{"ok":false,"error_code":%d,"description":"%s"}' % (code, description))
+    return HTTPError(
+        url="https://api.telegram.org/botX/method",
+        code=code,
+        msg="Bad Request" if code == 400 else "Conflict",
+        hdrs=None,
+        fp=io.BytesIO(body.encode("utf-8")),
+    )
+
+
+class TestCallbackAckOrdering(unittest.TestCase):
+    """Ack callback phải chạy TRƯỚC review_bot.handle_callback (issue #88)."""
+
+    def setUp(self):
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.cfg.TELEGRAM_CHAT_ID = "123"
+        self.addCleanup(self.p_cfg.stop)
+
+    def test_ack_before_heavy_processing(self):
+        order = []
+
+        def _handle(data):
+            order.append("handle")
+            return ("✅ ok", None)
+
+        with patch.object(tb, "_answer_callback_query",
+                          side_effect=lambda cid, *a, **k: order.append("ack")), \
+             patch("notifier.review_bot.handle_callback", side_effect=_handle), \
+             patch.object(tb, "_send_text") as send:
+            tb._handle_callback_query({
+                "id": "cb1",
+                "message": {"chat": {"id": "123"}},
+                "data": "rv:a:117",
+            })
+
+        self.assertEqual(order, ["ack", "handle"],
+                         "ack phải chạy trước handle_callback (tránh 400 query too old)")
+        send.assert_called_once()  # kết quả gửi bằng message riêng
+
+    def test_wrong_chat_acked_but_not_processed(self):
+        with patch.object(tb, "_answer_callback_query") as ack, \
+             patch("notifier.review_bot.handle_callback") as handle:
+            tb._handle_callback_query({
+                "id": "cb2",
+                "message": {"chat": {"id": "999"}},  # sai chat
+                "data": "rv:a:117",
+            })
+        ack.assert_called_once_with("cb2")           # vẫn nhả nút của người lạ
+        handle.assert_not_called()
+
+
+class TestAnswerCallbackErrorHandling(unittest.TestCase):
+    def setUp(self):
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.addCleanup(self.p_cfg.stop)
+
+    def test_400_query_too_old_is_info_not_error(self):
+        err = _http_error(400, "Bad Request: query is too old and response timeout expired")
+        with patch.object(tb, "urlopen", side_effect=err), \
+             patch.object(tb.logger, "info") as info, \
+             patch.object(tb.logger, "error") as error:
+            ok = tb._answer_callback_query("cb1")
+        self.assertFalse(ok)
+        error.assert_not_called()                    # 400 KHÔNG phải ERROR
+        self.assertTrue(info.called)
+        # description thật + callback_id có mặt để debug (gợi ý #3 của issue)
+        logged = " ".join(str(a) for a in info.call_args.args)
+        self.assertIn("cb1", logged)
+        self.assertIn("query is too old", logged)
+
+    def test_non_400_still_logs_error_with_body(self):
+        err = _http_error(500, "Internal Server Error")
+        with patch.object(tb, "urlopen", side_effect=err), \
+             patch.object(tb.logger, "error") as error:
+            ok = tb._answer_callback_query("cb9")
+        self.assertFalse(ok)
+        error.assert_called_once()
+        logged = " ".join(str(a) for a in error.call_args.args)
+        self.assertIn("cb9", logged)
+
+
+class TestGetUpdatesConflict(unittest.TestCase):
+    def setUp(self):
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.addCleanup(self.p_cfg.stop)
+        # Không đọc offset file thật
+        self.p_exists = patch.object(tb.os.path, "exists", return_value=False)
+        self.p_exists.start()
+        self.addCleanup(self.p_exists.stop)
+
+    def test_409_self_heals_via_delete_webhook_without_raising(self):
+        err = _http_error(409, "Conflict: terminated by other getUpdates request")
+        with patch.object(tb, "urlopen", side_effect=err), \
+             patch.object(tb, "_delete_webhook") as dw, \
+             patch.object(tb.time, "sleep") as slept:
+            result = tb._get_updates(timeout=0)
+        self.assertEqual(result, [])                 # nuốt gọn, không raise
+        dw.assert_called_once()                      # tự chữa webhook
+        slept.assert_called_once()                   # lùi, không busy-loop
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #88

Hai phần: (A) sửa lỗi nút "Duyệt" Telegram (issue #88); (B) theo yêu cầu chủ kênh, cho YouTube **tự đăng theo CADENCE** thay vì bắt bấm ✅ — Telegram chỉ còn để xem trước video TikTok.

---

## Phần A — Nút "Duyệt" không phản hồi (issue #88)

**Root cause & fix (`notifier/telegram_bot.py`, `launchd/install.sh`):**
1. **409 Conflict vĩnh viễn** — webhook tồn đọng loại trừ long-poll → MỌI `getUpdates` trả 409; code cũ nuốt lỗi → busy-loop. Fix: `_delete_webhook()` lúc khởi động + `_get_updates` tự chữa + lùi 5s.
2. **answerCallbackQuery 400 "query too old"** — ack SAU bước approve nặng (vài giây) → callback hết hạn. Fix: **ack trước** (toast "⏳ Đang xử lý…"), xử lý sau, gửi kết quả riêng; 400 → log `info` kèm `callback_id` + `description` thật.
3. **plist `/Users/YOU`** — guard trong `install.sh` chỉ soi đúng đường dẫn Program (không grep cả comment — đã sửa theo P1 của Codex).

---

## Phần B — Tự đăng YouTube, bỏ nút ✅ chặn

**Vấn đề:** CADENCE tự đăng YouTube đã có, nhưng Phase 5 đặt review gate chặn CẢ 2 track → video kẹt chờ bấm ✅. Chủ kênh chỉ muốn xem trước video **TikTok** để đăng tay; YouTube nên tự động.

**Thay đổi (`notifier/review_bot.py`, `main.py`, `main_drama.py`):**
- **`auto_dispatch(video_id)`** thay `push_review` ở bước render: claim `ready`→`approved` (idempotent, chống dispatch trùng khi resume) rồi route mọi kênh qua **`_route_all`** (tách ra dùng chung với `_approve`):
  - **YouTube** → `schedule_video` (CADENCE: short T2–T7 12:00, long CN 20:00; `tick` tự upload).
  - **TikTok** → `send_tiktok_manual` (Telegram Bé MC đăng tay).
  - + 1 tin Telegram **FYI không nút chặn**: đính kèm preview nếu video CHƯA tới Telegram qua đường TikTok (tránh gửi trùng file nặng); video long chỉ-YouTube thì luôn kèm preview. `_send_dispatch_fyi` best-effort.
- Stuck-handler đổi tên/hành vi: `_dispatch_ready_ai_videos` / `_dispatch_stuck_videos` re-dispatch video kẹt `ready`.
- **Review gate ✅/❌/✏️ giữ nguyên** cho video cũ `pending_approval` + duyệt tay `needs_review` — chỉ không còn là đường mặc định của video mới.

**Verify end-to-end (real routing, không mock `_route_to_channel`):** short drama → `approved` + `drama_youtube` scheduled + `tiktok_main` gửi Telegram + FYI text-only; long drama → `approved` + scheduled + FYI kèm preview.

---

## Test
- `tests/test_telegram_callback.py` (5), `tests/test_review_bot.py` (thêm `TestAutoDispatch` + `TestSendDispatchFyi`), cập nhật `tests/test_main_drama.py` cho `auto_dispatch`.
- Full suite: 773 test, chỉ 5 error tiền tồn do thiếu dep `anthropic` (không liên quan).

## Ghi chú CI
Check `create-pr` fail là do token workflow thiếu scope `read:org` (vấn đề repo-automation có sẵn), KHÔNG do diff này. Bot review `github-actions` đã báo PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)