### PR TITLE
feat(#94 follow-up): monitor Pexels & Replicate media API keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,6 +576,21 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   chung file token** (`unconfigured`, chưa có token riêng) và token **thiếu
   scope** `youtube.force-ssl` (refresh OK nhưng uploader loại bỏ → kích OAuth
   giữa lúc upload) — cả hai đều alert trước giờ upload (review PR #95).
+- **`video/asset_key_health.py` — giám sát API key asset (follow-up #94).**
+  Cùng tinh thần `token_health` nhưng cho **API key TĨNH** của nhà cung cấp asset
+  (không phải OAuth refresh): **Pexels** (`PEXELS_API_KEY`, nền b-roll cả 2 track)
+  và **Replicate** (`REPLICATE_API_TOKEN`, minh hoạ AI track Drama). Gọi 1 request
+  xác thực nhẹ bằng stdlib `urllib` + socket timeout (`ASSET_KEY_HEALTH_TIMEOUT`
+  =15s): 200 = `ok`, 401/403 = `invalid` (alert), 5xx/429/timeout = `transient`
+  (đếm bền vững `pipeline_state`, chỉ alert khi lặp `ASSET_KEY_HEALTH_TRANSIENT_
+  ALERT_AFTER`=3). **Bất đối xứng theo thiết kế:** Pexels rỗng = `missing` →
+  **alert** (nền hỏng thì mọi video mới dùng lại nền cache CŨ — hỏng IM LẶNG,
+  không crash); Replicate rỗng = `disabled` → **KHÔNG alert** (tuỳ chọn, composer
+  fallback gradient). KHÔNG log giá trị key. Chạy độc lập `python -m
+  video.asset_key_health` (08:10, `launchd/com.ai5phut.asset-key-health.plist`)
+  VÀ ké best-effort trong `main.run_pipeline`. **Cấp/cập nhật key:** Pexels miễn
+  phí tại https://www.pexels.com/api/, Replicate tại
+  https://replicate.com/account/api-tokens — đặt vào `.env`.
 
 ---
 

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -186,6 +186,17 @@ TOKEN_HEALTH_TRANSIENT_ALERT_AFTER = int(
     os.getenv("TOKEN_HEALTH_TRANSIENT_ALERT_AFTER", "3")
 )
 
+# --- Media asset API key health check (follow-up #94) ---
+# Giám sát API key TĨNH của nhà cung cấp asset video: Pexels (nền b-roll, dùng
+# cả 2 track) và Replicate (minh hoạ AI, chỉ track Drama). Khác token YouTube:
+# đây là key bearer tĩnh (không refresh), nên video/asset_key_health.py chỉ gọi
+# 1 request xác thực nhẹ (200 = ok, 401/403 = key hỏng) — cùng tinh thần
+# fail-fast + phân biệt lỗi cứng/tạm thời của token_health.
+ASSET_KEY_HEALTH_TIMEOUT = int(os.getenv("ASSET_KEY_HEALTH_TIMEOUT", "15"))
+ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER = int(
+    os.getenv("ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER", "3")
+)
+
 # --- Video engine flags (Video Enhancement roadmap; default = legacy behaviour) ---
 # Each flag has a "legacy" default so the pipeline behaves exactly as before
 # unless explicitly opted in. See docs/current/video-enhancement/.

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -65,6 +65,7 @@ Quy ước: **tên file plist == Label bên trong** — cả `install.sh` lẫn
 | `com.ai5phut.reddit-drama` | 06:06 sáng — Reddit drama collector (Phase 2) |
 | `com.ai5phut.drama-health` | 06:30 + 18:30 — alert collector im lặng >2 ngày |
 | `com.ai5phut.token-health` | 08:00 sáng — kiểm tra OAuth token mọi kênh YouTube, alert nếu thu hồi/hết hạn (issue #94) |
+| `com.ai5phut.asset-key-health` | 08:10 sáng — kiểm tra API key Pexels/Replicate, alert nếu hỏng/thiếu (follow-up #94) |
 | `com.ai5phut.drama-pipeline` | 06:40 sáng — Drama orchestrator end-to-end (Phase 5) |
 | `com.ai5phut.post-scheduler` | tick 5 phút — upload video đã duyệt theo cadence (Phase 5) |
 | `com.ai5phut.metrics-pull` | 23:00 đêm — YouTube Analytics (Phase 6) |

--- a/content-pipeline/launchd/com.ai5phut.asset-key-health.plist
+++ b/content-pipeline/launchd/com.ai5phut.asset-key-health.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ai5phut.asset-key-health</string>
+
+    <!-- Root cause #74/#75: plist KHÔNG khai báo WorkingDirectory/StandardOutPath/
+         StandardErrorPath (launchd giữ handle inode stale sau rebuild venv/re-clone
+         → EX_CONFIG). run_module.sh thiết lập cwd + log ở runtime (LOG_BASENAME).
+         Replace /Users/YOU with your actual home directory path. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/YOU/ContentCreator/content-pipeline/run_module.sh</string>
+        <string>-m</string>
+        <string>video.asset_key_health</string>
+    </array>
+
+    <!-- Follow-up #94: kiểm tra API key Pexels/Replicate mỗi sáng 08:10 (sau
+         token-health 08:00) và alert Telegram nếu key hỏng/thiếu. Module tự bound
+         thời gian bằng socket timeout nên không cần timeout cứng. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>8</integer>
+        <key>Minute</key>
+        <integer>10</integer>
+    </dict>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>LOG_BASENAME</key>
+        <string>asset_key_health</string>
+    </dict>
+</dict>
+</plist>

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -147,6 +147,15 @@ def run_pipeline(force_video: str | None = None):
     except Exception as e:
         logger.warning("Token health check failed (non-fatal): %s", e)
 
+    # Watchdog follow-up #94: kiểm tra API key asset (Pexels/Replicate) — key
+    # Pexels hỏng làm mọi video mới dùng lại nền cache CŨ mà không crash, tụt chất
+    # lượng âm thầm. Ké trong pipeline (track AI dùng Pexels) + cron riêng 08:10.
+    try:
+        from video.asset_key_health import check_and_alert as _asset_key_check
+        _asset_key_check()
+    except Exception as e:
+        logger.warning("Asset key health check failed (non-fatal): %s", e)
+
     # --- Phase 0: Ensure assets exist ---
     logger.info("--- Phase 0: Assets ---")
     if not download_backgrounds():

--- a/content-pipeline/tests/test_asset_key_health.py
+++ b/content-pipeline/tests/test_asset_key_health.py
@@ -1,0 +1,199 @@
+"""Tests for video/asset_key_health.py (follow-up #94 — media API key monitoring)."""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import video.asset_key_health as ah
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("https://api.example.com/x", code, "err", {},
+                                  io.BytesIO(b""))
+
+
+def _ok_urlopen():
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = b"{"
+    return MagicMock(return_value=cm)
+
+
+class TestProbe(unittest.TestCase):
+    def test_200_is_ok(self):
+        with patch.object(ah.urllib.request, "urlopen", _ok_urlopen()):
+            code, _ = ah._probe("https://x", {"Authorization": "k"}, 5)
+        self.assertEqual(code, ah.OK)
+
+    def test_401_is_invalid(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(401))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.INVALID)
+
+    def test_403_is_invalid(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(403))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.INVALID)
+
+    def test_500_is_transient(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(503))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.TRANSIENT)
+
+    def test_429_is_transient(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(429))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.TRANSIENT)
+
+    def test_timeout_is_transient(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=TimeoutError("t"))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.TRANSIENT)
+
+    def test_urlerror_is_transient(self):
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=urllib.error.URLError("dns"))):
+            code, _ = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.TRANSIENT)
+
+
+class TestCheckPexels(unittest.TestCase):
+    def test_missing_key(self):
+        with patch.object(ah.config, "PEXELS_API_KEY", ""):
+            res = ah.check_pexels()
+        self.assertEqual(res.code, ah.MISSING)
+
+    def test_ok_and_uses_raw_auth_header(self):
+        opener = _ok_urlopen()
+        with patch.object(ah.config, "PEXELS_API_KEY", "pk_live"), \
+             patch.object(ah.urllib.request, "urlopen", opener):
+            res = ah.check_pexels()
+        self.assertEqual(res.code, ah.OK)
+        req = opener.call_args[0][0]
+        # Pexels uses the raw key (NOT "Bearer ...")
+        self.assertEqual(req.headers["Authorization"], "pk_live")
+
+    def test_invalid_key(self):
+        with patch.object(ah.config, "PEXELS_API_KEY", "bad"), \
+             patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(401))):
+            res = ah.check_pexels()
+        self.assertEqual(res.code, ah.INVALID)
+
+
+class TestCheckReplicate(unittest.TestCase):
+    def test_empty_token_is_disabled(self):
+        with patch.object(ah.config, "REPLICATE_API_TOKEN", ""):
+            res = ah.check_replicate()
+        self.assertEqual(res.code, ah.DISABLED)
+        self.assertTrue(res.healthy)  # optional feature off is not a failure
+
+    def test_ok_and_uses_bearer_header(self):
+        opener = _ok_urlopen()
+        with patch.object(ah.config, "REPLICATE_API_TOKEN", "r8_tok"), \
+             patch.object(ah.urllib.request, "urlopen", opener):
+            res = ah.check_replicate()
+        self.assertEqual(res.code, ah.OK)
+        req = opener.call_args[0][0]
+        self.assertEqual(req.headers["Authorization"], "Bearer r8_tok")
+
+    def test_invalid_token(self):
+        with patch.object(ah.config, "REPLICATE_API_TOKEN", "r8_bad"), \
+             patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(401))):
+            res = ah.check_replicate()
+        self.assertEqual(res.code, ah.INVALID)
+
+
+class TestCheckAll(unittest.TestCase):
+    def test_default_checks_both_providers(self):
+        with patch.object(ah, "check_pexels",
+                          return_value=ah.KeyCheckResult("pexels", ah.OK)), \
+             patch.object(ah, "check_replicate",
+                          return_value=ah.KeyCheckResult("replicate", ah.DISABLED)):
+            results = ah.check_all()
+        self.assertEqual({r.provider for r in results}, {"pexels", "replicate"})
+
+
+class _AlertBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+
+    def tearDown(self):
+        self._patch.stop()
+
+    def _res(self, provider, code):
+        return ah.KeyCheckResult(provider, code, "detail")
+
+
+class TestCheckAndAlert(_AlertBase):
+    def test_pexels_invalid_alerts_with_link(self):
+        with patch.object(ah, "check_all", return_value=[self._res("pexels", ah.INVALID)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_called_once()
+        self.assertIn("pexels.com/api", alert.call_args[0][0])
+
+    def test_pexels_missing_alerts(self):
+        with patch.object(ah, "check_all", return_value=[self._res("pexels", ah.MISSING)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_called_once()
+
+    def test_replicate_disabled_no_alert(self):
+        with patch.object(ah, "check_all", return_value=[self._res("replicate", ah.DISABLED)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_not_called()
+
+    def test_replicate_invalid_alerts_with_link(self):
+        with patch.object(ah, "check_all", return_value=[self._res("replicate", ah.INVALID)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_called_once()
+        self.assertIn("replicate.com/account", alert.call_args[0][0])
+
+    def test_ok_resets_transient_counter(self):
+        ah._set_transient_count("pexels", 2)
+        with patch.object(ah, "check_all", return_value=[self._res("pexels", ah.OK)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_not_called()
+        self.assertEqual(ah._get_transient_count("pexels"), 0)
+
+    def test_transient_alerts_once_at_threshold(self):
+        with patch.object(ah.config, "ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER", 2), \
+             patch.object(ah, "check_all", return_value=[self._res("pexels", ah.TRANSIENT)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()  # 1
+            ah.check_and_alert()  # 2 == threshold → alert
+            ah.check_and_alert()  # 3 no repeat
+        alert.assert_called_once()
+
+    def test_alert_send_failure_swallowed(self):
+        with patch.object(ah, "check_all", return_value=[self._res("pexels", ah.INVALID)]), \
+             patch("notifier.telegram_bot.send_alert", side_effect=RuntimeError("net")):
+            results = ah.check_and_alert()
+        self.assertEqual(results[0].code, ah.INVALID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/video/asset_key_health.py
+++ b/content-pipeline/video/asset_key_health.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+"""
+Media asset API key health — follow-up cho issue #94 (giám sát credential).
+
+token_health.py lo OAuth token của kênh YouTube; module này lo các **API key
+TĨNH** của nhà cung cấp asset video mà pipeline phụ thuộc:
+
+- **Pexels** (`PEXELS_API_KEY`) — nguồn b-roll nền cho CẢ hai track. Key hỏng/
+  hết hạn không làm crash (pexels_downloader fallback về clip cache) nhưng **âm
+  thầm** khiến mọi video mới dùng lại nền cũ → chất lượng tụt mà không ai biết
+  (đúng loại "hỏng im lặng" mà #94 muốn chặn).
+- **Replicate** (`REPLICATE_API_TOKEN`) — minh hoạ AI cho track Drama. TUỲ CHỌN:
+  không cấu hình thì composer fallback gradient (image_generator trả None), nên
+  key RỖNG = tính năng tắt hợp lệ → KHÔNG alert; chỉ khi đã đặt key mà key hỏng
+  mới đáng báo.
+
+Khác token YouTube (OAuth refresh) — đây là bearer key tĩnh, nên chỉ cần gọi 1
+request xác thực nhẹ (200 = sống, 401/403 = key hỏng). Vẫn giữ đúng tinh thần
+token_health: stdlib urllib + socket timeout fail-fast, phân biệt lỗi ĐỊNH DANH
+(key hỏng/thiếu) với TẠM THỜI (timeout/5xx/429 — đếm bền vững, chỉ alert khi lặp
+để "monitor không tới được provider" cũng lộ ra), best-effort không raise, KHÔNG
+log giá trị key.
+
+Chạy độc lập:  python -m video.asset_key_health
+launchd:       launchd/com.ai5phut.asset-key-health.plist (08:10 hằng ngày)
+Defense-in-depth: main.run_pipeline gọi best-effort (track AI dùng Pexels).
+"""
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+
+logger = logging.getLogger(__name__)
+
+# Endpoint xác thực nhẹ nhất của mỗi provider (giữ đồng bộ với module gọi thật:
+# video/pexels_downloader.py và video/image_generator.py).
+_PEXELS_PROBE_URL = "https://api.pexels.com/videos/search?query=nature&per_page=1"
+_REPLICATE_ACCOUNT_URL = "https://api.replicate.com/v1/account"
+
+# Mã trạng thái.
+OK = "ok"
+INVALID = "invalid"        # 401/403 — key sai/hết hạn/thu hồi
+MISSING = "missing"        # key bắt buộc nhưng chưa cấu hình
+DISABLED = "disabled"      # key tuỳ chọn chưa cấu hình → tính năng tắt (không alert)
+TRANSIENT = "transient"    # timeout/mạng/5xx/429 — thử lại lần sau
+
+
+class KeyCheckResult:
+    """Kết quả kiểm tra 1 API key."""
+
+    __slots__ = ("provider", "code", "detail")
+
+    def __init__(self, provider, code, detail=""):
+        self.provider = provider
+        self.code = code
+        self.detail = detail
+
+    @property
+    def healthy(self) -> bool:
+        return self.code in (OK, DISABLED)
+
+    def __repr__(self) -> str:
+        return (f"KeyCheckResult({self.provider}, {self.code}"
+                + (f", {self.detail!r}" if self.detail else "") + ")")
+
+
+def _probe(url: str, headers: dict, timeout: int) -> tuple[str, str]:
+    """GET `url` với header xác thực → (code, detail). Chỉ stdlib, HTTPS verify.
+
+    KHÔNG bao giờ đưa giá trị key vào detail (headers chỉ dùng để gửi).
+    """
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            resp.read(1)
+        return OK, ""
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            return INVALID, f"HTTP {e.code} — key bị từ chối"
+        if e.code == 429 or e.code >= 500:
+            return TRANSIENT, f"HTTP {e.code}"
+        # 4xx khác (400 query...) coi như tạm thời/không kết luận key hỏng.
+        return TRANSIENT, f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return TRANSIENT, f"không kết nối được: {e}"
+
+
+def check_pexels(timeout: int | None = None) -> KeyCheckResult:
+    """Kiểm tra `PEXELS_API_KEY`. Key rỗng = MISSING (Pexels là nguồn nền chính)."""
+    timeout = config.ASSET_KEY_HEALTH_TIMEOUT if timeout is None else timeout
+    key = getattr(config, "PEXELS_API_KEY", "") or ""
+    if not key:
+        return KeyCheckResult("pexels", MISSING,
+                              "PEXELS_API_KEY chưa cấu hình — video dùng nền cache cũ")
+    # Pexels dùng raw key trong header Authorization (không phải Bearer).
+    code, detail = _probe(_PEXELS_PROBE_URL, {"Authorization": key}, timeout)
+    return KeyCheckResult("pexels", code, detail)
+
+
+def check_replicate(timeout: int | None = None) -> KeyCheckResult:
+    """Kiểm tra `REPLICATE_API_TOKEN`. Key rỗng = DISABLED (tuỳ chọn — không alert)."""
+    timeout = config.ASSET_KEY_HEALTH_TIMEOUT if timeout is None else timeout
+    token = getattr(config, "REPLICATE_API_TOKEN", "") or ""
+    if not token:
+        return KeyCheckResult("replicate", DISABLED,
+                              "REPLICATE_API_TOKEN chưa đặt — minh hoạ AI tắt (composer fallback gradient)")
+    code, detail = _probe(_REPLICATE_ACCOUNT_URL,
+                          {"Authorization": f"Bearer {token}"}, timeout)
+    return KeyCheckResult("replicate", code, detail)
+
+
+_CHECKS = {"pexels": check_pexels, "replicate": check_replicate}
+
+
+def check_all(providers: list[str] | None = None,
+              timeout: int | None = None) -> list[KeyCheckResult]:
+    """Kiểm tra các provider (mặc định: tất cả)."""
+    names = providers if providers is not None else list(_CHECKS.keys())
+    return [_CHECKS[name](timeout=timeout) for name in names if name in _CHECKS]
+
+
+_STATE_PREFIX = "asset_key_transient:"
+
+
+def _get_transient_count(provider: str) -> int:
+    """Bộ đếm transient bền vững; DB chưa migrate 008 → 0 (degrade gracefully)."""
+    try:
+        from storage.pipeline_state import get_int
+        return get_int(_STATE_PREFIX + provider, 0)
+    except Exception as e:
+        logger.warning("Không đọc được transient counter (%s): %s", provider, e)
+        return 0
+
+
+def _set_transient_count(provider: str, value: int) -> None:
+    try:
+        from storage.pipeline_state import set_int
+        set_int(_STATE_PREFIX + provider, value)
+    except Exception as e:
+        logger.warning("Không ghi được transient counter (%s): %s", provider, e)
+
+
+def _alert_message(res: KeyCheckResult) -> str | None:
+    """Tin nhắn Telegram cho 1 kết quả (None = không alert)."""
+    if res.provider == "pexels":
+        if res.code == INVALID:
+            return ("🔴 PEXELS_API_KEY bị từ chối "
+                    f"({res.detail}) — video mới sẽ dùng lại nền cache cũ. "
+                    "Cấp key mới tại https://www.pexels.com/api/ rồi cập nhật .env.")
+        if res.code == MISSING:
+            return ("🟡 PEXELS_API_KEY chưa cấu hình — video dùng nền cache cũ, "
+                    "chất lượng nền giảm. Lấy key miễn phí tại "
+                    "https://www.pexels.com/api/ và đặt vào .env.")
+    if res.provider == "replicate" and res.code == INVALID:
+        return ("🔴 REPLICATE_API_TOKEN bị từ chối "
+                f"({res.detail}) — minh hoạ AI (Drama) sẽ fallback gradient. "
+                "Lấy token tại https://replicate.com/account/api-tokens rồi cập nhật .env.")
+    return None
+
+
+def check_and_alert(providers: list[str] | None = None,
+                    timeout: int | None = None) -> list[KeyCheckResult]:
+    """Kiểm tra + alert Telegram cho key hỏng/thiếu. Trả toàn bộ kết quả.
+
+    - INVALID/MISSING → alert ngay mỗi lần chạy (nhắc tới khi sửa).
+    - TRANSIENT → tăng bộ đếm; chỉ alert khi CHẠM ngưỡng
+      ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER (một lần) để "monitor không tới được
+      provider" cũng lộ ra, không spam khi provider chập chờn.
+    - OK / DISABLED → reset bộ đếm, không alert.
+
+    Best-effort: lỗi gửi Telegram được nuốt, không raise (như token_health).
+    """
+    results = check_all(providers, timeout=timeout)
+    threshold = config.ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER
+
+    def _send(text: str) -> None:
+        try:
+            from notifier.telegram_bot import send_alert
+            send_alert(text)
+        except Exception as e:
+            logger.warning("Asset-key alert send failed (non-fatal): %s", e)
+
+    for res in results:
+        if res.code in (OK, DISABLED):
+            logger.info("Asset key %s: %s", res.provider, res.code)
+            _set_transient_count(res.provider, 0)
+            continue
+
+        if res.code == TRANSIENT:
+            count = _get_transient_count(res.provider) + 1
+            _set_transient_count(res.provider, count)
+            logger.warning("Asset key %s transient lần %d: %s",
+                           res.provider, count, res.detail)
+            if threshold > 0 and count == threshold:
+                _send(f"⚠️ Không kiểm tra được API key {res.provider} {count} lần "
+                      f"liên tiếp — mạng/endpoint provider có vấn đề, hoặc cron "
+                      f"asset-key-health lỗi. ({res.detail})")
+            continue
+
+        # INVALID / MISSING → reset transient + alert.
+        _set_transient_count(res.provider, 0)
+        logger.warning("Asset key %s %s: %s", res.provider, res.code, res.detail)
+        msg = _alert_message(res)
+        if msg:
+            _send(msg)
+
+    return results
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    results = check_and_alert()
+    print(f"Checked {len(results)} media asset API key(s).")
+    for r in results:
+        mark = "✅" if r.healthy else "❌"
+        line = f"  {mark} {r.provider}: {r.code}"
+        if r.detail:
+            line += f" — {r.detail}"
+        print(line)


### PR DESCRIPTION
Follow-up của #94 (PR #95 đã lo OAuth token YouTube). PR này bổ sung giám sát các **API key TĨNH** của nhà cung cấp asset video mà `token_health.py` không phủ.

## Vì sao cần

- **Pexels** (`PEXELS_API_KEY`) — nền b-roll cho **cả 2 track**. Key hỏng **không crash** (pexels_downloader fallback về clip cache), nên mọi video mới **âm thầm dùng lại nền cũ** → chất lượng tụt mà không ai biết. Đúng loại "hỏng im lặng" mà #94 muốn chặn.
- **Replicate** (`REPLICATE_API_TOKEN`) — minh hoạ AI track Drama. **Tuỳ chọn** (composer fallback gradient khi chưa đặt).

## Cách làm

`video/asset_key_health.py` — cùng khuôn với `token_health`: gọi 1 request xác thực nhẹ bằng stdlib `urllib` + socket timeout giới hạn (`ASSET_KEY_HEALTH_TIMEOUT`=15s, fail-fast).

- Phân loại: `200 → ok`, `401/403 → invalid` (alert), `5xx/429/timeout → transient` (đếm bền vững `pipeline_state`, chỉ alert khi lặp `ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER`=3 → "provider outage / monitor chết" cũng lộ ra).
- **Bất đối xứng có chủ đích, khớp cách pipeline đối xử từng key:**
  - Pexels rỗng → `missing` → **alert** (nền tụt về cache-only).
  - Replicate rỗng → `disabled` → **không alert** (trạng thái "tắt tính năng" hợp lệ); chỉ token đã-đặt-nhưng-bị-từ-chối mới alert.
- Header đúng từng provider: Pexels dùng **raw key** trong `Authorization`, Replicate dùng **`Bearer`**.
- **Bảo mật:** không log giá trị key; HTTPS verify mặc định. Best-effort, không raise.

## Wiring

- `launchd/com.ai5phut.asset-key-health.plist` — chạy **08:10** hằng ngày (sau token-health 08:00), qua `run_module.sh`.
- `main.run_pipeline` — gọi best-effort làm defense-in-depth (track AI dùng Pexels).

## Tài liệu & test

- `CLAUDE.md` + `launchd/README.md` — mô tả module + **nơi lấy/cập nhật key**: Pexels https://www.pexels.com/api/ , Replicate https://replicate.com/account/api-tokens (đặt vào `.env`).
- `tests/test_asset_key_health.py` — 21 test: phân loại probe, header từng provider, missing vs disabled, và logic alert/counter. Tất cả pass, không đụng mạng.

## Trả lời câu hỏi về REPLICATE_API_TOKEN

Lấy tại **https://replicate.com/account/api-tokens** (đăng nhập → Account → API tokens), token dạng `r8_...`. Cập nhật bằng cách sửa dòng `REPLICATE_API_TOKEN=r8_...` trong `content-pipeline/.env` rồi chạy lại pipeline. Đây là key **tuỳ chọn** — bỏ trống thì minh hoạ AI tắt, composer tự fallback nền gradient (không lỗi). Cần đặt kèm `REPLICATE_MODEL_VERSION` (hash model trên replicate.com) mới sinh được ảnh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K16RpqaAzCwHxo2NRVnkQ