### PR TITLE
fix(#92): raw-CSV fallback when HF datasets-server is unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,18 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   HuggingFace qua **datasets-server REST API** (`/rows?dataset&config&split&offset&
   length`, stdlib — không cần lib `datasets`). Tự dò cột title/body (override
   `HF_TITLE_FIELD`/`HF_BODY_FIELD`), phân trang ≤100 dòng/request, `source_id` từ
-  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **HF = nguồn
+  id dataset hoặc hash title+body (idempotent, re-run bỏ trùng). **Comment chất
+  lượng (issue #92 follow-up):** với AITA thì phần phán xét cộng đồng (YTA/NTA +
+  reply gắt) là "comment bait" mạnh nhất, nên nếu dataset có cột comment
+  (`top_comments`/`comments`/… — tự dò, override `HF_COMMENTS_FIELD`) thì lọc theo
+  score/độ dài (mirror bộ lọc Q&A của Lemmy: `HF_COMMENT_MIN_SCORE`/`_MIN_CHARS`,
+  cap `HF_COMMENT_TOP_N`), rank theo score, gắn vào CUỐI `raw_content` dưới nhãn
+  "TOP COMMENTS FROM REDDIT" (để scorer/rewriter — vốn đọc `raw_content[:4000]` —
+  nhìn thấy) + lưu structured ở `metadata.top_comments`. Parse được cả 3 dạng dump
+  (JSON list dict có score / JSON list string / một comment string thuần); comment
+  KHÔNG lọt vào `source_id` (vẫn từ title+body) nên một dòng dedupe y hệt dù có/không
+  comment. No-op êm khi dataset không có cột comment; tắt bằng `HF_IMPORT_COMMENTS=0`.
+  Cả đường API lẫn CSV dùng chung `_import_row` nên enrichment nhất quán. **HF = nguồn
   drama TIN CẬY hàng ngày (issue #90):** Reddit tắt + Lemmy drama cạn nên dump
   AITA 270K dòng là giếng drama THẬT duy nhất đáng tin — và với kênh drama thì
   "thời sự" KHÔNG quan trọng (một vụ AITA năm 2019 hấp dẫn y như 2026; freshness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,10 +210,25 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   (`cursor` mặc định | `newest`). **Suy giảm êm (PA1, issue #90):** khi
   datasets-server không phục vụ được rows (viewer đang build/hỏng → body
   KHÔNG-JSON hay 5xx qua mọi retry) → `_fetch_rows` raise
-  `HFDatasetUnavailableError` (phân biệt với 404 misconfig / lỗi code); bước
-  collect `main_drama` coi đây là **cảnh báo mềm, KHÔNG nhét vào summary lỗi**
-  (đỡ spam Telegram mỗi sáng) — kho drama do **deep backfill một lần** gánh, nên
-  outage viewer không làm chết pipeline. Con trỏ KHÔNG advance khi outage (mai
+  `HFDatasetUnavailableError` (phân biệt với 404 misconfig / lỗi code).
+  **Raw-CSV fallback (issue #92):** datasets-server `/rows` hay 503 dài ngày với
+  dataset lớn, làm nguồn drama hàng ngày cạn dù dataset vẫn ổn. Nay khi API báo
+  `HFDatasetUnavailableError`, importer TỰ chuyển sang tải CSV thô của dataset qua
+  Git LFS trên Hub (`huggingface.co/datasets/<ds>/resolve/main/<file>.csv`) — Hub
+  vẫn sống trong các đợt viewer sập. CSV **cache 1 lần trên đĩa** (dump tĩnh nên
+  không cần tải lại; `HF_CSV_CACHE_DIR`, cap `HF_CSV_MAX_BYTES` chống fill đĩa,
+  `HF_CSV_CACHE_TTL_DAYS=0` = không hết hạn). **Consistency:** đọc CSV DÙNG CHUNG
+  `_resolve_columns`/`_import_row`/`_row_source_id` với đường API, và CSV cùng
+  THỨ TỰ dòng như datasets-server, nên con trỏ `import_daily` và dedupe `source_id`
+  KHỚP y hệt khi API↔CSV đổi qua lại giữa chừng (một dòng nạp lối nào cũng ra cùng
+  `source_id` → không nạp trùng). Tên CSV auto-dò qua Hub API (`/api/datasets/X`,
+  vẫn sống khi viewer sập), override `HF_DRAMA_CSV_FILE`; không thấy `.csv` = lỗi
+  cứng (surface). Bật/tắt `HF_CSV_FALLBACK_ENABLED` (mặc định **1**). Đường CSV
+  thủ công: cờ `--csv` (vd `--dataset X --limit 500 --csv`) đọc thẳng CSV, bỏ qua
+  API — đúng workaround của issue #92. Chỉ khi **CẢ API lẫn CSV** đều sập
+  `import_daily` mới raise `HFDatasetUnavailableError`; bước collect `main_drama`
+  coi đó là **cảnh báo mềm, KHÔNG nhét vào summary lỗi** (đỡ spam Telegram) — kho
+  drama do **deep backfill một lần** gánh. Con trỏ KHÔNG advance khi outage (mai
   retry cùng lát). *License:* dataset tái phân phối nội dung Reddit — kiểm tra
   terms từng dataset.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,16 @@ phạm vi: TTS/render video thật (Phase 4).
   chặn tên/từ văn hoá Mỹ lọt qua). Rewrite hợp lệ →
   `status='approved'`; không hợp lệ → `status='needs_review'` + alert
   Telegram (nhưng output vẫn được lưu để người xem lại, không bị huỷ).
+  **Beat "cộng đồng phán xử" — `vn_reactions` (issue #92 follow-up):** prompt v1
+  giờ có field `vn_reactions` — khi STORY GỐC mang mục "TOP COMMENTS FROM REDDIT"
+  (do `hf_drama_importer` gắn vào `raw_content`), model VIỆT HOÁ tinh thần các
+  comment đó thành 2-4 câu bình luận giọng cư dân mạng VN (văn xuôi, không giữ
+  YTA/NTA), đặt gần cuối để **tăng hook + mời người xem vào bình luận**. Field
+  **OPTIONAL** (story không có comment → rỗng), nên KHÔNG nằm trong
+  `_REQUIRED_FIELDS`, không block validate; nhưng khi có thì vẫn bị scan luật
+  Việt-hoá (tên/từ Mỹ). `main_drama.build_narration` chèn `vn_reactions` SAU
+  script, TRƯỚC `vn_commentary` (story → đám đông phán xử → góc nhìn người kể +
+  CTA); story cũ không có field này → narration không đổi.
   **Word count 2 dải (issue #86):** prompt vẫn nhắm 800-1200 từ, nhưng LLM
   không bao giờ trúng chính xác — story #2 ra 733 từ (script hoàn chỉnh, chỉ
   thiếu 67 từ) bị reject y như stub gãy → cả run render **0 video**. Fix: tách
@@ -516,8 +526,9 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
   row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn
   auto-render lại, chờ xử lý tay — không bao giờ render trùng. Narration =
-  hook + script + vn_commentary (check containment tránh đọc lặp — prompt
-  rewriter không nói rõ script có chứa hook hay không). Chạy 06:40
+  hook + script + `vn_reactions` (beat cộng đồng phán xử, optional) +
+  vn_commentary (check containment tránh đọc lặp — prompt rewriter không nói rõ
+  script có chứa hook hay không). Chạy 06:40
   (`com.ai5phut.drama-pipeline.plist`), sau collector 06:06, trước pipeline
   AI 07:00.
 - **`storage/quota.py`** — đếm unit YouTube API (upload 1600, thumbnail 50,

--- a/content-pipeline/.gitignore
+++ b/content-pipeline/.gitignore
@@ -15,5 +15,7 @@ notifier/.telegram_offset
 notifier/.seed_state.json
 notifier/.review_state.json
 notifier/.analytics_state.json
+data/hf_csv_cache/
+data/*.csv
 video/assets/backgrounds/*.mp4
 video/assets/fonts/*.ttf

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -73,7 +73,16 @@ _BODY_CANDIDATES = [
     "content", "story", "self_text",
 ]
 _ID_CANDIDATES = ["id", "post_id", "submission_id", "name", "link_id"]
+# Comment/reaction columns, most-specific first (issue #92 follow-up). AITA dumps
+# vary: some ship a single top comment, some a JSON list, some scored dicts.
+_COMMENT_CANDIDATES = [
+    "top_comments", "top_comment", "best_comment", "comments", "comment",
+    "comment_body", "selftext_comments", "body_comments",
+]
 _REMOVED_SENTINELS = {"[removed]", "[deleted]", ""}
+# Keys a comment dict might use for its text / score, across dataset conventions.
+_COMMENT_TEXT_KEYS = ("body", "content", "text", "comment", "comment_body")
+_COMMENT_SCORE_KEYS = ("score", "ups", "upvotes", "num_upvotes")
 
 
 class HFImportError(Exception):
@@ -179,8 +188,83 @@ def _row_source_id(dataset: str, row: dict, id_field: str | None, title: str, bo
     return f"hf_{tag}_{raw}"
 
 
-def _resolve_columns(columns: list[str], dataset: str) -> tuple[str | None, str, str | None]:
-    """Pick (title, body, id) columns for a dataset, shared by API and CSV paths.
+def _parse_comments(value) -> list[dict]:
+    """Normalise a row's comment cell into [{content, score}], score None if absent.
+
+    Handles the shapes AITA dumps use: a JSON list of strings, a JSON list of
+    scored dicts, or a single plain-string top comment. Best-effort — anything
+    unparseable degrades to a single-string comment rather than raising."""
+    if value is None:
+        return []
+    if isinstance(value, (list, dict)):
+        parsed = value
+    else:
+        text = str(value).strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return [{"content": text, "score": None}]  # one plain comment
+    items = parsed if isinstance(parsed, list) else [parsed]
+    out: list[dict] = []
+    for item in items:
+        if isinstance(item, dict):
+            content = next((str(item[k]) for k in _COMMENT_TEXT_KEYS
+                            if item.get(k)), "").strip()
+            score = next((item[k] for k in _COMMENT_SCORE_KEYS
+                          if isinstance(item.get(k), (int, float))), None)
+        else:
+            content, score = str(item).strip(), None
+        if content:
+            out.append({"content": content, "score": score})
+    return out
+
+
+def _select_quality_comments(comments: list[dict]) -> list[str]:
+    """Filter + rank comments the way the Lemmy Q&A collector does: drop
+    removed/short/low-scored ones, best-score first, cap at HF_COMMENT_TOP_N.
+
+    When a comment carries no score (dataset didn't store one) we can't score-gate
+    it, so it's kept on length alone — better a good unscored reply than nothing."""
+    good = []
+    for c in comments:
+        content = c["content"]
+        if content in _REMOVED_SENTINELS or len(content) < config.HF_COMMENT_MIN_CHARS:
+            continue
+        score = c["score"]
+        if score is not None and score < config.HF_COMMENT_MIN_SCORE:
+            continue
+        good.append(c)
+    # Stable sort: scored comments by score desc; unscored keep insertion order
+    # (datasets that ship a single/pre-ranked comment stay in their given order).
+    good.sort(key=lambda c: c["score"] if c["score"] is not None else -1, reverse=True)
+    return [c["content"] for c in good[:config.HF_COMMENT_TOP_N]]
+
+
+def _row_comments(row: dict, comment_field: str | None) -> list[str]:
+    """Quality comments for a row, or [] when comments are off / column absent."""
+    if not (config.HF_IMPORT_COMMENTS and comment_field):
+        return []
+    return _select_quality_comments(_parse_comments(row.get(comment_field)))
+
+
+def _compose_raw_content(body: str, comments: list[str]) -> str:
+    """Body plus a labelled community-reaction section the scorer/rewriter can see.
+
+    Kept in English (the source language) so it reads as part of the raw material
+    the rewriter localises; the label makes it unambiguous these are Reddit
+    reactions, not the OP's story."""
+    if not comments:
+        return body
+    section = "\n\n---\nTOP COMMENTS FROM REDDIT:\n" + "\n".join(f"- {c}" for c in comments)
+    return body + section
+
+
+def _resolve_columns(columns: list[str], dataset: str
+                     ) -> tuple[str | None, str, str | None, str | None]:
+    """Pick (title, body, id, comment) columns for a dataset, shared by API and
+    CSV paths.
 
     Raises HFImportError if no usable body/text column is present. Keeping this in
     one place is what guarantees the two row sources auto-detect identically, so a
@@ -195,15 +279,24 @@ def _resolve_columns(columns: list[str], dataset: str) -> tuple[str | None, str,
             f"column holding the story text"
         )
     id_field = _pick_column(columns, "", _ID_CANDIDATES)
-    return title_field, body_field, id_field
+    # Comment column is optional: auto-detect, but only when it isn't the body
+    # column already claimed (some datasets name the body "comment").
+    comment_field = None
+    if config.HF_IMPORT_COMMENTS:
+        comment_field = _pick_column(columns, config.HF_COMMENTS_FIELD, _COMMENT_CANDIDATES)
+        if comment_field == body_field:
+            comment_field = None
+    return title_field, body_field, id_field, comment_field
 
 
 def _import_row(dataset: str, row: dict, title_field: str | None, body_field: str,
-                id_field: str | None, split: str) -> str:
+                id_field: str | None, split: str, comment_field: str | None = None) -> str:
     """Insert one dataset row as a drama story. Returns 'imported'|'dup'|'empty'.
 
     The single source of truth for row → story mapping (source_id, dedupe,
-    metadata) so the API and CSV paths stay byte-for-byte consistent."""
+    metadata, comment enrichment) so the API and CSV paths stay byte-for-byte
+    consistent. source_id is derived from title+body ONLY (not comments), so a row
+    dedupes identically whether or not its comments were available/loaded."""
     title = str(row.get(title_field, "") or "").strip() if title_field else ""
     body = str(row.get(body_field, "") or "").strip()
     if not body or body in _REMOVED_SENTINELS:
@@ -211,13 +304,17 @@ def _import_row(dataset: str, row: dict, title_field: str | None, body_field: st
     source_id = _row_source_id(dataset, row, id_field, title, body)
     if dedupe_check(source_id):
         return "dup"
+    comments = _row_comments(row, comment_field)
+    metadata = {"dataset": dataset, "hf_split": split}
+    if comments:
+        metadata["top_comments"] = comments
     insert_story(
         source="huggingface",
         source_id=source_id,
-        raw_content=body,
+        raw_content=_compose_raw_content(body, comments),
         track="drama",
         title=title or None,
-        metadata={"dataset": dataset, "hf_split": split},
+        metadata=metadata,
     )
     return "imported"
 
@@ -234,9 +331,9 @@ def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
     """
     first = _fetch_rows(dataset, cfg, split, offset, min(_PAGE, limit))
     columns = [f["name"] for f in first.get("features", []) if isinstance(f, dict) and "name" in f]
-    title_field, body_field, id_field = _resolve_columns(columns, dataset)
-    logger.info("HF import %s: title=%r body=%r id=%r (%d columns)",
-                dataset, title_field, body_field, id_field, len(columns))
+    title_field, body_field, id_field, comment_field = _resolve_columns(columns, dataset)
+    logger.info("HF import %s: title=%r body=%r id=%r comment=%r (%d columns)",
+                dataset, title_field, body_field, id_field, comment_field, len(columns))
 
     total_available = first.get("num_rows_total", limit)
     target = min(limit, max(0, total_available - offset)) if total_available else limit
@@ -254,7 +351,8 @@ def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
                 break
             scanned += 1
             row = entry.get("row", {}) if isinstance(entry, dict) else {}
-            verdict = _import_row(dataset, row, title_field, body_field, id_field, split)
+            verdict = _import_row(dataset, row, title_field, body_field, id_field,
+                                  split, comment_field)
             if verdict == "imported":
                 imported += 1
             elif verdict == "dup":
@@ -439,9 +537,9 @@ def _paginate_import_csv(dataset: str, split: str, offset: int,
     path = _ensure_csv_cached(dataset)
     f, reader, columns = _open_csv_reader(path)
     try:
-        title_field, body_field, id_field = _resolve_columns(columns, dataset)
-        logger.info("HF CSV import %s: title=%r body=%r id=%r (%d columns)",
-                    dataset, title_field, body_field, id_field, len(columns))
+        title_field, body_field, id_field, comment_field = _resolve_columns(columns, dataset)
+        logger.info("HF CSV import %s: title=%r body=%r id=%r comment=%r (%d columns)",
+                    dataset, title_field, body_field, id_field, comment_field, len(columns))
         imported = scanned = skipped_dup = skipped_empty = 0
         for i, row in enumerate(reader):
             if i < offset:
@@ -449,7 +547,8 @@ def _paginate_import_csv(dataset: str, split: str, offset: int,
             if imported >= limit:
                 break
             scanned += 1
-            verdict = _import_row(dataset, row, title_field, body_field, id_field, split)
+            verdict = _import_row(dataset, row, title_field, body_field, id_field,
+                                  split, comment_field)
             if verdict == "imported":
                 imported += 1
             elif verdict == "dup":

--- a/content-pipeline/collectors/hf_drama_importer.py
+++ b/content-pipeline/collectors/hf_drama_importer.py
@@ -15,6 +15,15 @@ or `pandas` dependency):
         ?dataset=<owner/name>&config=<cfg>&split=<split>&offset=<n>&length=<=100
 Response: {"features":[{"name":...}], "rows":[{"row":{...}}], "num_rows_total":N}
 
+RAW-CSV FALLBACK (issue #92): datasets-server is a separate service that
+periodically 503s / serves a "viewer building" HTML page for big datasets. When
+that happens the API path raises HFDatasetUnavailableError and we fall back to
+downloading the dataset's raw CSV from the Hub (which stays up) via Git LFS
+    GET https://huggingface.co/datasets/<owner/name>/resolve/main/<file>.csv
+caching it once on disk (the dump is static — see HF_DRAMA_* in config). The CSV
+is read with the SAME column auto-detection and source_id scheme as the API path,
+so the daily cursor offset and dedupe stay consistent across an API↔CSV switch.
+
 This is a MANUAL, occasional tool (a 270K-row dataset shouldn't re-import daily):
     python -m collectors.hf_drama_importer [--dataset X] [--limit N] [--offset M]
 Idempotent: source_id is derived from a stable row id (or a content hash), so
@@ -26,12 +35,13 @@ intended use, but check each dataset's license/terms before relying on it.
 """
 
 import argparse
+import csv
 import hashlib
 import json
 import logging
 import time
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 import sys
@@ -45,6 +55,15 @@ logger = logging.getLogger(__name__)
 
 _ROWS_URL = "https://datasets-server.huggingface.co/rows"
 _PAGE = 100  # datasets-server caps a page at 100 rows.
+
+# Raw-CSV fallback (issue #92). The Hub stays up when datasets-server is down.
+_HUB_API_URL = "https://huggingface.co/api/datasets/"          # + <owner/name>
+_RESOLVE_URL = "https://huggingface.co/datasets/{ds}/resolve/main/{path}"
+_CSV_DOWNLOAD_CHUNK = 1 << 20  # 1 MiB streaming chunks
+
+# AITA bodies routinely exceed csv's default 128 KiB field cap; raise it so a
+# long story doesn't abort the whole read with "field larger than field limit".
+csv.field_size_limit(16 * 1024 * 1024)
 
 # Candidate column names, most-specific first, used when HF_TITLE_FIELD /
 # HF_BODY_FIELD aren't set. AITA/relationship datasets vary in naming.
@@ -160,6 +179,49 @@ def _row_source_id(dataset: str, row: dict, id_field: str | None, title: str, bo
     return f"hf_{tag}_{raw}"
 
 
+def _resolve_columns(columns: list[str], dataset: str) -> tuple[str | None, str, str | None]:
+    """Pick (title, body, id) columns for a dataset, shared by API and CSV paths.
+
+    Raises HFImportError if no usable body/text column is present. Keeping this in
+    one place is what guarantees the two row sources auto-detect identically, so a
+    row's source_id (and thus dedupe) is the same however it was fetched."""
+    if not columns:
+        raise HFImportError(f"no columns reported for {dataset}")
+    title_field = _pick_column(columns, config.HF_TITLE_FIELD, _TITLE_CANDIDATES)
+    body_field = _pick_column(columns, config.HF_BODY_FIELD, _BODY_CANDIDATES)
+    if not body_field:
+        raise HFImportError(
+            f"no text/body column found in {columns}; set HF_BODY_FIELD to the "
+            f"column holding the story text"
+        )
+    id_field = _pick_column(columns, "", _ID_CANDIDATES)
+    return title_field, body_field, id_field
+
+
+def _import_row(dataset: str, row: dict, title_field: str | None, body_field: str,
+                id_field: str | None, split: str) -> str:
+    """Insert one dataset row as a drama story. Returns 'imported'|'dup'|'empty'.
+
+    The single source of truth for row → story mapping (source_id, dedupe,
+    metadata) so the API and CSV paths stay byte-for-byte consistent."""
+    title = str(row.get(title_field, "") or "").strip() if title_field else ""
+    body = str(row.get(body_field, "") or "").strip()
+    if not body or body in _REMOVED_SENTINELS:
+        return "empty"
+    source_id = _row_source_id(dataset, row, id_field, title, body)
+    if dedupe_check(source_id):
+        return "dup"
+    insert_story(
+        source="huggingface",
+        source_id=source_id,
+        raw_content=body,
+        track="drama",
+        title=title or None,
+        metadata={"dataset": dataset, "hf_split": split},
+    )
+    return "imported"
+
+
 def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
                      limit: int) -> tuple[int, int]:
     """Import up to `limit` rows starting at `offset`. Returns (imported, scanned).
@@ -172,17 +234,7 @@ def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
     """
     first = _fetch_rows(dataset, cfg, split, offset, min(_PAGE, limit))
     columns = [f["name"] for f in first.get("features", []) if isinstance(f, dict) and "name" in f]
-    if not columns:
-        raise HFImportError(f"no feature columns reported for {dataset}")
-
-    title_field = _pick_column(columns, config.HF_TITLE_FIELD, _TITLE_CANDIDATES)
-    body_field = _pick_column(columns, config.HF_BODY_FIELD, _BODY_CANDIDATES)
-    if not body_field:
-        raise HFImportError(
-            f"no text/body column found in {columns}; set HF_BODY_FIELD to the "
-            f"column holding the story text"
-        )
-    id_field = _pick_column(columns, "", _ID_CANDIDATES)
+    title_field, body_field, id_field = _resolve_columns(columns, dataset)
     logger.info("HF import %s: title=%r body=%r id=%r (%d columns)",
                 dataset, title_field, body_field, id_field, len(columns))
 
@@ -202,24 +254,13 @@ def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
                 break
             scanned += 1
             row = entry.get("row", {}) if isinstance(entry, dict) else {}
-            title = str(row.get(title_field, "") or "").strip() if title_field else ""
-            body = str(row.get(body_field, "") or "").strip()
-            if not body or body in _REMOVED_SENTINELS:
-                skipped_empty += 1
-                continue
-            source_id = _row_source_id(dataset, row, id_field, title, body)
-            if dedupe_check(source_id):
+            verdict = _import_row(dataset, row, title_field, body_field, id_field, split)
+            if verdict == "imported":
+                imported += 1
+            elif verdict == "dup":
                 skipped_dup += 1
-                continue
-            insert_story(
-                source="huggingface",
-                source_id=source_id,
-                raw_content=body,
-                track="drama",
-                title=title or None,
-                metadata={"dataset": dataset, "hf_split": split},
-            )
-            imported += 1
+            else:
+                skipped_empty += 1
 
         next_offset = offset + scanned
         if imported >= target or next_offset >= (total_available or next_offset):
@@ -231,9 +272,234 @@ def _paginate_import(dataset: str, cfg: str, split: str, offset: int,
     return imported, scanned
 
 
+# --------------------------------------------------------------------------- #
+# Raw-CSV fallback (issue #92): datasets-server down → read the Hub's raw CSV.
+# --------------------------------------------------------------------------- #
+
+def _hub_get(url: str) -> bytes:
+    """GET a Hub URL, translating failures into the same soft/hard split the API
+    path uses: network/5xx → HFDatasetUnavailableError (retry tomorrow); 404 →
+    HFImportError (misconfig). Retries transient failures with backoff."""
+    last_error = None
+    for attempt in range(3):
+        req = Request(url)
+        req.add_header("User-Agent", "ai5phut-content-pipeline/1.0")
+        try:
+            with urlopen(req, timeout=config.HF_TIMEOUT) as resp:
+                return resp.read()
+        except HTTPError as e:
+            last_error = e
+            if e.code == 404:
+                raise HFImportError(f"Hub resource not found (404): {url}") from e
+            logger.warning("Hub HTTP %s for %s (attempt %d/3)", e.code, url, attempt + 1)
+        except (URLError, TimeoutError) as e:
+            last_error = e
+            logger.warning("Hub request error for %s (attempt %d/3): %s", url, attempt + 1, e)
+        if attempt < 2:
+            time.sleep(2 ** (attempt + 1))
+    raise HFDatasetUnavailableError(
+        f"Hub unreachable for {url} (last: {last_error}); raw-CSV fallback failed"
+    )
+
+
+def _resolve_csv_file(dataset: str) -> str:
+    """Repo path of the CSV to read. HF_DRAMA_CSV_FILE wins; else discover it via
+    the Hub API (which stays up when datasets-server is down, per issue #92).
+
+    Picks the first `.csv` sibling. Raises HFImportError if the repo exposes none
+    (a real misconfig — surface it, don't silently soft-skip)."""
+    if config.HF_DRAMA_CSV_FILE:
+        return config.HF_DRAMA_CSV_FILE
+    body = _hub_get(f"{_HUB_API_URL}{dataset}")
+    try:
+        meta = json.loads(body.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as e:
+        raise HFDatasetUnavailableError(f"Hub API non-JSON for {dataset}: {e}") from e
+    csvs = [s.get("rfilename") for s in meta.get("siblings", [])
+            if isinstance(s, dict) and str(s.get("rfilename", "")).lower().endswith(".csv")]
+    if not csvs:
+        raise HFImportError(
+            f"no .csv file in {dataset}; set HF_DRAMA_CSV_FILE to the data file's "
+            f"repo path (raw-CSV fallback needs a CSV)"
+        )
+    logger.info("HF CSV fallback: using %r from %s (%d csv files)", csvs[0], dataset, len(csvs))
+    return csvs[0]
+
+
+def _cache_path(dataset: str, csv_file: str) -> str:
+    """Local cache path for a dataset's CSV. The filename is hashed so an
+    attacker-controlled repo path can't escape HF_CSV_CACHE_DIR (path traversal),
+    with a readable prefix for humans browsing the cache dir."""
+    safe = dataset.replace("/", "__")[:40]
+    digest = hashlib.sha256(f"{dataset}\n{csv_file}".encode("utf-8")).hexdigest()[:16]
+    return os.path.join(config.HF_CSV_CACHE_DIR, f"{safe}__{digest}.csv")
+
+
+def _cache_is_fresh(path: str) -> bool:
+    if not (os.path.exists(path) and os.path.getsize(path) > 0):
+        return False
+    ttl_days = config.HF_CSV_CACHE_TTL_DAYS
+    if ttl_days <= 0:
+        return True  # static dump: cache never expires
+    age_days = (time.time() - os.path.getmtime(path)) / 86400.0
+    return age_days < ttl_days
+
+
+def _download_csv(dataset: str, csv_file: str, dest: str) -> None:
+    """Stream the raw CSV to `dest` atomically. Aborts if it exceeds
+    HF_CSV_MAX_BYTES (disk-fill guard). Downloads to a temp file and renames so a
+    crash mid-download never leaves a truncated CSV that later reads as valid."""
+    url = _RESOLVE_URL.format(ds=dataset, path=quote(csv_file))
+    os.makedirs(config.HF_CSV_CACHE_DIR, exist_ok=True)
+    tmp = f"{dest}.part"
+    written = 0
+    logger.info("HF CSV fallback: downloading %s → %s", url, dest)
+    req = Request(url)
+    req.add_header("User-Agent", "ai5phut-content-pipeline/1.0")
+    try:
+        with urlopen(req, timeout=config.HF_TIMEOUT) as resp, open(tmp, "wb") as out:
+            while True:
+                chunk = resp.read(_CSV_DOWNLOAD_CHUNK)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > config.HF_CSV_MAX_BYTES:
+                    raise HFImportError(
+                        f"CSV for {dataset} exceeds HF_CSV_MAX_BYTES "
+                        f"({config.HF_CSV_MAX_BYTES} bytes); raise the cap or pick a smaller file"
+                    )
+                out.write(chunk)
+    except HTTPError as e:
+        _safe_unlink(tmp)
+        if e.code == 404:
+            raise HFImportError(f"CSV not found (404): {url}") from e
+        raise HFDatasetUnavailableError(f"Hub CSV download failed ({e.code}): {url}") from e
+    except (URLError, TimeoutError) as e:
+        _safe_unlink(tmp)
+        raise HFDatasetUnavailableError(f"Hub CSV download error: {url} ({e})") from e
+    except BaseException:
+        _safe_unlink(tmp)
+        raise
+    os.replace(tmp, dest)
+    logger.info("HF CSV fallback: cached %d bytes at %s", written, dest)
+
+
+def _safe_unlink(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def _ensure_csv_cached(dataset: str) -> str:
+    """Return a local path to the dataset's CSV, downloading (and caching) it if
+    the cache is missing/stale. One download serves both the size probe and the
+    row read, so a fallback run fetches the big file at most once."""
+    csv_file = _resolve_csv_file(dataset)
+    path = _cache_path(dataset, csv_file)
+    if _cache_is_fresh(path):
+        logger.info("HF CSV fallback: using cached %s", path)
+        return path
+    _download_csv(dataset, csv_file, path)
+    return path
+
+
+def _open_csv_reader(path: str):
+    """Open the cached CSV as a DictReader, returning (file, reader, columns).
+    Caller closes the file. Raises HFImportError if it has no header."""
+    f = open(path, newline="", encoding="utf-8", errors="replace")
+    reader = csv.DictReader(f)
+    columns = reader.fieldnames or []
+    if not columns:
+        f.close()
+        raise HFImportError(f"cached CSV {path} has no header row")
+    return f, reader, list(columns)
+
+
+def _csv_row_count(dataset: str) -> int:
+    """Row count (excluding header) of the dataset's CSV — the CSV analogue of
+    _dataset_size, for cursor wrap-around. Cheap on a local cached file."""
+    path = _ensure_csv_cached(dataset)
+    f, reader, _cols = _open_csv_reader(path)
+    try:
+        return sum(1 for _ in reader)
+    finally:
+        f.close()
+
+
+def _paginate_import_csv(dataset: str, split: str, offset: int,
+                         limit: int) -> tuple[int, int]:
+    """CSV analogue of _paginate_import: import up to `limit` rows starting at
+    row `offset` from the cached CSV. Returns (imported, scanned) with the SAME
+    semantics — scanned counts rows consumed from `offset` including skipped ones,
+    so the daily cursor advances identically whether the API or CSV served them.
+
+    Row order matches the datasets-server (both read the same underlying file in
+    file order), so an offset written by the API path resumes correctly here."""
+    path = _ensure_csv_cached(dataset)
+    f, reader, columns = _open_csv_reader(path)
+    try:
+        title_field, body_field, id_field = _resolve_columns(columns, dataset)
+        logger.info("HF CSV import %s: title=%r body=%r id=%r (%d columns)",
+                    dataset, title_field, body_field, id_field, len(columns))
+        imported = scanned = skipped_dup = skipped_empty = 0
+        for i, row in enumerate(reader):
+            if i < offset:
+                continue
+            if imported >= limit:
+                break
+            scanned += 1
+            verdict = _import_row(dataset, row, title_field, body_field, id_field, split)
+            if verdict == "imported":
+                imported += 1
+            elif verdict == "dup":
+                skipped_dup += 1
+            else:
+                skipped_empty += 1
+    finally:
+        f.close()
+    logger.info("HF CSV import done: %d new stories (%d dup, %d empty, %d scanned) from %s",
+                imported, skipped_dup, skipped_empty, scanned, dataset)
+    return imported, scanned
+
+
+def _import_window(dataset: str, cfg: str, split: str, offset: int,
+                   limit: int, force_csv: bool = False) -> tuple[int, int]:
+    """Import a window via the datasets-server API, falling back to the raw CSV
+    when the API viewer is unavailable (issue #92). Single dispatch point so
+    import_dataset and import_daily both get the fallback with identical cursor
+    semantics. If the CSV fallback is disabled or itself unavailable, the soft
+    HFDatasetUnavailableError propagates unchanged (main_drama soft-skips it).
+
+    force_csv=True skips the API entirely (the `--csv` backfill path): read
+    straight from the raw CSV even when the API is up."""
+    if force_csv:
+        return _paginate_import_csv(dataset, split, offset, limit)
+    try:
+        return _paginate_import(dataset, cfg, split, offset, limit)
+    except HFDatasetUnavailableError:
+        if not config.HF_CSV_FALLBACK_ENABLED:
+            raise
+        logger.warning("datasets-server unavailable for %s — falling back to raw CSV (issue #92)",
+                       dataset)
+        return _paginate_import_csv(dataset, split, offset, limit)
+
+
+def _dataset_size_or_csv(dataset: str, cfg: str, split: str) -> int:
+    """_dataset_size with the same CSV fallback as _import_window, so import_daily
+    can compute cursor wrap-around while the API is down."""
+    try:
+        return _dataset_size(dataset, cfg, split)
+    except HFDatasetUnavailableError:
+        if not config.HF_CSV_FALLBACK_ENABLED:
+            raise
+        return _csv_row_count(dataset)
+
+
 def import_dataset(dataset: str | None = None, config_name: str | None = None,
                    split: str | None = None, limit: int | None = None,
-                   offset: int = 0, newest: bool = False) -> int:
+                   offset: int = 0, newest: bool = False,
+                   force_csv: bool = False) -> int:
     """Import up to `limit` rows into `stories` (track='drama'). Returns new count.
 
     newest=True pulls from the TAIL of the dataset (offset = num_rows_total -
@@ -241,6 +507,10 @@ def import_dataset(dataset: str | None = None, config_name: str | None = None,
     AITA dataset) the tail is the freshest content, which is what "thời sự"
     wants. It costs one extra 1-row probe to learn the size. For the daily
     static-dump source use import_daily (a forward cursor), not newest.
+
+    force_csv=True reads straight from the raw CSV (the `--csv` backfill path),
+    bypassing the datasets-server API — useful when the API is known to be down
+    (issue #92) or for a fast one-shot deep backfill.
     """
     dataset = dataset or config.HF_DRAMA_DATASET
     cfg = config_name or config.HF_DRAMA_CONFIG
@@ -248,12 +518,13 @@ def import_dataset(dataset: str | None = None, config_name: str | None = None,
     limit = config.HF_IMPORT_LIMIT if limit is None else limit
 
     if newest:
-        total = _dataset_size(dataset, cfg, split)
+        total = (_csv_row_count(dataset) if force_csv
+                 else _dataset_size_or_csv(dataset, cfg, split))
         offset = max(0, total - limit)
         logger.info("HF --newest: %s has %d rows → importing from offset %d",
                     dataset, total, offset)
 
-    imported, _scanned = _paginate_import(dataset, cfg, split, offset, limit)
+    imported, _scanned = _import_window(dataset, cfg, split, offset, limit, force_csv=force_csv)
     return imported
 
 
@@ -283,14 +554,14 @@ def import_daily(dataset: str | None = None, limit: int | None = None) -> int:
     # different row stream per config, so a shared cursor across configs would
     # start a new config at a stale offset (skip its head, later collide).
     key = f"hf_cursor:{dataset}:{cfg}:{split}"
-    total = _dataset_size(dataset, cfg, split)
+    total = _dataset_size_or_csv(dataset, cfg, split)
     offset = get_int(key, 0)
     if total and offset >= total:
         logger.info("HF cursor for %s past end (%d/%d) — wrapping to 0",
                     dataset, offset, total)
         offset = 0
 
-    imported, scanned = _paginate_import(dataset, cfg, split, offset, limit)
+    imported, scanned = _import_window(dataset, cfg, split, offset, limit)
     new_offset = offset + scanned
     if total and new_offset >= total:
         new_offset = 0  # wrapped; next run restarts from the top
@@ -313,6 +584,9 @@ if __name__ == "__main__":
     parser.add_argument("--offset", type=int, default=0, help="start row offset")
     parser.add_argument("--newest", action="store_true",
                         help="import the newest rows (tail) instead of from --offset")
+    parser.add_argument("--csv", action="store_true",
+                        help="read from the raw CSV (Git LFS) instead of the "
+                             "datasets-server API — use when the API is down (issue #92)")
     args = parser.parse_args()
 
     from storage.database import init_db
@@ -321,4 +595,4 @@ if __name__ == "__main__":
     migrate_up()
     import_dataset(dataset=args.dataset, config_name=args.config_name,
                    split=args.split, limit=args.limit, offset=args.offset,
-                   newest=args.newest)
+                   newest=args.newest, force_csv=args.csv)

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -429,6 +429,31 @@ HF_DRAMA_DAILY_MODE = os.getenv("HF_DRAMA_DAILY_MODE", "cursor").strip().lower()
 # the videos/day, so bump it only when you want a deeper cushion.
 HF_DAILY_LIMIT = int(os.getenv("HF_DAILY_LIMIT", "10"))
 
+# --- HuggingFace raw-CSV fallback (issue #92) ---
+# The datasets-server /rows API is a separate, flaky service that periodically
+# returns 503 / a "viewer building" HTML page for large datasets — when it does,
+# the daily drama source dries up even though the dataset itself is fine. The Hub
+# (huggingface.co) stays up in those outages, and the raw CSV is downloadable via
+# Git LFS at /datasets/<ds>/resolve/main/<file>.csv. So when the API is
+# unavailable we fall back to reading rows straight from that CSV (cached once on
+# disk — the dump is static, per HF_DRAMA_* above, so it never needs refetching).
+# Row ORDER and column detection match the API path, so the daily cursor and
+# source_id dedupe stay consistent across a mid-run API↔CSV switch.
+HF_CSV_FALLBACK_ENABLED = os.getenv("HF_CSV_FALLBACK_ENABLED", "1") == "1"
+# "" = auto-discover the CSV filename in the repo via the Hub API (which stays up
+# when datasets-server is down). Set to a specific repo path (e.g.
+# "cleaned_dataset.csv") to skip discovery or pick among multiple CSVs.
+HF_DRAMA_CSV_FILE = os.getenv("HF_DRAMA_CSV_FILE", "")
+HF_CSV_CACHE_DIR = os.getenv(
+    "HF_CSV_CACHE_DIR", os.path.join(os.path.dirname(__file__), "data", "hf_csv_cache")
+)
+# Guard against filling the disk with a runaway/hostile download (the AITA dump is
+# ~680MB; 2GB leaves headroom). Streaming download aborts past this.
+HF_CSV_MAX_BYTES = int(os.getenv("HF_CSV_MAX_BYTES", str(2 * 1024 ** 3)))
+# Cached CSV freshness in days; 0 = never expire (the default dump is STATIC, so a
+# stale-forever cache is correct). Set >0 only for a dataset you expect to change.
+HF_CSV_CACHE_TTL_DAYS = int(os.getenv("HF_CSV_CACHE_TTL_DAYS", "0"))
+
 # Drama backlog alert (issue #78 follow-up). With Reddit off by default, the
 # Drama channel is fed by manual seeds — so the meaningful health signal is "not
 # enough stories queued to keep producing", not "a collector went silent". When

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -403,6 +403,16 @@ HF_IMPORT_LIMIT = int(os.getenv("HF_IMPORT_LIMIT", "200"))  # default for the ma
 HF_TITLE_FIELD = os.getenv("HF_TITLE_FIELD", "")   # "" = auto-detect
 HF_BODY_FIELD = os.getenv("HF_BODY_FIELD", "")     # "" = auto-detect
 HF_TIMEOUT = int(os.getenv("HF_TIMEOUT", "30"))
+# Quality comments. For AITA/drama, the community reaction (the YTA/NTA verdicts +
+# the savage top replies) is often the strongest "comment bait" — so when a
+# dataset row carries comments, append the best few to the story so the scorer and
+# rewriter see them (they read raw_content). Auto-detected like the body column;
+# a no-op when the dataset has no comment column. Mirrors the Lemmy Q&A filter.
+HF_IMPORT_COMMENTS = os.getenv("HF_IMPORT_COMMENTS", "1") == "1"
+HF_COMMENTS_FIELD = os.getenv("HF_COMMENTS_FIELD", "")   # "" = auto-detect
+HF_COMMENT_TOP_N = int(os.getenv("HF_COMMENT_TOP_N", "3"))       # keep best N
+HF_COMMENT_MIN_SCORE = int(os.getenv("HF_COMMENT_MIN_SCORE", "10"))  # only if scored
+HF_COMMENT_MIN_CHARS = int(os.getenv("HF_COMMENT_MIN_CHARS", "40"))  # drop one-liners
 # Daily HuggingFace auto-import inside main_drama's collect step. ON by default
 # (issue #90): with Reddit off (#78) and Lemmy drama communities near-empty, the
 # 270K-row AITA dump is the only reliable well of *genuine* drama — and for a

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -304,10 +304,12 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
                 else:
                     collected += import_daily(limit=config.HF_DAILY_LIMIT)
             except Exception as e:
-                # HF is best-effort. A "dataset viewer unavailable" condition is a
-                # SOFT failure — the deep-backfill cushion carries production — so
+                # HF is best-effort. When datasets-server is down the importer now
+                # falls back to the raw CSV on the Hub (issue #92), so this except
+                # only fires when BOTH the API and that CSV fallback are unavailable
+                # — a genuinely soft condition the deep-backfill cushion carries, so
                 # warn without spamming the daily Telegram summary. Anything else
-                # (real bug, 404 misconfig) is a hard error worth surfacing.
+                # (real bug, 404 misconfig, no CSV in repo) is a hard error to surface.
                 soft = False
                 try:
                     from collectors.hf_drama_importer import HFDatasetUnavailableError

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -66,12 +66,17 @@ DRAMA_DESTINATION = "drama_youtube"  # khoá trong channels.py
 
 
 def build_narration(rewrite: dict) -> str:
-    """Ghép text TTS từ output rewriter: hook + script + vn_commentary.
+    """Ghép text TTS từ output rewriter: hook + script + vn_reactions + vn_commentary.
 
-    Prompt rewriter (prompts/drama/rewriter.v1.txt) trả hook/vn_commentary
-    thành FIELD RIÊNG nhưng script cũng có cấu trúc "Hook → ... → Reflection",
-    nên model có thể đã lặp hook/commentary bên trong script. Kiểm tra
-    containment trước khi ghép để không đọc trùng 2 lần.
+    Prompt rewriter (prompts/drama/rewriter.v1.txt) trả hook/vn_commentary/
+    vn_reactions thành FIELD RIÊNG nhưng script cũng có cấu trúc "Hook → ...
+    → Reflection", nên model có thể đã lặp các phần này bên trong script. Kiểm
+    tra containment trước khi ghép để không đọc trùng 2 lần.
+
+    `vn_reactions` (beat "cộng đồng phán xử" Việt hoá từ top comments Reddit —
+    issue #92 follow-up) đặt SAU script, TRƯỚC commentary: story → đám đông phán
+    xử → góc nhìn người kể + CTA. Optional: story không có comment thì field rỗng
+    và bị bỏ qua, nên narration của story cũ không đổi.
 
     Mỗi phần được gỡ artifact phi-giọng-đọc (delimiter/markdown lọt từ LLM)
     TRƯỚC khi ghép: narration này vừa là input TTS vừa được lưu làm
@@ -80,6 +85,7 @@ def build_narration(rewrite: dict) -> str:
     from video.text_preprocessor import strip_nonspeech_artifacts
     script = strip_nonspeech_artifacts((rewrite.get("script") or "").strip())
     hook = strip_nonspeech_artifacts((rewrite.get("hook") or "").strip())
+    reactions = strip_nonspeech_artifacts((rewrite.get("vn_reactions") or "").strip())
     commentary = strip_nonspeech_artifacts((rewrite.get("vn_commentary") or "").strip())
 
     parts = []
@@ -87,6 +93,8 @@ def build_narration(rewrite: dict) -> str:
         parts.append(hook)
     if script:
         parts.append(script)
+    if reactions and reactions not in script:
+        parts.append(reactions)
     if commentary and commentary not in script:
         parts.append(commentary)
     return "\n\n".join(parts)

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -124,7 +124,12 @@ def validate_rewrite(result: dict) -> list[str]:
     - `vn_commentary` >= 200 words
     - `hook` is a short punchy line, not a paragraph (structure heuristic)
     - no common Western name fragments / US-culture terms leaking through
+      (scanned across title/script/vn_commentary AND the optional vn_reactions)
     - `tags` is a non-empty list
+
+    `vn_reactions` (the localized community-reactions beat, issue #92 follow-up)
+    is OPTIONAL — only stories carrying comments have it — so its absence never
+    blocks; when present it's held to the same localization rules.
     """
     issues = []
     missing = [k for k in _REQUIRED_FIELDS if not result.get(k)]
@@ -151,7 +156,11 @@ def validate_rewrite(result: dict) -> list[str]:
             f"(need >= {_VN_COMMENTARY_MIN_WORDS})"
         )
 
-    combined = f"{result['title']} {script} {result['vn_commentary']}".lower()
+    # vn_reactions is OPTIONAL (only stories carrying comments have it), so it's
+    # not a required field — but when present it must obey the same localization
+    # rules (no Western names / US-culture terms / raw YTA-NTA verdicts leaking).
+    reactions = result.get("vn_reactions") or ""
+    combined = f"{result['title']} {script} {result['vn_commentary']} {reactions}".lower()
 
     for term in _FOREIGN_CULTURE_TERMS + _WESTERN_NAME_FRAGMENTS:
         if re.search(rf"\b{re.escape(term)}\b", combined):

--- a/content-pipeline/prompts/drama/rewriter.v1.txt
+++ b/content-pipeline/prompts/drama/rewriter.v1.txt
@@ -12,6 +12,7 @@ Quy tắc bắt buộc:
 7. KHÔNG dùng ngôn từ 18+, không nhắc tên người thật, không vu khống
 8. Đặt câu chuyện HOÀN TOÀN ở Việt Nam - KHÔNG nhắc tới đô la Mỹ, mall, prom, Thanksgiving, hay bất kỳ chi tiết văn hoá Mỹ nào khác
 9. Tên nhân vật phải THUẦN VIỆT (họ + tên đệm + tên, 2-3 từ, vd "Nguyễn Thị Mai") - KHÔNG đặt tên nửa Tây nửa Việt (vd "Linh Smith")
+10. PHẢN ỨNG CỘNG ĐỒNG: nếu STORY GỐC có mục "TOP COMMENTS FROM REDDIT" (bình luận cư dân mạng), hãy DỰA THEO TINH THẦN các bình luận đó viết field "vn_reactions" - 2-4 câu bình luận NGẮN, gay gắt hoặc hài hước, GIỌNG cư dân mạng Việt (vd "Trời ơi bên nhà trai quá đáng thật sự luôn", "Đọc mà tức thay cho chị"). Đây là beat "cộng đồng phán xử" đặt gần cuối trước Reflection để tăng độ hook và mời người xem vào bình luận. Việt hoá HOÀN TOÀN (KHÔNG giữ verdict tiếng Anh kiểu YTA/NTA/ESH), viết dạng VĂN XUÔI liền mạch để đọc TTS (KHÔNG gạch đầu dòng, KHÔNG emoji). Nếu STORY GỐC KHÔNG có mục bình luận thì để "vn_reactions" là chuỗi RỖNG "".
 
 STORY GỐC (tiếng Anh từ Reddit, hoặc seed VN-original):
 {{RAW_CONTENT}}
@@ -22,6 +23,7 @@ Trả lời CHỈ bằng JSON, không giải thích thêm:
   "hook": "<3 giây đầu>",
   "script": "<full script>",
   "vn_commentary": "<đoạn bình luận góc nhìn Việt, riêng, tối thiểu 200 từ>",
+  "vn_reactions": "<phản ứng cư dân mạng VN Việt hoá từ TOP COMMENTS; chuỗi rỗng nếu story gốc không có bình luận>",
   "thumbnail_prompt": "<mô tả ảnh AI cho thumbnail>",
   "tags": ["<tag1>", "<tag2>"]
 }

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -154,6 +154,23 @@ class TestValidateRewrite(unittest.TestCase):
         issues = drama_rewriter.validate_rewrite(result)
         self.assertTrue(any("tags" in i for i in issues))
 
+    def test_vn_reactions_optional_absence_ok(self):
+        # vn_reactions is optional (only comment-carrying stories have it); a
+        # perfectly good rewrite without it must still pass.
+        self.assertEqual(drama_rewriter.validate_rewrite(_good_rewrite()), [])
+
+    def test_vn_reactions_localization_enforced(self):
+        # When present, vn_reactions obeys the same localization rules.
+        result = _good_rewrite()
+        result["vn_reactions"] = "Đám đông phán YTA, đúng kiểu thanksgiving drama"
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("thanksgiving" in i for i in issues))
+
+    def test_clean_vn_reactions_passes(self):
+        result = _good_rewrite()
+        result["vn_reactions"] = "Cư dân mạng bình luận bên nhà trai quá đáng thật sự."
+        self.assertEqual(drama_rewriter.validate_rewrite(result), [])
+
     def test_vietnamese_word_not_falsely_flagged_as_western_name(self):
         # Sanity check: word-boundary regex shouldn't misfire on ordinary
         # Vietnamese text that happens to contain a substring like "john".

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -301,6 +301,86 @@ class TestImportDaily(_HFDBTest):
         self.assertEqual(ps.get_int(self._key()), 30)  # unchanged
 
 
+class TestQualityComments(_HFDBTest):
+    """Loading quality comments alongside the story body."""
+
+    def _import(self, rows, columns):
+        with patch.object(hf, "_fetch_rows", return_value=_page(rows, columns=columns)):
+            hf.import_dataset(dataset="owner/ds", limit=10)
+        return stories.get_pending(track="drama")
+
+    def test_parse_json_list_of_scored_dicts(self):
+        val = '[{"body": "you are NTA clearly", "score": 120}, {"body": "YTA", "score": 3}]'
+        got = hf._parse_comments(val)
+        self.assertEqual(got[0]["content"], "you are NTA clearly")
+        self.assertEqual(got[0]["score"], 120)
+
+    def test_parse_json_list_of_strings(self):
+        got = hf._parse_comments('["first reply", "second reply"]')
+        self.assertEqual([c["content"] for c in got], ["first reply", "second reply"])
+        self.assertIsNone(got[0]["score"])
+
+    def test_parse_plain_string_single_comment(self):
+        got = hf._parse_comments("just one top comment here")
+        self.assertEqual(got, [{"content": "just one top comment here", "score": None}])
+
+    def test_parse_empty_returns_nothing(self):
+        self.assertEqual(hf._parse_comments(""), [])
+        self.assertEqual(hf._parse_comments(None), [])
+
+    def test_select_filters_and_ranks(self):
+        comments = [
+            {"content": "short", "score": 999},                        # too short
+            {"content": "a solid high-scored community reaction here", "score": 80},
+            {"content": "a solid low-scored community reaction here", "score": 2},   # low score
+            {"content": "another strong well-upvoted reaction to this", "score": 150},
+        ]
+        with patch.object(hf.config, "HF_COMMENT_MIN_SCORE", 10), \
+             patch.object(hf.config, "HF_COMMENT_MIN_CHARS", 40), \
+             patch.object(hf.config, "HF_COMMENT_TOP_N", 3):
+            got = hf._select_quality_comments(comments)
+        # Best-score first, low-scored + short dropped.
+        self.assertEqual(got[0], "another strong well-upvoted reaction to this")
+        self.assertEqual(len(got), 2)
+
+    def test_comments_appended_to_raw_content_and_metadata(self):
+        rows = [{
+            "title": "AITA", "body": "the original story body text here", "id": "1",
+            "top_comments": '[{"body": "This is a strong NTA verdict from the crowd", "score": 200}]',
+        }]
+        pending = self._import(rows, columns=("title", "body", "id", "top_comments"))
+        self.assertEqual(len(pending), 1)
+        story = pending[0]
+        self.assertIn("TOP COMMENTS FROM REDDIT", story["raw_content"])
+        self.assertIn("strong NTA verdict", story["raw_content"])
+        # get_pending deserializes metadata to a dict.
+        self.assertEqual(len(story["metadata"]["top_comments"]), 1)
+
+    def test_no_comment_column_is_noop(self):
+        pending = self._import([{"title": "t", "body": "a body", "id": "1"}],
+                               columns=("title", "body", "id"))
+        self.assertNotIn("TOP COMMENTS", pending[0]["raw_content"])
+
+    def test_comments_do_not_change_source_id(self):
+        # Same row with and without comments must dedupe (source_id from body only).
+        base = {"title": "t", "body": "identical body", "id": "x"}
+        with_c = dict(base, top_comments='["a long enough community reaction text"]')
+        with patch.object(hf, "_fetch_rows",
+                          return_value=_page([base], columns=("title", "body", "id"))):
+            first = hf.import_dataset(dataset="owner/ds", limit=10)
+        with patch.object(hf, "_fetch_rows",
+                          return_value=_page([with_c], columns=("title", "body", "id", "top_comments"))):
+            second = hf.import_dataset(dataset="owner/ds", limit=10)
+        self.assertEqual((first, second), (1, 0))
+
+    def test_disabled_skips_comments(self):
+        rows = [{"title": "t", "body": "a body", "id": "1",
+                 "top_comments": '["a long enough community reaction text here"]'}]
+        with patch.object(hf.config, "HF_IMPORT_COMMENTS", False):
+            pending = self._import(rows, columns=("title", "body", "id", "top_comments"))
+        self.assertNotIn("TOP COMMENTS", pending[0]["raw_content"])
+
+
 def _write_csv(path, rows, columns=("title", "body", "id")):
     import csv as _csv
     with open(path, "w", newline="", encoding="utf-8") as f:

--- a/content-pipeline/tests/test_hf_drama_importer.py
+++ b/content-pipeline/tests/test_hf_drama_importer.py
@@ -153,6 +153,24 @@ class _FakeResp:
         return False
 
 
+class _ChunkResp:
+    """urlopen() stand-in that supports chunked read(n) for streaming downloads."""
+    def __init__(self, body: bytes):
+        self._buf = body
+        self._pos = 0
+    def read(self, n=-1):
+        if n is None or n < 0:
+            chunk, self._pos = self._buf[self._pos:], len(self._buf)
+            return chunk
+        chunk = self._buf[self._pos:self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
 class TestFetchRowsClassifiesFailures(unittest.TestCase):
     """_fetch_rows tells a soft 'viewer unavailable' apart from a hard error."""
 
@@ -271,14 +289,181 @@ class TestImportDaily(_HFDBTest):
         self.assertEqual(ps.get_int(self._key()), 20)  # unchanged
 
     def test_dataset_unavailable_propagates_and_keeps_cursor(self):
-        # Viewer down: even the size probe fails -> import_daily raises the soft
-        # error and the cursor stays put so tomorrow retries the same window.
+        # Viewer down AND the raw-CSV fallback also down (issue #92): import_daily
+        # raises the soft error and the cursor stays put so tomorrow retries.
         ps.set_int(self._key(), 30)
         with patch.object(hf, "_fetch_rows",
-                          side_effect=hf.HFDatasetUnavailableError("viewer down")):
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached",
+                          side_effect=hf.HFDatasetUnavailableError("hub down too")):
             with self.assertRaises(hf.HFDatasetUnavailableError):
                 hf.import_daily(dataset="owner/ds", limit=10)
         self.assertEqual(ps.get_int(self._key()), 30)  # unchanged
+
+
+def _write_csv(path, rows, columns=("title", "body", "id")):
+    import csv as _csv
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = _csv.DictWriter(f, fieldnames=list(columns))
+        w.writeheader()
+        for r in rows:
+            w.writerow({c: r.get(c, "") for c in columns})
+
+
+class TestCsvFallback(_HFDBTest):
+    """Raw-CSV fallback when datasets-server is unavailable (issue #92)."""
+
+    def _key(self, dataset="owner/ds", cfg="default", split="train"):
+        return f"hf_cursor:{dataset}:{cfg}:{split}"
+
+    def _csv_with(self, rows, columns=("title", "body", "id")):
+        path = os.path.join(self.tmp, "ds.csv")
+        _write_csv(path, rows, columns)
+        return path
+
+    def test_import_dataset_falls_back_to_csv_when_api_down(self):
+        rows = [
+            {"title": "A", "body": "body a", "id": "1"},
+            {"title": "B", "body": "body b", "id": "2"},
+        ]
+        csv_path = self._csv_with(rows)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            n = hf.import_dataset(dataset="owner/ds", limit=10)
+        self.assertEqual(n, 2)
+        titles = {p["title"] for p in stories.get_pending(track="drama")}
+        self.assertEqual(titles, {"A", "B"})
+
+    def test_import_daily_falls_back_and_advances_cursor(self):
+        rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(10)]
+        csv_path = self._csv_with(rows)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            n = hf.import_daily(dataset="owner/ds", limit=4)
+        self.assertEqual(n, 4)
+        # Cursor advanced by rows scanned from offset 0 (4), same as the API path.
+        self.assertEqual(ps.get_int(self._key()), 4)
+
+    def test_csv_cursor_resumes_from_offset(self):
+        rows = [{"title": f"t{i}", "body": f"body{i}", "id": str(i)} for i in range(10)]
+        csv_path = self._csv_with(rows)
+        ps.set_int(self._key(), 6)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            n = hf.import_daily(dataset="owner/ds", limit=10)
+        # Only rows 6..9 remain (4), and the cursor wraps at end (10 rows total).
+        self.assertEqual(n, 4)
+        self.assertEqual(ps.get_int(self._key()), 0)
+
+    def test_csv_scanned_counts_skipped_rows(self):
+        rows = [
+            {"title": "a", "body": "real one", "id": "1"},
+            {"title": "b", "body": "   ", "id": "2"},         # empty -> skipped
+            {"title": "c", "body": "[removed]", "id": "3"},   # removed -> skipped
+            {"title": "d", "body": "real two", "id": "4"},
+        ]
+        csv_path = self._csv_with(rows)
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            n = hf.import_daily(dataset="owner/ds", limit=2)
+        self.assertEqual(n, 2)
+        # Scanned 4 rows to import 2 -> cursor advances by scanned, wraps at end.
+        self.assertEqual(ps.get_int(self._key()), 0)
+
+    def test_source_id_consistent_between_api_and_csv(self):
+        # THE consistency guarantee: the same row imported via API then via CSV
+        # must dedupe (identical source_id), so an API<->CSV switch mid-dataset
+        # never double-imports.
+        row = {"title": "t", "body": "shared body", "id": "same"}
+        with patch.object(hf, "_fetch_rows", return_value=_page([row])):
+            first = hf.import_dataset(dataset="owner/ds", limit=10)
+        csv_path = self._csv_with([row])
+        with patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")), \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            second = hf.import_dataset(dataset="owner/ds", limit=10)
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)  # CSV path produced the same source_id
+
+    def test_force_csv_skips_api_entirely(self):
+        rows = [{"title": "A", "body": "body a", "id": "1"}]
+        csv_path = self._csv_with(rows)
+        with patch.object(hf, "_fetch_rows") as fetch, \
+             patch.object(hf, "_ensure_csv_cached", return_value=csv_path):
+            n = hf.import_dataset(dataset="owner/ds", limit=10, force_csv=True)
+        self.assertEqual(n, 1)
+        fetch.assert_not_called()  # API never touched
+
+    def test_fallback_disabled_propagates_soft_error(self):
+        with patch.object(hf.config, "HF_CSV_FALLBACK_ENABLED", False), \
+             patch.object(hf, "_fetch_rows",
+                          side_effect=hf.HFDatasetUnavailableError("viewer down")):
+            with self.assertRaises(hf.HFDatasetUnavailableError):
+                hf.import_dataset(dataset="owner/ds", limit=10)
+
+    def test_hard_error_not_masked_by_fallback(self):
+        # A plain HFImportError (e.g. 404 misconfig) is NOT a viewer-down signal,
+        # so the CSV fallback must not swallow it.
+        with patch.object(hf, "_fetch_rows", side_effect=hf.HFImportError("404")), \
+             patch.object(hf, "_ensure_csv_cached") as ens:
+            with self.assertRaises(hf.HFImportError):
+                hf.import_dataset(dataset="owner/ds", limit=10)
+        ens.assert_not_called()
+
+
+class TestCsvDiscoveryAndDownload(unittest.TestCase):
+    def test_resolve_csv_file_override_wins(self):
+        with patch.object(hf.config, "HF_DRAMA_CSV_FILE", "my_data.csv"):
+            self.assertEqual(hf._resolve_csv_file("owner/ds"), "my_data.csv")
+
+    def test_resolve_csv_file_discovers_via_hub(self):
+        meta = b'{"siblings":[{"rfilename":"README.md"},{"rfilename":"cleaned.csv"}]}'
+        with patch.object(hf.config, "HF_DRAMA_CSV_FILE", ""), \
+             patch.object(hf, "_hub_get", return_value=meta):
+            self.assertEqual(hf._resolve_csv_file("owner/ds"), "cleaned.csv")
+
+    def test_resolve_csv_file_no_csv_raises_hard_error(self):
+        meta = b'{"siblings":[{"rfilename":"README.md"}]}'
+        with patch.object(hf.config, "HF_DRAMA_CSV_FILE", ""), \
+             patch.object(hf, "_hub_get", return_value=meta):
+            with self.assertRaises(hf.HFImportError):
+                hf._resolve_csv_file("owner/ds")
+
+    def test_cache_path_no_traversal(self):
+        # A hostile repo path must not escape the cache dir.
+        p = hf._cache_path("owner/ds", "../../etc/passwd")
+        self.assertTrue(os.path.abspath(p).startswith(
+            os.path.abspath(hf.config.HF_CSV_CACHE_DIR)))
+        self.assertNotIn("..", os.path.basename(p))
+
+    def test_download_aborts_over_size_cap(self):
+        tmp = tempfile.mkdtemp()
+        dest = os.path.join(tmp, "out.csv")
+        resp = _ChunkResp(b"x" * (5 * 1024 * 1024))
+        with patch.object(hf.config, "HF_CSV_MAX_BYTES", 1024), \
+             patch.object(hf.config, "HF_CSV_CACHE_DIR", tmp), \
+             patch.object(hf, "urlopen", return_value=resp):
+            with self.assertRaises(hf.HFImportError):
+                hf._download_csv("owner/ds", "d.csv", dest)
+        # Partial file cleaned up; final file never created.
+        self.assertFalse(os.path.exists(dest))
+        self.assertFalse(os.path.exists(dest + ".part"))
+
+    def test_download_streams_and_renames_atomically(self):
+        tmp = tempfile.mkdtemp()
+        dest = os.path.join(tmp, "out.csv")
+        resp = _ChunkResp(b"title,body,id\nA,body a,1\n")
+        with patch.object(hf.config, "HF_CSV_MAX_BYTES", 10 * 1024 * 1024), \
+             patch.object(hf.config, "HF_CSV_CACHE_DIR", tmp), \
+             patch.object(hf, "urlopen", return_value=resp):
+            hf._download_csv("owner/ds", "d.csv", dest)
+        with open(dest, encoding="utf-8") as f:
+            self.assertIn("body a", f.read())
+        self.assertFalse(os.path.exists(dest + ".part"))
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -40,6 +40,28 @@ class TestBuildNarration(unittest.TestCase):
     def test_empty_rewrite(self):
         self.assertEqual(main_drama.build_narration({}), "")
 
+    def test_reactions_placed_between_script_and_commentary(self):
+        rewrite = {"hook": "Hook!", "script": "Câu chuyện chính.",
+                   "vn_reactions": "Cư dân mạng phán bên kia quá đáng thật.",
+                   "vn_commentary": "Góc nhìn của mình là..."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(
+            narration,
+            "Hook!\n\nCâu chuyện chính.\n\n"
+            "Cư dân mạng phán bên kia quá đáng thật.\n\nGóc nhìn của mình là...")
+
+    def test_missing_reactions_is_backward_compatible(self):
+        # Stories with no comments have no vn_reactions -> narration unchanged.
+        rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
+                   "vn_commentary": "Bình luận."}
+        self.assertEqual(main_drama.build_narration(rewrite),
+                         "Hook!\n\nCâu chuyện.\n\nBình luận.")
+
+    def test_empty_reactions_skipped(self):
+        rewrite = {"hook": "H", "script": "S", "vn_reactions": "",
+                   "vn_commentary": "C"}
+        self.assertEqual(main_drama.build_narration(rewrite), "H\n\nS\n\nC")
+
 
 class RenderBase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #92

## Vấn đề

`hf_drama_importer` chỉ đọc dataset AITA qua **datasets-server REST API** (`/rows`). Service này hay trả **HTTP 503 / trang "viewer building"** với dataset lớn — khi đó nguồn drama hàng ngày (dump AITA) **cạn hoàn toàn** dù bản thân dataset vẫn ổn: importer raise `HFDatasetUnavailableError` rồi soft-skip, không nạp được story nào.

## Root cause

datasets-server là **service riêng, hay chập chờn**. Nhưng Hub (`huggingface.co`) **vẫn sống** trong các đợt viewer sập, và CSV thô tải được qua **Git LFS** tại `/datasets/<ds>/resolve/main/<file>.csv`. Đây đúng là workaround thủ công issue mô tả — nay tự động hoá thành fallback.

## Thay đổi

### 1. Raw-CSV fallback (`collectors/hf_drama_importer.py`)
- Khi API báo `HFDatasetUnavailableError` → **tự tải CSV thô**, **cache 1 lần trên đĩa** (dump tĩnh, không cần tải lại), đọc rows từ đó.
- Tên CSV **auto-dò qua Hub API** (`/api/datasets/X`, vẫn sống khi viewer sập); override `HF_DRAMA_CSV_FILE`.
- **Consistency:** đường CSV DÙNG CHUNG `_resolve_columns` / `_import_row` / `_row_source_id` với đường API và đọc rows **cùng thứ tự file**, nên con trỏ `import_daily` và dedupe `source_id` **khớp y hệt** khi API↔CSV đổi giữa chừng.
- Chỉ khi **CẢ API lẫn CSV** đều sập, `import_daily` mới raise soft error; `main_drama` vẫn soft-skip.
- Cờ mới **`--csv`** ép đọc thẳng CSV (đúng workaround backfill thủ công), bỏ qua API.

### 2. Tải comment chất lượng (issue #92 follow-up)
Với AITA, phần **phán xét cộng đồng (YTA/NTA) + reply gắt** là comment-bait mạnh nhất — nên nếu dataset có cột comment thì nạp kèm thay vì bỏ:
- **Auto-dò** cột comment (`top_comments`/`comments`/…), override `HF_COMMENTS_FIELD`.
- Parse cả 3 dạng dump: JSON list dict có score / JSON list string / một comment string thuần.
- **Lọc + rank như Lemmy Q&A:** bỏ removed/ngắn/score thấp, tốt-nhất-trước, cap `HF_COMMENT_TOP_N` (`HF_COMMENT_MIN_SCORE` / `_MIN_CHARS`).
- Gắn vào cuối `raw_content` dưới nhãn `TOP COMMENTS FROM REDDIT` (để scorer/rewriter — đọc `raw_content[:4000]` — nhìn thấy) + lưu structured ở `metadata.top_comments`.
- Comment **không lọt vào `source_id`** (vẫn từ title+body) → một dòng dedupe y hệt dù có/không comment. Cùng `_import_row` nên API↔CSV nhất quán.

**Safety / Performance:** streaming + atomic rename, guard `HF_CSV_MAX_BYTES` chống fill đĩa, tên file cache **hash** (chống path traversal), **không tắt verify TLS**. Cache không tải lại cho dump tĩnh.

**Config mới:** `HF_CSV_FALLBACK_ENABLED`, `HF_DRAMA_CSV_FILE`, `HF_CSV_CACHE_DIR`, `HF_CSV_MAX_BYTES`, `HF_CSV_CACHE_TTL_DAYS`, `HF_IMPORT_COMMENTS`, `HF_COMMENTS_FIELD`, `HF_COMMENT_TOP_N`, `HF_COMMENT_MIN_SCORE`, `HF_COMMENT_MIN_CHARS`.

**Docs:** cập nhật CLAUDE.md; `.gitignore` bỏ qua `data/hf_csv_cache/`; sửa comment `main_drama`.

## Test

`python -m unittest tests.test_hf_drama_importer` — **48/48 pass**, phủ:
- CSV fallback: source_id consistency API↔CSV, cursor resume/wrap, download cap + atomic rename, cache-path không traversal, `--csv`, fallback disabled
- Comments: parse 3 dạng dump, lọc/rank chất lượng, gắn vào raw_content + metadata, source_id không đổi khi có comment, no-op khi tắt/không có cột

`tests.test_main_drama` pass (16/16). *(`tests.test_drama_scorer` fail do thiếu package `anthropic` trong sandbox — không liên quan.)* Verify end-to-end qua đường CSV: comment ngắn/score thấp bị loại, rank theo score, gắn đúng vào `raw_content` + `metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)