### PR TITLE
fix(#90): reliable daily drama source — HF AITA cursor import + drop asklemmy noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,34 +168,47 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   drama). Lọc `nsfw`/`featured_*` (stickied)/`removed`/score < `LEMMY_MIN_SCORE`;
   `source_id` hash từ `ap_id` (dedupe xuyên instance). Story tiếng Anh → được
   `drama_rewriter` Việt hoá như cũ. Bật mặc định (`LEMMY_ENABLED=1`); mặc định
-  cào 3 community active `relationship_advice`/`aita`/`asklemmy`@lemmy.world (Lemmy
-  lưu lượng thấp hơn Reddit nhiều nên cào nhiều community để đủ story tươi), cấu
+  cào 2 community body-story `relationship_advice`/`aita`@lemmy.world, cấu
   hình qua `LEMMY_COMMUNITIES` ("name@instance", phẩy); community 404 chỉ log +
   bỏ qua (không fatal). Total outage (MỌI community fail) mới raise (như
   `collect_all_drama`). **Hai chế độ:** (1) *body-story* (mặc định, `relationship_
   advice`/`aita`) — body bài LÀ story; (2) *Q&A / AskReddit-style* (community
-  trong `LEMMY_QA_COMMUNITIES`, mặc định `asklemmy`) — giá trị nằm ở COMMENTS, nên
+  trong `LEMMY_QA_COMMUNITIES`) — giá trị nằm ở COMMENTS, nên
   gọi thêm `/api/v3/comment/list?sort=Top&max_depth=1`, ghép "câu hỏi + top câu
   trả lời" thành story (`metadata.format='qa'`); lọc comment theo score/độ dài,
   cần ≥`LEMMY_QA_MIN_COMMENTS`, cap `_MAX_QA_POSTS_PER_RUN` post/community để giới
-  hạn số request. Chỉ stdlib. **Lemmy là nguồn TƯƠI DUY NHẤT đáng tin** sau khi
-  Reddit đóng — không có dataset HF nào còn cập nhật (xem dưới). Chạy vào bước
-  collect của `main_drama`.
+  hạn số request. Chỉ stdlib. **`asklemmy` bị GỠ khỏi default (issue #90):** nó
+  là Q&A general (nhạc/thú cưng/PC), zero drama — 8/8 post cào từ đó bị
+  `drama_scorer` loại 1-3/6, nã Haiku vào nội dung không bao giờ pass.
+  `LEMMY_QA_COMMUNITIES` giờ mặc định **rỗng** (máy móc Q&A giữ nguyên, trỏ vào
+  community drama thật thì bật lại). **Lemmy chỉ là topping TƯƠI best-effort** —
+  lưu lượng drama thấp, nên nguồn drama tin cậy hàng ngày là dump AITA trên HF
+  (xem dưới), KHÔNG phải Lemmy. Chạy vào bước collect của `main_drama`.
 - **`collectors/hf_drama_importer.py`** — nạp story từ dataset AITA công khai trên
   HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
   length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override
   `HF_TITLE_FIELD`/`HF_BODY_FIELD`), phân trang ≤100 dòng/request, `source_id` từ
-  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **Vai trò HF =
-  BACKFILL số lượng, KHÔNG phải thời sự** — nguồn tươi là Lemmy (API sống). Đa số
-  dataset AITA "tự cập nhật" đã chết (vd `derek-thomas/...-amitheasshole` dừng ở
-  2023-12-04 ~2.5k dòng — Codex bắt ở PR #81), nên đừng trông cậy HF cho freshness.
-  **Deep backfill (chính):** `python -m collectors.hf_drama_importer --dataset
-  OsamaBsher/AITA-Reddit-Dataset --limit 500` (270K bài, 2013–2023). **`--newest`
-  (`import_dataset(newest=True)`):** lấy dòng MỚI NHẤT (đuôi: `offset =
-  num_rows_total − limit`) — dùng trong bước collect `main_drama` **nếu**
-  `HF_DRAMA_DAILY_ENABLED=1` (mặc định **0**, chỉ bật khi trỏ tới dataset ĐÃ xác
-  nhận còn cập nhật; không thì chỉ re-poll đuôi cũ). *License:* dataset tái phân
-  phối nội dung Reddit — kiểm tra terms từng dataset.
+  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **HF = nguồn
+  drama TIN CẬY hàng ngày (issue #90):** Reddit tắt + Lemmy drama cạn nên dump
+  AITA 270K dòng là giếng drama THẬT duy nhất đáng tin — và với kênh drama thì
+  "thời sự" KHÔNG quan trọng (một vụ AITA năm 2019 hấp dẫn y như 2026; freshness
+  là mối lo của track AI-news, không phải track này). Deep backfill dataset
+  "tự cập nhật" đã chết vẫn không sao vì ta không cần chúng tươi. **Deep backfill
+  (một lần):** `python -m collectors.hf_drama_importer --dataset
+  OsamaBsher/AITA-Reddit-Dataset --limit 500` (270K bài, 2013–2023).
+  **`import_daily()` — con trỏ tiến (mặc định của bước collect):** đi TỚI trong
+  dump TĨNH mỗi ngày một lát `HF_DAILY_LIMIT` dòng chưa gặp, lưu offset ở
+  `pipeline_state` (migration 008) nên hôm sau tiếp đúng chỗ dừng — KHÁC
+  `--newest`, không bao giờ nạp lại cùng đuôi; hết dataset thì cuộn về 0 (270K
+  dòng ~10/ngày = nhiều năm runway). Con trỏ advance theo số dòng ĐÃ QUÉT
+  (không phải số import) nên bỏ-qua-rỗng không bị quét lại; `dedupe_check` vẫn
+  gác từng dòng nên con trỏ và backfill tay `--limit N` sống chung an toàn; fetch
+  lỗi thì con trỏ KHÔNG advance (lần sau retry cùng lát). **`--newest`
+  (`import_dataset(newest=True)`):** lấy đuôi — CHỈ hợp dataset xác nhận còn
+  append; với dump tĩnh nó re-poll đuôi cũ (nạp 0). Bật/tắt qua
+  `HF_DRAMA_DAILY_ENABLED` (mặc định **1**), chọn chế độ qua `HF_DRAMA_DAILY_MODE`
+  (`cursor` mặc định | `newest`). *License:* dataset tái phân phối nội dung Reddit
+  — kiểm tra terms từng dataset.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
@@ -222,6 +235,11 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   thêm `check_and_alert(["reddit_drama"])` song song.
 - Migration 002 (`stories.title`/`metadata` + unique `source_id`) và 003
   (`collector_health`) — chạy `python -m storage.migrate up` sau khi pull.
+- **`storage/pipeline_state.py`** (migration 008, issue #90) — kv scalar bền
+  vững giữa các lần chạy (`get_state`/`set_state`/`get_int`/`set_int`). User đầu
+  tiên: con trỏ offset của `import_daily` (HF). Generic — collector/job nào cần
+  nhớ 1 scalar (cursor/last-id/timestamp) qua các lần chạy dùng chung, thay vì
+  file state (không sống sót re-clone). `get_int` value hỏng → default (self-heal).
 
 ---
 
@@ -452,14 +470,15 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   fallback lưu file gốc, không còn là đường chính.
 - **`main_drama.py`** — orchestrator: collect → score → rewrite → render
   (TTS voice drama + `compose_drama_video`) → `auto_dispatch` (tự phát hành:
-  YouTube cadence + TikTok Telegram tay, không nút ✅). **Bước collect (follow-up
-  #78) gọi nhiều nguồn độc lập, best-effort (một nguồn lỗi không kéo cả bước):
-  Reddit (tắt mặc định), Lemmy (`collect_all_lemmy` — nguồn TƯƠI chính), và HF
-  `--newest` (`import_dataset(newest=True)` CHỈ khi `HF_DRAMA_DAILY_ENABLED=1`,
-  mặc định off; HF là backfill, không phải thời sự). Seed thủ công (`seed_bot`)
-  vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.** Chọn story
-  theo `created_at DESC` nên nội dung tươi (Lemmy hôm nay) luôn được ưu tiên
-  trước backlog cũ. Resume: trạng
+  YouTube cadence + TikTok Telegram tay, không nút ✅). **Bước collect gọi nhiều
+  nguồn độc lập, best-effort (một nguồn lỗi không kéo cả bước): Reddit (tắt mặc
+  định), Lemmy (`collect_all_lemmy` — topping tươi best-effort), và HF hàng ngày
+  (`import_daily` chế độ `cursor` mặc định, hoặc `import_dataset(newest=True)` khi
+  `HF_DRAMA_DAILY_MODE=newest`; gác bởi `HF_DRAMA_DAILY_ENABLED`, mặc định **ON**
+  từ issue #90 — HF là nguồn drama TIN CẬY, xem Phase 2). Seed thủ công
+  (`seed_bot`) vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.**
+  Chọn story theo `created_at DESC` nên nội dung mới nạp (HF/Lemmy hôm nay) luôn
+  được ưu tiên trước backlog cũ. Resume: trạng
   thái nằm hết trong DB; video row được insert TRƯỚC khi render (gắn
   `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
   row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,15 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   (`import_dataset(newest=True)`):** lấy đuôi — CHỈ hợp dataset xác nhận còn
   append; với dump tĩnh nó re-poll đuôi cũ (nạp 0). Bật/tắt qua
   `HF_DRAMA_DAILY_ENABLED` (mặc định **1**), chọn chế độ qua `HF_DRAMA_DAILY_MODE`
-  (`cursor` mặc định | `newest`). *License:* dataset tái phân phối nội dung Reddit
-  — kiểm tra terms từng dataset.
+  (`cursor` mặc định | `newest`). **Suy giảm êm (PA1, issue #90):** khi
+  datasets-server không phục vụ được rows (viewer đang build/hỏng → body
+  KHÔNG-JSON hay 5xx qua mọi retry) → `_fetch_rows` raise
+  `HFDatasetUnavailableError` (phân biệt với 404 misconfig / lỗi code); bước
+  collect `main_drama` coi đây là **cảnh báo mềm, KHÔNG nhét vào summary lỗi**
+  (đỡ spam Telegram mỗi sáng) — kho drama do **deep backfill một lần** gánh, nên
+  outage viewer không làm chết pipeline. Con trỏ KHÔNG advance khi outage (mai
+  retry cùng lát). *License:* dataset tái phân phối nội dung Reddit — kiểm tra
+  terms từng dataset.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -86,6 +86,9 @@ HF_IMPORT_LIMIT=200
 # HF_DAILY_LIMIT kept modest: the funnel is import -> scorer -> rewriter (Sonnet,
 # the cost driver, ~10/day cap) -> ~2 videos/day + a slow approved cushion.
 # Raising it mostly grows the approved backlog and Sonnet spend, not videos/day.
+# If the datasets-server viewer is temporarily unavailable for your dataset, the
+# daily import degrades gracefully (a warning, not a daily error) and the one-off
+# deep backfill above is the reservoir that keeps the pipeline producing.
 HF_DRAMA_DAILY_ENABLED=1
 HF_DRAMA_DAILY_MODE=cursor
 HF_DAILY_LIMIT=10

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -42,24 +42,31 @@ DRAMA_BACKLOG_MIN=3
 # Communities are "name@instance", comma-separated; add more for volume.
 LEMMY_ENABLED=1
 LEMMY_INSTANCE=https://lemmy.world
-# Curated active drama/story communities; add/trim freely ("name@instance").
-LEMMY_COMMUNITIES=relationship_advice@lemmy.world,aita@lemmy.world,asklemmy@lemmy.world
+# Body-story drama communities (the post body IS the conflict); add/trim freely
+# ("name@instance"). asklemmy was dropped (issue #90): it's a general Q&A board,
+# zero drama, so every post it yielded got scored-rejected. Lemmy drama volume is
+# thin — the reliable daily source is the HF AITA dump below, not Lemmy.
+LEMMY_COMMUNITIES=relationship_advice@lemmy.world,aita@lemmy.world
 LEMMY_MIN_SCORE=10
 # AskReddit-style communities: the collector builds "question + top answers"
-# stories from these (the answers are the content, not the post body).
-LEMMY_QA_COMMUNITIES=asklemmy@lemmy.world
+# stories from these (the answers are the content, not the post body). Empty by
+# default (issue #90) — point at a genuinely dramatic Q&A community to use it,
+# and add it to LEMMY_COMMUNITIES too so it's fetched.
+LEMMY_QA_COMMUNITIES=
 LEMMY_QA_TOP_COMMENTS=6       # answers included per story
 LEMMY_QA_MIN_COMMENTS=2       # min good answers to keep a story
 LEMMY_QA_MIN_COMMENT_SCORE=3
 LEMMY_QA_MIN_COMMENT_CHARS=30
 
-# --- HuggingFace drama dataset import (issue #78 follow-up) ---
+# --- HuggingFace drama dataset import (issue #78 follow-up; #90) ---
 # Seeds the stories table from a public AITA/relationship dataset via the HF
-# datasets-server REST API (stdlib only). HF's reliable role is VOLUME/backfill,
-# NOT timeliness — timely stories come from Lemmy (a live API). Most
-# "auto-updating" AITA datasets have gone stale, so don't rely on HF for freshness.
+# datasets-server REST API (stdlib only). With Reddit off and Lemmy drama thin,
+# the 270K-row AITA dump is the RELIABLE daily drama source (issue #90) — and a
+# drama channel doesn't need "thời sự" (a 2019 AITA is as engaging as a 2026 one;
+# freshness is the AI-news track's concern). Stale "auto-updating" datasets are
+# fine here precisely because timeliness doesn't matter.
 #
-# Typical use = one-off DEEP backfill cushion:
+# One-off DEEP backfill cushion:
 #   python -m collectors.hf_drama_importer --dataset OsamaBsher/AITA-Reddit-Dataset --limit 500
 # Verify a dataset once (columns auto-detect; a 404 means wrong config/split):
 #   python -m collectors.hf_drama_importer --limit 3
@@ -70,11 +77,18 @@ HF_DRAMA_SPLIT=train
 HF_IMPORT_LIMIT=200
 # HF_TITLE_FIELD=      # leave empty to auto-detect
 # HF_BODY_FIELD=       # leave empty to auto-detect
-# Optional daily `--newest` auto-import in main_drama's collect step. OFF by
-# default — enable ONLY if HF_DRAMA_DATASET points at a dataset you've confirmed
-# is still updating (else it re-polls a stale tail). Timeliness = Lemmy, not this.
-HF_DRAMA_DAILY_ENABLED=0
-HF_DAILY_LIMIT=30
+# Daily auto-import in main_drama's collect step. ON by default (issue #90).
+#   HF_DRAMA_DAILY_MODE=cursor (default) — walk the big STATIC dump FORWARD a
+#     fresh slice per day, tracked by a persisted offset (never re-imports rows;
+#     wraps at the end). This is what makes daily HF reliable for a static dump.
+#   HF_DRAMA_DAILY_MODE=newest — pull the tail; only for a confirmed-updating
+#     dataset (against a static dump it re-polls the same stale tail = 0 new).
+# HF_DAILY_LIMIT kept modest: the funnel is import -> scorer -> rewriter (Sonnet,
+# the cost driver, ~10/day cap) -> ~2 videos/day + a slow approved cushion.
+# Raising it mostly grows the approved backlog and Sonnet spend, not videos/day.
+HF_DRAMA_DAILY_ENABLED=1
+HF_DRAMA_DAILY_MODE=cursor
+HF_DAILY_LIMIT=10
 
 # --- Pexels (free stock video backgrounds) ---
 PEXELS_API_KEY=...

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -61,21 +61,47 @@ class HFImportError(Exception):
     """Raised when the dataset can't be read or no usable text column is found."""
 
 
+class HFDatasetUnavailableError(HFImportError):
+    """The datasets-server can't currently serve this dataset's rows — the viewer
+    is unavailable/still building (a non-JSON HTML gateway page, or a 5xx), as
+    opposed to a config mistake (404) or a code bug.
+
+    This is a SOFT, expected condition: the daily drama pipeline treats it as a
+    warning (the deep-backfill cushion carries production) instead of a hard
+    error that spams the morning summary. See main_drama's collect step."""
+
+
 def _fetch_rows(dataset: str, cfg: str, split: str, offset: int, length: int) -> dict:
-    """GET one page from the datasets-server. Raises HFImportError on failure."""
+    """GET one page from the datasets-server. Raises on failure.
+
+    Raises HFDatasetUnavailableError (a soft, retriable-tomorrow condition) when
+    the server keeps returning a non-JSON body or a 5xx across all retries — the
+    signature of a dataset whose viewer is unavailable/still building. Raises
+    plain HFImportError for a 404 (wrong dataset/config/split) or other errors.
+    """
     query = urlencode({
         "dataset": dataset, "config": cfg, "split": split,
         "offset": offset, "length": length,
     })
     url = f"{_ROWS_URL}?{query}"
     last_error = None
+    unavailable = False  # last failure looked like "viewer down" (non-JSON / 5xx)
     for attempt in range(3):
         req = Request(url)
         req.add_header("User-Agent", "ai5phut-content-pipeline/1.0")
         req.add_header("Accept", "application/json")
         try:
             with urlopen(req, timeout=config.HF_TIMEOUT) as resp:
-                return json.loads(resp.read().decode("utf-8", errors="replace"))
+                body = resp.read().decode("utf-8", errors="replace")
+            try:
+                return json.loads(body)
+            except json.JSONDecodeError as e:
+                # A non-JSON body (typically an HTML gateway/"viewer unavailable"
+                # page → "Unexpected token '<'") means rows aren't servable now.
+                last_error = e
+                unavailable = True
+                logger.warning("HF non-JSON response at offset %d (attempt %d/3): %.80s",
+                               offset, attempt + 1, body.lstrip())
         except HTTPError as e:
             last_error = e
             # 404 = wrong dataset/config/split; retrying won't help.
@@ -84,12 +110,21 @@ def _fetch_rows(dataset: str, cfg: str, split: str, offset: int, length: int) ->
                     f"dataset/config/split not found: {dataset} {cfg}/{split} "
                     f"(check names; set HF_DRAMA_CONFIG/HF_DRAMA_SPLIT)"
                 ) from e
+            # 5xx = server can't build/serve the dataset right now (viewer down).
+            unavailable = e.code >= 500
             logger.warning("HF HTTP %s at offset %d (attempt %d/3)", e.code, offset, attempt + 1)
-        except (URLError, TimeoutError, json.JSONDecodeError) as e:
+        except (URLError, TimeoutError) as e:
             last_error = e
+            unavailable = False  # network blip, not a dataset-availability signal
             logger.warning("HF request error at offset %d (attempt %d/3): %s", offset, attempt + 1, e)
         if attempt < 2:
             time.sleep(2 ** (attempt + 1))
+    if unavailable:
+        raise HFDatasetUnavailableError(
+            f"datasets-server can't serve rows for {dataset} ({cfg}/{split}) — "
+            f"viewer unavailable/building (last: {last_error}). Falling back to the "
+            f"backfill cushion; run a deep backfill if the drama backlog runs low."
+        )
     raise HFImportError(f"failed to fetch rows at offset {offset}: {last_error}")
 
 

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -244,7 +244,10 @@ def import_daily(dataset: str | None = None, limit: int | None = None) -> int:
     split = config.HF_DRAMA_SPLIT
     limit = config.HF_DAILY_LIMIT if limit is None else limit
 
-    key = f"hf_cursor:{dataset}:{split}"
+    # Key by dataset + config + split: _dataset_size/_paginate_import read a
+    # different row stream per config, so a shared cursor across configs would
+    # start a new config at a stale offset (skip its head, later collide).
+    key = f"hf_cursor:{dataset}:{cfg}:{split}"
     total = _dataset_size(dataset, cfg, split)
     offset = get_int(key, 0)
     if total and offset >= total:

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -125,27 +125,16 @@ def _row_source_id(dataset: str, row: dict, id_field: str | None, title: str, bo
     return f"hf_{tag}_{raw}"
 
 
-def import_dataset(dataset: str | None = None, config_name: str | None = None,
-                   split: str | None = None, limit: int | None = None,
-                   offset: int = 0, newest: bool = False) -> int:
-    """Import up to `limit` rows into `stories` (track='drama'). Returns new count.
+def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
+                     limit: int) -> tuple[int, int]:
+    """Import up to `limit` rows starting at `offset`. Returns (imported, scanned).
 
-    newest=True pulls from the TAIL of the dataset (offset = num_rows_total -
-    limit) instead of the head — for append-updated datasets (e.g. the hourly
-    AITA dataset) the tail is the freshest content, which is what "thời sự"
-    wants. It costs one extra 1-row probe to learn the size.
+    imported = new stories inserted; scanned = dataset rows consumed (INCLUDING
+    empty/removed/duplicate ones) counted from `offset`. A caller tracking a
+    forward cursor advances by exactly `scanned`, so skipped-empty rows aren't
+    re-scanned next run. Shared by import_dataset (head/tail/manual offset) and
+    import_daily (persisted cursor).
     """
-    dataset = dataset or config.HF_DRAMA_DATASET
-    cfg = config_name or config.HF_DRAMA_CONFIG
-    split = split or config.HF_DRAMA_SPLIT
-    limit = config.HF_IMPORT_LIMIT if limit is None else limit
-
-    if newest:
-        total = _dataset_size(dataset, cfg, split)
-        offset = max(0, total - limit)
-        logger.info("HF --newest: %s has %d rows → importing from offset %d",
-                    dataset, total, offset)
-
     first = _fetch_rows(dataset, cfg, split, offset, min(_PAGE, limit))
     columns = [f["name"] for f in first.get("features", []) if isinstance(f, dict) and "name" in f]
     if not columns:
@@ -166,9 +155,9 @@ def import_dataset(dataset: str | None = None, config_name: str | None = None,
     target = min(limit, max(0, total_available - offset)) if total_available else limit
 
     imported = 0
+    scanned = 0  # rows consumed from `offset`; exact even when we break mid-page
     skipped_dup = skipped_empty = 0
     page = first
-    fetched = 0
     while imported < target:
         rows = page.get("rows", [])
         if not rows:
@@ -176,6 +165,7 @@ def import_dataset(dataset: str | None = None, config_name: str | None = None,
         for entry in rows:
             if imported >= target:
                 break
+            scanned += 1
             row = entry.get("row", {}) if isinstance(entry, dict) else {}
             title = str(row.get(title_field, "") or "").strip() if title_field else ""
             body = str(row.get(body_field, "") or "").strip()
@@ -196,14 +186,79 @@ def import_dataset(dataset: str | None = None, config_name: str | None = None,
             )
             imported += 1
 
-        fetched += len(rows)
-        next_offset = offset + fetched
+        next_offset = offset + scanned
         if imported >= target or next_offset >= (total_available or next_offset):
             break
         page = _fetch_rows(dataset, cfg, split, next_offset, min(_PAGE, target - imported))
 
-    logger.info("HF import done: %d new stories (%d dup, %d empty) from %s",
-                imported, skipped_dup, skipped_empty, dataset)
+    logger.info("HF import done: %d new stories (%d dup, %d empty, %d scanned) from %s",
+                imported, skipped_dup, skipped_empty, scanned, dataset)
+    return imported, scanned
+
+
+def import_dataset(dataset: str | None = None, config_name: str | None = None,
+                   split: str | None = None, limit: int | None = None,
+                   offset: int = 0, newest: bool = False) -> int:
+    """Import up to `limit` rows into `stories` (track='drama'). Returns new count.
+
+    newest=True pulls from the TAIL of the dataset (offset = num_rows_total -
+    limit) instead of the head — for append-updated datasets (e.g. the hourly
+    AITA dataset) the tail is the freshest content, which is what "thời sự"
+    wants. It costs one extra 1-row probe to learn the size. For the daily
+    static-dump source use import_daily (a forward cursor), not newest.
+    """
+    dataset = dataset or config.HF_DRAMA_DATASET
+    cfg = config_name or config.HF_DRAMA_CONFIG
+    split = split or config.HF_DRAMA_SPLIT
+    limit = config.HF_IMPORT_LIMIT if limit is None else limit
+
+    if newest:
+        total = _dataset_size(dataset, cfg, split)
+        offset = max(0, total - limit)
+        logger.info("HF --newest: %s has %d rows → importing from offset %d",
+                    dataset, total, offset)
+
+    imported, _scanned = _paginate_import(dataset, cfg, split, offset, limit)
+    return imported
+
+
+def import_daily(dataset: str | None = None, limit: int | None = None) -> int:
+    """Import the next unseen window of a STATIC dataset, tracked by a cursor.
+
+    The reliable daily drama source (issue #90). Walks FORWARD through the dataset
+    a fresh `limit`-row slice per call, persisting the offset in `pipeline_state`
+    (migration 008) so the next run continues where this one stopped — unlike
+    newest=True, it never re-imports the same tail against a static dump. When the
+    cursor reaches the end it wraps back to 0 (a 270K-row dump at ~10/day is years
+    of runway; wrap keeps it self-sustaining after that).
+
+    dedupe_check still guards every row, so the cursor and a manual `--limit N`
+    backfill coexist safely: rows the backfill already inserted are scanned,
+    skipped as duplicates, and the cursor advances past them. If the fetch fails
+    the exception propagates (cursor NOT advanced) so the next run retries the
+    same window.
+    """
+    from storage.pipeline_state import get_int, set_int
+    dataset = dataset or config.HF_DRAMA_DATASET
+    cfg = config.HF_DRAMA_CONFIG
+    split = config.HF_DRAMA_SPLIT
+    limit = config.HF_DAILY_LIMIT if limit is None else limit
+
+    key = f"hf_cursor:{dataset}:{split}"
+    total = _dataset_size(dataset, cfg, split)
+    offset = get_int(key, 0)
+    if total and offset >= total:
+        logger.info("HF cursor for %s past end (%d/%d) — wrapping to 0",
+                    dataset, offset, total)
+        offset = 0
+
+    imported, scanned = _paginate_import(dataset, cfg, split, offset, limit)
+    new_offset = offset + scanned
+    if total and new_offset >= total:
+        new_offset = 0  # wrapped; next run restarts from the top
+    set_int(key, new_offset)
+    logger.info("HF daily import: %d new from %s (cursor %d → %d of %d)",
+                imported, dataset, offset, new_offset, total)
     return imported
 
 

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -342,16 +342,21 @@ DRAMA_SCRIPT_HARD_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MAX_WORDS", "1500
 # lower than Reddit, so the score bar is modest.
 LEMMY_ENABLED = os.getenv("LEMMY_ENABLED", "1") == "1"
 LEMMY_INSTANCE = os.getenv("LEMMY_INSTANCE", "https://lemmy.world").rstrip("/")
-# Curated set of active drama/story communities on lemmy.world. Lemmy volume is
-# far lower than Reddit, so we pull from several to keep enough fresh stories.
-# relationship_advice + aita carry story bodies; asklemmy is the highest-traffic
-# community (many posts are question-only and get skipped by the empty-body
-# filter, but its story-ish posts add variety). A community that 404s is logged
-# and skipped, not fatal — trim any that stay noisy in your logs.
+# Curated set of drama/story communities on lemmy.world. Only *body-story*
+# communities (the post body IS the conflict) belong here: relationship_advice +
+# aita. asklemmy was REMOVED from the default (issue #90): it is a general Q&A
+# board — its top-of-day is everyday questions (music, pets, PCs), zero
+# interpersonal drama, so every asklemmy post the collector scored got rejected
+# 1-3/6, burning Haiku calls on content that can never pass. Add it back via
+# LEMMY_COMMUNITIES only if you want the variety and accept the noise. Lemmy
+# drama volume is thin regardless (far below Reddit), so the reliable daily
+# drama source is the HuggingFace AITA dump (see HF_DRAMA_* below); Lemmy is the
+# best-effort *live* topping. A community that 404s is logged and skipped, not
+# fatal — trim any that stay noisy in your logs.
 LEMMY_COMMUNITIES = [
     c.strip() for c in os.getenv(
         "LEMMY_COMMUNITIES",
-        "relationship_advice@lemmy.world,aita@lemmy.world,asklemmy@lemmy.world",
+        "relationship_advice@lemmy.world,aita@lemmy.world",
     ).split(",") if c.strip()
 ]
 LEMMY_MIN_SCORE = int(os.getenv("LEMMY_MIN_SCORE", "10"))
@@ -364,11 +369,14 @@ LEMMY_MAX_RETRIES = int(os.getenv("LEMMY_MAX_RETRIES", "3"))
 # (answers), not the post body — like the "câu hỏi + tuyển câu trả lời" threads
 # that VN pages repost. For a community in this set, the collector fetches a
 # post's top comments and assembles "question + selected answers" into a story;
-# other communities (relationship_advice/aita) stay body-story mode. asklemmy is
-# lower-traffic than r/AskReddit, so expect thinner volume.
+# body-story communities (relationship_advice/aita) stay body-story mode.
+# Default is EMPTY (issue #90): asklemmy — the only Q&A board we had — proved to
+# be non-drama noise (see LEMMY_COMMUNITIES). The Q&A machinery stays in place;
+# to use it, add a genuinely dramatic Q&A community to LEMMY_COMMUNITIES (so it
+# gets fetched) AND list it here (so it's parsed in Q&A mode).
 LEMMY_QA_COMMUNITIES = [
     c.strip() for c in os.getenv(
-        "LEMMY_QA_COMMUNITIES", "asklemmy@lemmy.world"
+        "LEMMY_QA_COMMUNITIES", ""
     ).split(",") if c.strip()
 ]
 LEMMY_QA_TOP_COMMENTS = int(os.getenv("LEMMY_QA_TOP_COMMENTS", "6"))       # answers per story
@@ -395,13 +403,31 @@ HF_IMPORT_LIMIT = int(os.getenv("HF_IMPORT_LIMIT", "200"))  # default for the ma
 HF_TITLE_FIELD = os.getenv("HF_TITLE_FIELD", "")   # "" = auto-detect
 HF_BODY_FIELD = os.getenv("HF_BODY_FIELD", "")     # "" = auto-detect
 HF_TIMEOUT = int(os.getenv("HF_TIMEOUT", "30"))
-# Optional daily `--newest` auto-import inside main_drama's collect step. OFF by
-# default: only worth enabling if you point HF_DRAMA_DATASET at a dataset you've
-# CONFIRMED is still being updated (otherwise it re-polls a stale tail and adds
-# nothing). Even then, daily is plenty — hourly polling is pointless (the channel
-# makes ~2 videos/day, the scorer handles ~20/day).
-HF_DRAMA_DAILY_ENABLED = os.getenv("HF_DRAMA_DAILY_ENABLED", "0") == "1"
-HF_DAILY_LIMIT = int(os.getenv("HF_DAILY_LIMIT", "30"))
+# Daily HuggingFace auto-import inside main_drama's collect step. ON by default
+# (issue #90): with Reddit off (#78) and Lemmy drama communities near-empty, the
+# 270K-row AITA dump is the only reliable well of *genuine* drama — and for a
+# drama channel it doesn't matter that these posts aren't "thời sự" (an AITA
+# conflict is as engaging in 2026 as in 2019; timeliness is the AI-news track's
+# concern, not this one). Set HF_DRAMA_DAILY_ENABLED=0 to turn it off (e.g. once
+# Reddit is re-enabled and carrying quality).
+HF_DRAMA_DAILY_ENABLED = os.getenv("HF_DRAMA_DAILY_ENABLED", "1") == "1"
+# How the daily import walks the dataset:
+#   "cursor" (default) — walk FORWARD through the big STATIC dump, a fresh window
+#       of unseen rows each day, tracked by a persisted per-dataset offset
+#       (storage/pipeline_state.py, migration 008). This is what makes daily HF
+#       reliable for a static dump: unlike "newest", it never re-imports the same
+#       rows. 270K rows / HF_DAILY_LIMIT per day = years of runway; it wraps back
+#       to the start when it reaches the end.
+#   "newest" — pull from the TAIL (offset = size - limit). ONLY useful for a
+#       dataset you've CONFIRMED is still appended to; against a static dump it
+#       re-polls the same stale tail and imports nothing (the old default's flaw).
+HF_DRAMA_DAILY_MODE = os.getenv("HF_DRAMA_DAILY_MODE", "cursor").strip().lower()
+# Rows to import per daily run. Kept modest to balance the funnel end-to-end:
+# import ~N -> scorer keeps the drama ones -> rewriter (Sonnet, the cost driver,
+# capped at ~10/day) -> render (~2 videos/day) + a slowly-growing approved
+# cushion. Raising this mostly grows the approved backlog and Sonnet spend, not
+# the videos/day, so bump it only when you want a deeper cushion.
+HF_DAILY_LIMIT = int(os.getenv("HF_DAILY_LIMIT", "10"))
 
 # Drama backlog alert (issue #78 follow-up). With Reddit off by default, the
 # Drama channel is fed by manual seeds — so the meaningful health signal is "not

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -304,8 +304,21 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
                 else:
                     collected += import_daily(limit=config.HF_DAILY_LIMIT)
             except Exception as e:
-                logger.error("Collect (hf) failed: %s", e)
-                summary["errors"].append(f"collect[hf]: {e}")
+                # HF is best-effort. A "dataset viewer unavailable" condition is a
+                # SOFT failure — the deep-backfill cushion carries production — so
+                # warn without spamming the daily Telegram summary. Anything else
+                # (real bug, 404 misconfig) is a hard error worth surfacing.
+                soft = False
+                try:
+                    from collectors.hf_drama_importer import HFDatasetUnavailableError
+                    soft = isinstance(e, HFDatasetUnavailableError)
+                except Exception:
+                    pass
+                if soft:
+                    logger.warning("Collect (hf) soft-skip: %s", e)
+                else:
+                    logger.error("Collect (hf) failed: %s", e)
+                    summary["errors"].append(f"collect[hf]: {e}")
         summary["collected"] = collected
 
     if "score" in steps:

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -289,15 +289,20 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
             except Exception as e:
                 logger.error("Collect (%s) failed: %s", name, e)
                 summary["errors"].append(f"collect[{name}]: {e}")
-        # Optional daily `--newest` HuggingFace import (issue #78 follow-up).
-        # OFF by default — only useful when HF_DRAMA_DATASET points at a dataset
-        # that's actually still updating (most AITA dumps are stale, so this
-        # would just re-poll an old tail). Timeliness comes from Lemmy; HF's job
-        # is backfill volume. Best-effort; deep backfill is the manual CLI tool.
+        # Daily HuggingFace AITA import — the reliable drama source (issue #90).
+        # ON by default now: with Reddit off (#78) and Lemmy drama communities
+        # near-empty, the 270K-row AITA dump is the only dependable well of real
+        # drama, and a drama channel doesn't need "thời sự". Default mode
+        # "cursor" walks the static dump forward a fresh slice each day (never
+        # re-imports the same rows); "newest" is only for a confirmed-updating
+        # dataset. Best-effort; deep backfill remains the manual CLI tool.
         if config.HF_DRAMA_DAILY_ENABLED:
             try:
-                from collectors.hf_drama_importer import import_dataset
-                collected += import_dataset(newest=True, limit=config.HF_DAILY_LIMIT)
+                from collectors.hf_drama_importer import import_daily, import_dataset
+                if config.HF_DRAMA_DAILY_MODE == "newest":
+                    collected += import_dataset(newest=True, limit=config.HF_DAILY_LIMIT)
+                else:
+                    collected += import_daily(limit=config.HF_DAILY_LIMIT)
             except Exception as e:
                 logger.error("Collect (hf) failed: %s", e)
                 summary["errors"].append(f"collect[hf]: {e}")

--- a/content-pipeline/storage/migrations/008_pipeline_state.sql
+++ b/content-pipeline/storage/migrations/008_pipeline_state.sql
@@ -1,0 +1,23 @@
+-- Migration 008: pipeline_state — a tiny generic key/value store (issue #90).
+--
+-- First user: the daily HuggingFace drama import (collectors/hf_drama_importer.py
+-- import_daily) persists a per-dataset offset cursor here, so each day's run
+-- walks FORWARD through the 270K-row static AITA dump instead of re-importing the
+-- same tail (the flaw of the old `--newest` daily path). With Reddit off (#78)
+-- and Lemmy drama communities near-empty, this cursor turns the static dump into
+-- a reliable daily drama source and fixes the "0 videos" outcome of issue #90.
+--
+-- Generic on purpose: any collector/job that needs to remember a small scalar
+-- across runs (a cursor, a last-seen id, a timestamp) can reuse this instead of
+-- adding a bespoke table or a fragile state file (state files don't survive a
+-- re-clone; the DB does — the same durability the drama pipeline already relies
+-- on for resume-from-crash).
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents together
+-- with the _migrations bookkeeping INSERT in one transaction.
+
+CREATE TABLE IF NOT EXISTS pipeline_state (
+  key TEXT PRIMARY KEY,
+  value TEXT,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/content-pipeline/storage/migrations/008_pipeline_state_down.sql
+++ b/content-pipeline/storage/migrations/008_pipeline_state_down.sql
@@ -1,0 +1,2 @@
+-- Rollback migration 008: drop the pipeline_state kv table.
+DROP TABLE IF EXISTS pipeline_state;

--- a/content-pipeline/storage/pipeline_state.py
+++ b/content-pipeline/storage/pipeline_state.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""
+Storage helper cho bảng `pipeline_state` — kv scalar bền vững giữa các lần chạy
+(migration 008, issue #90).
+
+Dùng khi một collector/job cần nhớ 1 giá trị nhỏ qua các lần chạy (con trỏ
+offset, id last-seen, timestamp) mà không muốn dựng bảng riêng hay file state
+mong manh (file state không sống sót qua re-clone; DB thì có — cùng độ bền mà
+drama pipeline đã dựa vào để resume-from-crash).
+
+User đầu tiên: con trỏ import HuggingFace hàng ngày
+(collectors/hf_drama_importer.import_daily) — mỗi ngày đi TỚI trong dump AITA
+270K dòng thay vì nạp lại cùng một đuôi.
+
+Value luôn lưu dạng TEXT; helper `get_int`/`set_int` bọc quy đổi cho con trỏ số.
+"""
+
+import logging
+from typing import Optional
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from storage.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def get_state(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Đọc value TEXT theo key, hoặc `default` nếu chưa có."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT value FROM pipeline_state WHERE key = ?", (key,)
+        ).fetchone()
+        return row["value"] if row is not None else default
+    finally:
+        conn.close()
+
+
+def set_state(key: str, value: str) -> None:
+    """Ghi (upsert) value TEXT cho key, cập nhật updated_at."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO pipeline_state (key, value, updated_at) "
+            "VALUES (?, ?, CURRENT_TIMESTAMP) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+            "updated_at = CURRENT_TIMESTAMP",
+            (key, value),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_int(key: str, default: int = 0) -> int:
+    """Đọc con trỏ số. Value hỏng (không phải int) → `default` (self-healing)."""
+    raw = get_state(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning("pipeline_state[%s]=%r không phải int — dùng default %d",
+                       key, raw, default)
+        return default
+
+
+def set_int(key: str, value: int) -> None:
+    """Ghi con trỏ số."""
+    set_state(key, str(int(value)))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    from storage.database import init_db
+    from storage.migrate import migrate_up
+    init_db()
+    migrate_up()
+    print("pipeline_state OK")

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import collectors.hf_drama_importer as hf
 import storage.database as db
 import storage.migrate as migrate
+import storage.pipeline_state as ps
 import storage.stories as stories
 
 
@@ -138,6 +139,81 @@ class TestImportDataset(_HFDBTest):
             n = hf.import_dataset(dataset="owner/ds", limit=150)
         self.assertEqual(n, 150)
         self.assertEqual(fetch.call_count, 2)  # needed a second page
+
+
+class TestImportDaily(_HFDBTest):
+    """Cursor-based daily import (issue #90) — forward-walks a static dump."""
+
+    def _key(self, dataset="owner/ds", split="train"):
+        return f"hf_cursor:{dataset}:{split}"
+
+    def test_first_run_starts_at_zero_and_advances_cursor(self):
+        rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(10)]
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=1000)
+        page = _page(rows, num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]) as fetch:
+            n = hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(n, 10)
+        # Real import fetch (2nd call) started at offset 0.
+        self.assertEqual(fetch.call_args_list[1][0][3], 0)
+        # Cursor advanced by rows scanned (10).
+        self.assertEqual(ps.get_int(self._key()), 10)
+
+    def test_second_run_continues_from_cursor(self):
+        ps.set_int(self._key(), 40)
+        rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(40, 50)]
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=1000)
+        page = _page(rows, num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]) as fetch:
+            n = hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(n, 10)
+        self.assertEqual(fetch.call_args_list[1][0][3], 40)  # resumed at 40
+        self.assertEqual(ps.get_int(self._key()), 50)
+
+    def test_cursor_advances_past_skipped_empties(self):
+        # Window has an empty row in the middle: importing the target (2) still
+        # scans 3 rows, so the cursor must advance by scanned (3), not imported.
+        rows = [
+            {"title": "a", "body": "real one", "id": "1"},
+            {"title": "b", "body": "   ", "id": "2"},
+            {"title": "c", "body": "real two", "id": "3"},
+        ]
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=1000)
+        page = _page(rows, num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]):
+            n = hf.import_daily(dataset="owner/ds", limit=2)
+        self.assertEqual(n, 2)
+        self.assertEqual(ps.get_int(self._key()), 3)  # scanned, not imported
+
+    def test_wraps_to_zero_at_end(self):
+        # Cursor already at the end -> wrap to 0 before importing.
+        ps.set_int(self._key(), 1000)
+        rows = [{"title": f"t{i}", "body": f"b{i}", "id": str(i)} for i in range(10)]
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=1000)
+        page = _page(rows, num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]) as fetch:
+            hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(fetch.call_args_list[1][0][3], 0)  # wrapped to start
+        self.assertEqual(ps.get_int(self._key()), 10)
+
+    def test_cursor_wraps_when_reaching_exact_end(self):
+        # Import the final window -> new offset == total -> reset to 0 for next run.
+        ps.set_int(self._key(), 90)
+        rows = [{"title": f"t{i}", "body": f"b{i}", "id": str(i)} for i in range(90, 100)]
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=100)
+        page = _page(rows, num_rows_total=100)
+        with patch.object(hf, "_fetch_rows", side_effect=[probe, page]):
+            hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(ps.get_int(self._key()), 0)  # wrapped for next run
+
+    def test_fetch_failure_does_not_advance_cursor(self):
+        ps.set_int(self._key(), 20)
+        probe = _page([{"title": "x", "body": "y", "id": "p"}], num_rows_total=1000)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=[probe, hf.HFImportError("boom")]):
+            with self.assertRaises(hf.HFImportError):
+                hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(ps.get_int(self._key()), 20)  # unchanged
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -141,6 +141,61 @@ class TestImportDataset(_HFDBTest):
         self.assertEqual(fetch.call_count, 2)  # needed a second page
 
 
+class _FakeResp:
+    """Minimal urlopen() context-manager stand-in."""
+    def __init__(self, body: bytes):
+        self._body = body
+    def read(self):
+        return self._body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+class TestFetchRowsClassifiesFailures(unittest.TestCase):
+    """_fetch_rows tells a soft 'viewer unavailable' apart from a hard error."""
+
+    def test_non_json_body_raises_unavailable(self):
+        # HTML gateway/"viewer unavailable" page -> "Unexpected token '<'".
+        html = _FakeResp(b"<!DOCTYPE html><html>502 Bad Gateway</html>")
+        with patch.object(hf, "urlopen", return_value=html), \
+             patch.object(hf.time, "sleep"):
+            with self.assertRaises(hf.HFDatasetUnavailableError):
+                hf._fetch_rows("owner/ds", "default", "train", 0, 10)
+
+    def test_5xx_raises_unavailable(self):
+        from urllib.error import HTTPError
+        err = HTTPError("u", 503, "Service Unavailable", {}, None)
+        with patch.object(hf, "urlopen", side_effect=err), \
+             patch.object(hf.time, "sleep"):
+            with self.assertRaises(hf.HFDatasetUnavailableError):
+                hf._fetch_rows("owner/ds", "default", "train", 0, 10)
+
+    def test_404_raises_plain_import_error(self):
+        from urllib.error import HTTPError
+        err = HTTPError("u", 404, "Not Found", {}, None)
+        with patch.object(hf, "urlopen", side_effect=err), \
+             patch.object(hf.time, "sleep"):
+            with self.assertRaises(hf.HFImportError) as ctx:
+                hf._fetch_rows("owner/ds", "default", "train", 0, 10)
+        self.assertNotIsInstance(ctx.exception, hf.HFDatasetUnavailableError)
+
+    def test_network_error_raises_plain_import_error(self):
+        from urllib.error import URLError
+        with patch.object(hf, "urlopen", side_effect=URLError("timeout")), \
+             patch.object(hf.time, "sleep"):
+            with self.assertRaises(hf.HFImportError) as ctx:
+                hf._fetch_rows("owner/ds", "default", "train", 0, 10)
+        self.assertNotIsInstance(ctx.exception, hf.HFDatasetUnavailableError)
+
+    def test_valid_json_returns_parsed(self):
+        good = _FakeResp(b'{"rows": [], "features": [], "num_rows_total": 0}')
+        with patch.object(hf, "urlopen", return_value=good):
+            out = hf._fetch_rows("owner/ds", "default", "train", 0, 10)
+        self.assertEqual(out["num_rows_total"], 0)
+
+
 class TestImportDaily(_HFDBTest):
     """Cursor-based daily import (issue #90) — forward-walks a static dump."""
 
@@ -214,6 +269,16 @@ class TestImportDaily(_HFDBTest):
             with self.assertRaises(hf.HFImportError):
                 hf.import_daily(dataset="owner/ds", limit=10)
         self.assertEqual(ps.get_int(self._key()), 20)  # unchanged
+
+    def test_dataset_unavailable_propagates_and_keeps_cursor(self):
+        # Viewer down: even the size probe fails -> import_daily raises the soft
+        # error and the cursor stays put so tomorrow retries the same window.
+        ps.set_int(self._key(), 30)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")):
+            with self.assertRaises(hf.HFDatasetUnavailableError):
+                hf.import_daily(dataset="owner/ds", limit=10)
+        self.assertEqual(ps.get_int(self._key()), 30)  # unchanged
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -144,8 +144,8 @@ class TestImportDataset(_HFDBTest):
 class TestImportDaily(_HFDBTest):
     """Cursor-based daily import (issue #90) — forward-walks a static dump."""
 
-    def _key(self, dataset="owner/ds", split="train"):
-        return f"hf_cursor:{dataset}:{split}"
+    def _key(self, dataset="owner/ds", cfg="default", split="train"):
+        return f"hf_cursor:{dataset}:{cfg}:{split}"
 
     def test_first_run_starts_at_zero_and_advances_cursor(self):
         rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(10)]

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -208,6 +208,33 @@ class TestRunDaily(RenderBase):
         self.assertNotIn("collected", summary)
         self.assertNotIn("scored", summary)
 
+    def test_hf_unavailable_is_soft_skip_not_summary_error(self):
+        # PA1 (issue #90): a "dataset viewer unavailable" HF failure must NOT
+        # spam the daily summary — it's a soft condition covered by the backfill.
+        import collectors.hf_drama_importer as hf
+        with patch.object(main_drama.config, "HF_DRAMA_DAILY_ENABLED", True), \
+             patch.object(main_drama.config, "HF_DRAMA_DAILY_MODE", "cursor"), \
+             patch("collectors.reddit_drama_collector.collect_all_drama", return_value=0), \
+             patch("collectors.lemmy_drama_collector.collect_all_lemmy", return_value=0), \
+             patch("collectors.hf_drama_importer.import_daily",
+                   side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(main_drama, "_send_summary_safe"):
+            summary = main_drama.run_daily(steps=["collect"])
+        self.assertEqual(summary["collected"], 0)
+        self.assertEqual(summary["errors"], [])  # soft-skipped, not surfaced
+
+    def test_hf_hard_error_is_surfaced_in_summary(self):
+        import collectors.hf_drama_importer as hf
+        with patch.object(main_drama.config, "HF_DRAMA_DAILY_ENABLED", True), \
+             patch.object(main_drama.config, "HF_DRAMA_DAILY_MODE", "cursor"), \
+             patch("collectors.reddit_drama_collector.collect_all_drama", return_value=0), \
+             patch("collectors.lemmy_drama_collector.collect_all_lemmy", return_value=0), \
+             patch("collectors.hf_drama_importer.import_daily",
+                   side_effect=hf.HFImportError("real bug")), \
+             patch.object(main_drama, "_send_summary_safe"):
+            summary = main_drama.run_daily(steps=["collect"])
+        self.assertTrue(any("collect[hf]" in e for e in summary["errors"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_pipeline_state.py
+++ b/content-pipeline/tests/test_pipeline_state.py
@@ -1,0 +1,53 @@
+"""Tests for storage/pipeline_state.py (migration 008, issue #90)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.pipeline_state as ps
+
+
+class TestPipelineState(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def test_get_default_when_absent(self):
+        self.assertIsNone(ps.get_state("nope"))
+        self.assertEqual(ps.get_state("nope", "fallback"), "fallback")
+        self.assertEqual(ps.get_int("nope", 7), 7)
+
+    def test_set_then_get(self):
+        ps.set_state("k", "hello")
+        self.assertEqual(ps.get_state("k"), "hello")
+
+    def test_upsert_overwrites(self):
+        ps.set_state("k", "one")
+        ps.set_state("k", "two")
+        self.assertEqual(ps.get_state("k"), "two")
+
+    def test_int_roundtrip(self):
+        ps.set_int("cursor", 1234)
+        self.assertEqual(ps.get_int("cursor"), 1234)
+
+    def test_get_int_corrupt_value_falls_back(self):
+        ps.set_state("cursor", "not-a-number")
+        self.assertEqual(ps.get_int("cursor", 42), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #90.

## Root cause

The Drama track (`main_drama.py`) ran clean but rendered **0 videos** because it had no dependable source of *genuine* drama:

- **Reddit** — off by default (#78, Reddit killed self-service API app creation).
- **Lemmy `relationship_advice`/`aita`** — near-zero posts/day (thin fediverse volume).
- **Lemmy `asklemmy`** — the only community that yielded anything, but it's a general Q&A board (music, pets, PCs) with zero interpersonal conflict. All 8 stories it produced scored **1–3/6** and were correctly rejected (`DRAMA_SCORE_THRESHOLD=4`).

There was no technical error. The scorer is behaving correctly — the content genuinely isn't drama — so the fix belongs **upstream in sourcing**, not in the scorer or the threshold.

## Fix

**1. HuggingFace AITA becomes the reliable daily source.** The 270K-row AITA dump is genuine drama, and a drama channel doesn't need *thời sự* (a 2019 AITA is as engaging as a 2026 one — freshness is the AI-news track's concern). New `import_daily()` walks the static dump **forward** a fresh slice each day, tracked by a persisted per-dataset **offset cursor** — unlike the old `--newest` path, it never re-imports the same tail against a static dump.
- Cursor advances by rows **scanned** (skipped-empty rows aren't re-scanned).
- `dedupe_check` still guards every row, so the cursor and a manual `--limit N` backfill coexist safely.
- Wraps to 0 at the end (270K rows / ~10 per day = years of runway).
- A failed fetch leaves the cursor untouched, so the next run retries the same window.
- Default **ON**, mode-selectable via `HF_DRAMA_DAILY_MODE` (`cursor` | `newest`).

**2. Durable cursor storage.** New generic `pipeline_state` kv table (migration **008**) + `storage/pipeline_state.py` — survives re-clones (unlike a state file), reusable by any future job that needs to remember a scalar.

**3. Drop `asklemmy` from the Lemmy defaults.** Removed from `LEMMY_COMMUNITIES`; `LEMMY_QA_COMMUNITIES` now defaults empty. It only produced guaranteed-reject non-drama that burned Haiku calls daily. The Q&A machinery stays in place for a genuinely dramatic community.

**4. Cost hygiene.** `HF_DAILY_LIMIT` lowered `30 → 10` to keep the funnel balanced (import → scorer → rewriter (Sonnet, ~10/day cap) → ~2 videos/day + a slow approved cushion) and avoid a runaway backlog / Sonnet spend.

## Consistency / performance / security

- One page fetch per day (cursor mode) — no O(n) dupe re-paging as the dataset fills.
- `get_int` self-heals a corrupt cursor value back to the default.
- No new dependencies (stdlib only); no new external input handling.
- `CLAUDE.md` and `.env.example` updated to match.

## Testing

Full suite green — **872 tests**, including new `test_pipeline_state.py` and `TestImportDaily` cursor tests (first run, resume, advance-past-empties, wrap-around, fetch-failure-doesn't-advance). Migration 008 up/down/re-up verified, and an end-to-end smoke run confirmed the cursor covers a whole dataset across days with no duplicates and clean wrap.

> Note: `lemmy.world` and `datasets-server.huggingface.co` are blocked by this session's egress policy, so live source verification relied on the empirical data in the issue and the documented dataset facts; the production host reaches them normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158GHkkRTTG9ueeKspe9uwj