### PR TITLE
Fix #97: gửi User-Agent cho Pexels/Replicate + phân biệt Cloudflare block với key sai

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -141,12 +141,23 @@ jobs:
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -n "$EXISTING_PR" ]; then
-            echo "PR #$EXISTING_PR already exists, updating body to link issue..."
-            gh pr edit "$EXISTING_PR" \
-              --body "AI generated implementation
-
-          Closes #${ISSUE_NUMBER}"
-            echo "✅ Updated PR #$EXISTING_PR with Closes #${ISSUE_NUMBER}"
+            # PR đã có: KHÔNG ghi đè body (giữ mô tả đã viết kỹ) — chỉ đảm bảo
+            # có dòng "Closes #N"; thiếu thì APPEND vào cuối. Lưu ý: dùng
+            # `gh pr view --json body` (query hẹp) thay vì để `gh pr edit`
+            # tự fetch — query rộng của nó đòi scope read:org mà PAT không có.
+            BODY=$(gh pr view "$EXISTING_PR" --json body --jq .body)
+            if printf '%s' "$BODY" | grep -q "Closes #${ISSUE_NUMBER}"; then
+              echo "✅ PR #$EXISTING_PR already links issue #${ISSUE_NUMBER} — body left untouched"
+            else
+              # Best-effort: link issue là cosmetic, không đáng fail cả job
+              # (gh pr edit có thể vẫn vướng scope read:org của PAT).
+              if gh pr edit "$EXISTING_PR" \
+                --body "$(printf '%s\n\nCloses #%s' "$BODY" "$ISSUE_NUMBER")"; then
+                echo "✅ Appended Closes #${ISSUE_NUMBER} to PR #$EXISTING_PR"
+              else
+                echo "⚠️ Could not edit PR body (token scope?) — non-fatal, link issue thủ công"
+              fi
+            fi
           else
             echo "Creating new PR..."
             NEW_PR=$(gh pr create \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,6 +591,19 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   VÀ ké best-effort trong `main.run_pipeline`. **Cấp/cập nhật key:** Pexels miễn
   phí tại https://www.pexels.com/api/, Replicate tại
   https://replicate.com/account/api-tokens — đặt vào `.env`.
+- **User-Agent bắt buộc cho mọi request urllib tới API sau CDN/WAF (issue #97).**
+  Root cause #97: urllib mặc định gửi UA `Python-urllib/3.x` → **Cloudflare chặn
+  với 403 body `error code: 1010`** dù key hoàn toàn đúng — Pexels/Replicate "chết"
+  từ 01/07 mà log lại đổ oan cho key. Fix: `config.HTTP_USER_AGENT` (env-overridable,
+  mặc định `Mozilla/5.0 (compatible; ContentPipelineBot/1.0)`) được gắn vào MỌI
+  request của `pexels_downloader` / `image_generator` / `asset_key_health`. Đồng
+  thời **phân biệt WAF-block với key sai** bằng cách đọc body lỗi (`error code:
+  10xx`): `asset_key_health` trả trạng thái `blocked` riêng (alert nói rõ "key
+  KHÔNG sai, đừng thay key — kiểm tra HTTP_USER_AGENT/IP"), còn
+  `pexels_downloader` set sentinel `_last_pexels_error='blocked'` (vẫn dừng vòng
+  query như `'auth'` — nã tiếp WAF chỉ phí request — nhưng log đúng nguyên nhân).
+  Module mới gọi API ngoài qua urllib: LUÔN gửi `config.HTTP_USER_AGENT` (trừ
+  Reddit/Lemmy đã có UA riêng theo quy định API của họ).
 
 ---
 

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -7,6 +7,12 @@ TELEGRAM_TIKTOK_CHAT_ID=
 TWITTER_BEARER_TOKEN=...
 PRODUCTHUNT_API_TOKEN=...
 
+# --- HTTP User-Agent dùng chung (issue #97) ---
+# Cloudflare chặn UA mặc định "Python-urllib/3.x" (error code 1010) → Pexels/
+# Replicate trả 403 dù key đúng. Mặc định trong code đã pass Cloudflare; chỉ
+# override nếu vẫn bị chặn.
+# HTTP_USER_AGENT=Mozilla/5.0 (compatible; ContentPipelineBot/1.0)
+
 # --- Reddit API (issue #78) ---
 # Reddit blocks unauthenticated www.reddit.com/*.json + .rss (403/429) and — as
 # of Nov 2025 — KILLED self-service API app creation (Responsible Builder

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -14,6 +14,16 @@ TELEGRAM_TIKTOK_CHAT_ID = os.getenv("TELEGRAM_TIKTOK_CHAT_ID", "")
 TWITTER_BEARER_TOKEN = os.getenv("TWITTER_BEARER_TOKEN", "")
 PRODUCTHUNT_API_TOKEN = os.getenv("PRODUCTHUNT_API_TOKEN", "")
 
+# --- HTTP User-Agent dùng chung (issue #97) ---
+# Cloudflare chặn User-Agent mặc định "Python-urllib/3.x" của urllib (error
+# code 1010) → Pexels/Replicate trả 403 dù key hoàn toàn đúng. MỌI request
+# urllib tới các API sau CDN/WAF phải gửi UA này thay vì để urllib tự điền.
+# (Reddit/Lemmy có UA riêng theo quy định API của họ — REDDIT_USER_AGENT/
+# LEMMY_USER_AGENT bên dưới, không dùng chung cái này.)
+HTTP_USER_AGENT = os.getenv(
+    "HTTP_USER_AGENT", "Mozilla/5.0 (compatible; ContentPipelineBot/1.0)"
+)
+
 # --- Reddit API (issue #78) ---
 # Root cause of #78: unauthenticated requests to www.reddit.com/*.json and
 # .rss are aggressively rate-limited (429) and blocked (403), especially from

--- a/content-pipeline/tests/test_asset_key_health.py
+++ b/content-pipeline/tests/test_asset_key_health.py
@@ -16,9 +16,9 @@ import storage.migrate as migrate
 import video.asset_key_health as ah
 
 
-def _http_error(code: int) -> urllib.error.HTTPError:
+def _http_error(code: int, body: bytes = b"") -> urllib.error.HTTPError:
     return urllib.error.HTTPError("https://api.example.com/x", code, "err", {},
-                                  io.BytesIO(b""))
+                                  io.BytesIO(body))
 
 
 def _ok_urlopen():
@@ -44,6 +44,30 @@ class TestProbe(unittest.TestCase):
                           MagicMock(side_effect=_http_error(403))):
             code, _ = ah._probe("https://x", {}, 5)
         self.assertEqual(code, ah.INVALID)
+
+    def test_sends_user_agent(self):
+        # urllib's default "Python-urllib/3.x" UA gets a Cloudflare 403 that
+        # looks like a bad key (issue #97) — every probe must send the shared UA.
+        opener = _ok_urlopen()
+        with patch.object(ah.urllib.request, "urlopen", opener):
+            ah._probe("https://x", {"Authorization": "k"}, 5)
+        req = opener.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"), ah.config.HTTP_USER_AGENT)
+
+    def test_caller_headers_survive_ua_merge(self):
+        opener = _ok_urlopen()
+        with patch.object(ah.urllib.request, "urlopen", opener):
+            ah._probe("https://x", {"Authorization": "k"}, 5)
+        req = opener.call_args[0][0]
+        self.assertEqual(req.headers["Authorization"], "k")
+
+    def test_403_cloudflare_body_is_blocked_not_invalid(self):
+        # Cloudflare's block body must NOT be reported as a rejected key.
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(403, b"error code: 1010\n"))):
+            code, detail = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.BLOCKED)
+        self.assertIn("1010", detail)
 
     def test_500_is_transient(self):
         with patch.object(ah.urllib.request, "urlopen",
@@ -170,6 +194,15 @@ class TestCheckAndAlert(_AlertBase):
             ah.check_and_alert()
         alert.assert_called_once()
         self.assertIn("replicate.com/account", alert.call_args[0][0])
+
+    def test_blocked_alerts_immediately_and_says_key_is_fine(self):
+        with patch.object(ah, "check_all", return_value=[self._res("pexels", ah.BLOCKED)]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            ah.check_and_alert()
+        alert.assert_called_once()
+        msg = alert.call_args[0][0]
+        self.assertIn("Cloudflare", msg)
+        self.assertIn("KHÔNG sai", msg)
 
     def test_ok_resets_transient_counter(self):
         ah._set_transient_count("pexels", 2)

--- a/content-pipeline/tests/test_asset_key_health.py
+++ b/content-pipeline/tests/test_asset_key_health.py
@@ -69,6 +69,17 @@ class TestProbe(unittest.TestCase):
         self.assertEqual(code, ah.BLOCKED)
         self.assertIn("1010", detail)
 
+    def test_403_cloudflare_html_page_is_blocked(self):
+        # Cloudflare's HTML block page exposes the code as markup, not the
+        # plain-text "error code:" form — both must classify as BLOCKED.
+        html = (b"<html><head><title>Access denied</title></head><body>"
+                b'<span class="cf-error-code">1010</span></body></html>')
+        with patch.object(ah.urllib.request, "urlopen",
+                          MagicMock(side_effect=_http_error(403, html))):
+            code, detail = ah._probe("https://x", {}, 5)
+        self.assertEqual(code, ah.BLOCKED)
+        self.assertIn("1010", detail)
+
     def test_500_is_transient(self):
         with patch.object(ah.urllib.request, "urlopen",
                           MagicMock(side_effect=_http_error(503))):

--- a/content-pipeline/tests/test_image_generator.py
+++ b/content-pipeline/tests/test_image_generator.py
@@ -191,6 +191,36 @@ class TestGenerateIllustrationFailureModes(ImageGeneratorTestBase):
         self.assertIsNone(result)
 
 
+class TestUserAgentHeaders(ImageGeneratorTestBase):
+    """Issue #97 — Cloudflare blocks urllib's default UA with 403; every
+    Replicate request must carry the shared HTTP_USER_AGENT."""
+
+    def test_create_prediction_sends_user_agent(self):
+        with patch.object(image_generator, "urlopen",
+                          return_value=_json_resp({"id": "pred123"})) as mocked:
+            image_generator._create_prediction("a scene", "fake-token")
+        req = mocked.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"),
+                         image_generator.config.HTTP_USER_AGENT)
+
+    def test_poll_prediction_sends_user_agent(self):
+        resp = _json_resp({"status": "succeeded", "output": ["http://x/img.png"]})
+        with patch.object(image_generator, "urlopen", return_value=resp) as mocked:
+            image_generator._poll_prediction("pred123", "fake-token")
+        req = mocked.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"),
+                         image_generator.config.HTTP_USER_AGENT)
+
+    def test_download_image_sends_user_agent(self):
+        out = os.path.join(self.tmp, "img.png")
+        with patch.object(image_generator, "urlopen",
+                          return_value=_FakeResp(b"png-bytes")) as mocked:
+            image_generator._download_image("https://x/img.png", out)
+        req = mocked.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"),
+                         image_generator.config.HTTP_USER_AGENT)
+
+
 class TestGenerateIllustrations(ImageGeneratorTestBase):
     def test_returns_only_successful_variants(self):
         call_count = {"n": 0}

--- a/content-pipeline/tests/test_pexels_downloader.py
+++ b/content-pipeline/tests/test_pexels_downloader.py
@@ -295,6 +295,14 @@ class TestSearchVideosErrorClassification(SearchVideosBase):
         self.assertEqual(result, [])
         self.assertEqual(pex._last_pexels_error, "blocked")
 
+    def test_cloudflare_html_block_page_sets_blocked(self):
+        html = (b"<html><head><title>Access denied</title></head><body>"
+                b'<span class="cf-error-code">1010</span></body></html>')
+        with patch.object(pex, "urlopen", side_effect=_http_error(403, html)):
+            result = pex._search_videos("nature")
+        self.assertEqual(result, [])
+        self.assertEqual(pex._last_pexels_error, "blocked")
+
     def test_plain_403_sets_auth(self):
         with patch.object(pex, "urlopen", side_effect=_http_error(403)):
             result = pex._search_videos("nature")

--- a/content-pipeline/tests/test_pexels_downloader.py
+++ b/content-pipeline/tests/test_pexels_downloader.py
@@ -242,5 +242,110 @@ class TestGetBackgrounds(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+# ---------------------------------------------------------------------------
+# Issue #97 — Cloudflare blocks urllib's default "Python-urllib/3.x" UA with
+# 403 + body "error code: 1010", which the old code misreported as an invalid
+# API key. These tests pin down: the shared UA is sent, a Cloudflare block is
+# classified as "blocked" (not "auth"), and both fatal kinds stop the loop.
+# ---------------------------------------------------------------------------
+
+import io
+from unittest.mock import MagicMock
+from urllib.error import HTTPError
+
+
+def _http_error(code: int, body: bytes = b"") -> HTTPError:
+    return HTTPError("https://api.pexels.com/videos/search", code, "err", {},
+                     io.BytesIO(body))
+
+
+def _json_response(body: bytes):
+    cm = MagicMock()
+    cm.__enter__.return_value.read.return_value = body
+    return cm
+
+
+class SearchVideosBase(unittest.TestCase):
+    def setUp(self):
+        pex._last_pexels_error = None
+        self._key = patch.object(pex.config, "PEXELS_API_KEY", "pk_live")
+        self._key.start()
+
+    def tearDown(self):
+        self._key.stop()
+        pex._last_pexels_error = None
+
+
+class TestSearchVideosHeaders(SearchVideosBase):
+    def test_sends_user_agent_and_auth(self):
+        with patch.object(pex, "urlopen",
+                          return_value=_json_response(b'{"videos": []}')) as opener:
+            pex._search_videos("nature")
+        req = opener.call_args[0][0]
+        self.assertEqual(req.get_header("User-agent"), pex.config.HTTP_USER_AGENT)
+        # Pexels uses the raw key (NOT "Bearer ...")
+        self.assertEqual(req.get_header("Authorization"), "pk_live")
+
+
+class TestSearchVideosErrorClassification(SearchVideosBase):
+    def test_cloudflare_403_sets_blocked_not_auth(self):
+        with patch.object(pex, "urlopen",
+                          side_effect=_http_error(403, b"error code: 1010\n")):
+            result = pex._search_videos("nature")
+        self.assertEqual(result, [])
+        self.assertEqual(pex._last_pexels_error, "blocked")
+
+    def test_plain_403_sets_auth(self):
+        with patch.object(pex, "urlopen", side_effect=_http_error(403)):
+            result = pex._search_videos("nature")
+        self.assertEqual(result, [])
+        self.assertEqual(pex._last_pexels_error, "auth")
+
+    def test_401_sets_auth(self):
+        with patch.object(pex, "urlopen", side_effect=_http_error(401)):
+            pex._search_videos("nature")
+        self.assertEqual(pex._last_pexels_error, "auth")
+
+    def test_500_is_not_fatal(self):
+        with patch.object(pex, "urlopen", side_effect=_http_error(500)):
+            result = pex._search_videos("nature")
+        self.assertEqual(result, [])
+        self.assertIsNone(pex._last_pexels_error)
+
+    def test_success_resets_sentinel(self):
+        pex._last_pexels_error = "auth"
+        with patch.object(pex, "urlopen",
+                          return_value=_json_response(b'{"videos": [{"id": 1}]}')):
+            result = pex._search_videos("nature")
+        self.assertEqual(result, [{"id": 1}])
+        self.assertIsNone(pex._last_pexels_error)
+
+
+class TestFatalErrorStopsLoop(SearchVideosBase):
+    def _run_get_backgrounds(self, sentinel: str):
+        calls = []
+
+        def fake_search(query, orient):
+            calls.append(query)
+            pex._last_pexels_error = sentinel
+            return None
+
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.object(pex, "CACHE_DIR", tmp), \
+             patch.object(pex, "_search_and_download", side_effect=fake_search):
+            result = get_backgrounds(orientation="landscape", count=2)
+        return calls, result
+
+    def test_blocked_stops_multi_bg_download(self):
+        calls, result = self._run_get_backgrounds("blocked")
+        self.assertEqual(len(calls), 1)  # no pointless retries against a WAF block
+        self.assertEqual(result, [])
+
+    def test_auth_stops_multi_bg_download(self):
+        calls, result = self._run_get_backgrounds("auth")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(result, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/video/asset_key_health.py
+++ b/content-pipeline/video/asset_key_health.py
@@ -29,6 +29,7 @@ Defense-in-depth: main.run_pipeline gọi best-effort (track AI dùng Pexels).
 
 import json
 import logging
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -48,9 +49,25 @@ _REPLICATE_ACCOUNT_URL = "https://api.replicate.com/v1/account"
 # Mã trạng thái.
 OK = "ok"
 INVALID = "invalid"        # 401/403 — key sai/hết hạn/thu hồi
+BLOCKED = "blocked"        # 403 từ Cloudflare (error code 10xx) — key ĐÚNG, request bị WAF chặn (issue #97)
 MISSING = "missing"        # key bắt buộc nhưng chưa cấu hình
 DISABLED = "disabled"      # key tuỳ chọn chưa cấu hình → tính năng tắt (không alert)
 TRANSIENT = "transient"    # timeout/mạng/5xx/429 — thử lại lần sau
+
+# Cloudflare trả 403 body "error code: 1010" khi chặn client (vd User-Agent
+# "Python-urllib/3.x" — issue #97). Phân biệt với 403 "key sai" thật để alert
+# nói đúng sự thật, không xúi người vận hành đi thay key vô ích.
+_CF_BLOCK_RE = re.compile(rb"error code:\s*(10\d\d)")
+
+
+def _cloudflare_block_code(err: urllib.error.HTTPError) -> str | None:
+    """Mã chặn Cloudflare ("1010"…) từ body lỗi; None nếu không phải WAF block."""
+    try:
+        body = err.read(256)
+    except Exception:
+        return None
+    m = _CF_BLOCK_RE.search(body or b"")
+    return m.group(1).decode() if m else None
 
 
 class KeyCheckResult:
@@ -76,14 +93,22 @@ def _probe(url: str, headers: dict, timeout: int) -> tuple[str, str]:
     """GET `url` với header xác thực → (code, detail). Chỉ stdlib, HTTPS verify.
 
     KHÔNG bao giờ đưa giá trị key vào detail (headers chỉ dùng để gửi).
+    User-Agent bắt buộc: urllib mặc định gửi "Python-urllib/3.x" và Cloudflare
+    chặn nó bằng 403 error code 1010 (issue #97) — probe sẽ báo key hỏng oan.
     """
-    req = urllib.request.Request(url, headers=headers, method="GET")
+    req = urllib.request.Request(
+        url, headers={"User-Agent": config.HTTP_USER_AGENT, **headers}, method="GET"
+    )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             resp.read(1)
         return OK, ""
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
+            cf = _cloudflare_block_code(e)
+            if cf:
+                return BLOCKED, (f"HTTP {e.code} — Cloudflare chặn request "
+                                 f"(error code {cf}), KHÔNG phải lỗi key")
             return INVALID, f"HTTP {e.code} — key bị từ chối"
         if e.code == 429 or e.code >= 500:
             return TRANSIENT, f"HTTP {e.code}"
@@ -150,6 +175,13 @@ def _set_transient_count(provider: str, value: int) -> None:
 
 def _alert_message(res: KeyCheckResult) -> str | None:
     """Tin nhắn Telegram cho 1 kết quả (None = không alert)."""
+    if res.code == BLOCKED:
+        impact = ("video mới sẽ dùng lại nền cache cũ"
+                  if res.provider == "pexels"
+                  else "minh hoạ AI (Drama) sẽ fallback gradient")
+        return (f"🔴 Request tới {res.provider} bị Cloudflare CHẶN ({res.detail}). "
+                f"Key KHÔNG sai — đừng thay key. {impact}. "
+                "Kiểm tra HTTP_USER_AGENT trong .env hoặc IP đang bị flag (issue #97).")
     if res.provider == "pexels":
         if res.code == INVALID:
             return ("🔴 PEXELS_API_KEY bị từ chối "
@@ -170,7 +202,7 @@ def check_and_alert(providers: list[str] | None = None,
                     timeout: int | None = None) -> list[KeyCheckResult]:
     """Kiểm tra + alert Telegram cho key hỏng/thiếu. Trả toàn bộ kết quả.
 
-    - INVALID/MISSING → alert ngay mỗi lần chạy (nhắc tới khi sửa).
+    - INVALID/MISSING/BLOCKED → alert ngay mỗi lần chạy (nhắc tới khi sửa).
     - TRANSIENT → tăng bộ đếm; chỉ alert khi CHẠM ngưỡng
       ASSET_KEY_HEALTH_TRANSIENT_ALERT_AFTER (một lần) để "monitor không tới được
       provider" cũng lộ ra, không spam khi provider chập chờn.
@@ -205,7 +237,7 @@ def check_and_alert(providers: list[str] | None = None,
                       f"asset-key-health lỗi. ({res.detail})")
             continue
 
-        # INVALID / MISSING → reset transient + alert.
+        # INVALID / MISSING / BLOCKED → reset transient + alert.
         _set_transient_count(res.provider, 0)
         logger.warning("Asset key %s %s: %s", res.provider, res.code, res.detail)
         msg = _alert_message(res)

--- a/content-pipeline/video/asset_key_health.py
+++ b/content-pipeline/video/asset_key_health.py
@@ -54,20 +54,27 @@ MISSING = "missing"        # key bắt buộc nhưng chưa cấu hình
 DISABLED = "disabled"      # key tuỳ chọn chưa cấu hình → tính năng tắt (không alert)
 TRANSIENT = "transient"    # timeout/mạng/5xx/429 — thử lại lần sau
 
-# Cloudflare trả 403 body "error code: 1010" khi chặn client (vd User-Agent
-# "Python-urllib/3.x" — issue #97). Phân biệt với 403 "key sai" thật để alert
-# nói đúng sự thật, không xúi người vận hành đi thay key vô ích.
-_CF_BLOCK_RE = re.compile(rb"error code:\s*(10\d\d)")
+# Cloudflare chặn client (vd User-Agent "Python-urllib/3.x" — issue #97) bằng
+# 403 với body dạng text thuần "error code: 1010" HOẶC trang HTML block chứa
+# markup `<span class="cf-error-code">1010</span>`. Bắt cả hai để phân biệt với
+# 403 "key sai" thật — alert nói đúng sự thật, không xúi đi thay key vô ích.
+_CF_BLOCK_RE = re.compile(
+    rb"error code:?\s*(10\d\d)|cf-error-code[^>]*>\s*(10\d\d)",
+    re.IGNORECASE,
+)
 
 
 def _cloudflare_block_code(err: urllib.error.HTTPError) -> str | None:
     """Mã chặn Cloudflare ("1010"…) từ body lỗi; None nếu không phải WAF block."""
     try:
-        body = err.read(256)
+        # Trang HTML block của Cloudflare dài — đọc đủ sâu để thấy error code.
+        body = err.read(4096)
     except Exception:
         return None
     m = _CF_BLOCK_RE.search(body or b"")
-    return m.group(1).decode() if m else None
+    if not m:
+        return None
+    return next(g for g in m.groups() if g).decode()
 
 
 class KeyCheckResult:

--- a/content-pipeline/video/image_generator.py
+++ b/content-pipeline/video/image_generator.py
@@ -110,6 +110,8 @@ def _create_prediction(prompt: str, api_token: str) -> str | None:
         headers={
             "Authorization": f"Bearer {api_token}",
             "Content-Type": "application/json",
+            # urllib's default UA gets Cloudflare-blocked with 403 (issue #97)
+            "User-Agent": config.HTTP_USER_AGENT,
         },
         method="POST",
     )
@@ -136,7 +138,10 @@ def _poll_prediction(prediction_id: str, api_token: str) -> str | None:
     deadline = time.monotonic() + POLL_TIMEOUT_SECONDS
     req = Request(
         f"{REPLICATE_API_BASE}/predictions/{prediction_id}",
-        headers={"Authorization": f"Bearer {api_token}"},
+        headers={
+            "Authorization": f"Bearer {api_token}",
+            "User-Agent": config.HTTP_USER_AGENT,
+        },
     )
     while True:
         try:
@@ -172,7 +177,7 @@ def _poll_prediction(prediction_id: str, api_token: str) -> str | None:
 def _download_image(url: str, output_path: str) -> str | None:
     try:
         os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-        req = Request(url)
+        req = Request(url, headers={"User-Agent": config.HTTP_USER_AGENT})
         with urlopen(req, timeout=30) as resp:
             data = resp.read()
         with open(output_path, "wb") as f:

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import random
+import re
 import subprocess
 from urllib.error import HTTPError
 from urllib.parse import quote
@@ -47,9 +48,29 @@ SEARCH_QUERIES = [
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), "assets", "backgrounds", "cache")
 
-# Tracks the last Pexels API error type so callers can stop retrying on auth failures.
-# Set to "auth" on HTTP 401/403, reset to None on success.
+# Tracks the last FATAL Pexels API error so callers stop retrying:
+#   "auth"    — HTTP 401/403: key rejected for real
+#   "blocked" — HTTP 403 with a Cloudflare "error code: 10xx" body (issue #97):
+#               the key is FINE, the request itself is WAF-blocked (e.g. bad
+#               User-Agent or flagged IP) — retrying other queries is pointless.
+# Reset to None on success / non-fatal errors.
 _last_pexels_error: str | None = None
+_FATAL_PEXELS_ERRORS = ("auth", "blocked")
+
+# Cloudflare rejects clients it dislikes (urllib's default "Python-urllib/3.x"
+# User-Agent, flagged IPs) with 403 + body "error code: 1010" (issue #97).
+# Same detection as video/asset_key_health.py — keep the two in sync.
+_CF_BLOCK_RE = re.compile(rb"error code:\s*(10\d\d)")
+
+
+def _cloudflare_block_code(err: HTTPError) -> str | None:
+    """Cloudflare block code ("1010"…) from the error body; None if not a WAF block."""
+    try:
+        body = err.read(256)
+    except Exception:
+        return None
+    m = _CF_BLOCK_RE.search(body or b"")
+    return m.group(1).decode() if m else None
 
 
 def get_video_duration(video_path: str) -> float:
@@ -239,8 +260,9 @@ def get_background(keywords: list[str] | None = None,
     if config.PEXELS_API_KEY:
         for query in queries:
             path = _search_and_download(query, orientation)
-            if path is None and _last_pexels_error == "auth":
-                logger.error("Pexels API key is invalid or expired — skipping remaining queries")
+            if path is None and _last_pexels_error in _FATAL_PEXELS_ERRORS:
+                logger.error("Pexels rejected our requests (%s) — skipping remaining queries",
+                             _last_pexels_error)
                 break
             if path:
                 return path
@@ -296,8 +318,9 @@ def get_backgrounds(keywords: list[str] | None = None,
             if len(collected) >= count:
                 break
             path = _search_and_download(query, orientation)
-            if path is None and _last_pexels_error == "auth":
-                logger.error("Pexels API key invalid — stopping multi-bg download")
+            if path is None and _last_pexels_error in _FATAL_PEXELS_ERRORS:
+                logger.error("Pexels rejected our requests (%s) — stopping multi-bg download",
+                             _last_pexels_error)
                 break
             if path and path not in collected:
                 collected.append(path)
@@ -325,7 +348,7 @@ def download_font(force: bool = False) -> bool:
     logger.info("Downloading NotoSans-Bold.ttf for Vietnamese subtitle rendering...")
 
     try:
-        req = Request(_NOTO_FONT_URL, headers={"User-Agent": "ContentPipeline/1.0"})
+        req = Request(_NOTO_FONT_URL, headers={"User-Agent": config.HTTP_USER_AGENT})
         with urlopen(req, timeout=30) as resp:
             with open(_FONT_PATH, "wb") as f:
                 f.write(resp.read())
@@ -354,12 +377,13 @@ def download_backgrounds(force: bool = False) -> bool:
         for query in SEARCH_QUERIES:
             for orient in ("landscape", "portrait"):
                 result = _search_and_download(query, orient)
-                if _last_pexels_error == "auth":
-                    logger.error("Pexels API key invalid — aborting force refresh")
+                if _last_pexels_error in _FATAL_PEXELS_ERRORS:
+                    logger.error("Pexels rejected our requests (%s) — aborting force refresh",
+                                 _last_pexels_error)
                     break
                 if not result:
                     logger.warning("Could not download '%s' %s background", query, orient)
-            if _last_pexels_error == "auth":
+            if _last_pexels_error in _FATAL_PEXELS_ERRORS:
                 break
 
     landscape = get_background(orientation="landscape")
@@ -447,15 +471,28 @@ def _search_videos(query: str, per_page: int = 5,
            f"?query={encoded_query}&per_page={per_page}&orientation={pexels_orient}")
 
     try:
-        req = Request(url, headers={"Authorization": config.PEXELS_API_KEY})
+        # User-Agent is mandatory: urllib's default "Python-urllib/3.x" gets a
+        # Cloudflare 403 (error code 1010) that looks like a bad key (issue #97).
+        req = Request(url, headers={
+            "Authorization": config.PEXELS_API_KEY,
+            "User-Agent": config.HTTP_USER_AGENT,
+        })
         with urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read().decode())
         _last_pexels_error = None  # Reset on success
         return data.get("videos", [])
     except HTTPError as e:
         if e.code in (401, 403):
-            _last_pexels_error = "auth"
-            logger.error("Pexels API key invalid or expired (HTTP %d) — check PEXELS_API_KEY in .env", e.code)
+            cf = _cloudflare_block_code(e)
+            if cf:
+                _last_pexels_error = "blocked"
+                logger.error(
+                    "Pexels request blocked by Cloudflare (HTTP %d, error code %s) — "
+                    "NOT an API key problem; check HTTP_USER_AGENT in .env or a flagged IP",
+                    e.code, cf)
+            else:
+                _last_pexels_error = "auth"
+                logger.error("Pexels API key invalid or expired (HTTP %d) — check PEXELS_API_KEY in .env", e.code)
         else:
             _last_pexels_error = None
             logger.error("Pexels search failed for '%s': %s", query, e)
@@ -506,7 +543,7 @@ def _find_best_file(files: list[dict], orientation: str = "landscape") -> dict |
 def _download_file(url: str, output_path: str) -> bool:
     """Download a file from URL to output_path."""
     try:
-        req = Request(url, headers={"User-Agent": "ContentPipeline/1.0"})
+        req = Request(url, headers={"User-Agent": config.HTTP_USER_AGENT})
         with urlopen(req, timeout=120) as resp:
             total = int(resp.headers.get("Content-Length", 0))
             downloaded = 0

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -58,19 +58,27 @@ _last_pexels_error: str | None = None
 _FATAL_PEXELS_ERRORS = ("auth", "blocked")
 
 # Cloudflare rejects clients it dislikes (urllib's default "Python-urllib/3.x"
-# User-Agent, flagged IPs) with 403 + body "error code: 1010" (issue #97).
+# User-Agent, flagged IPs) with 403 + either a plain-text body "error code:
+# 1010" (issue #97) or a full HTML block page carrying
+# `<span class="cf-error-code">1010</span>` — match both.
 # Same detection as video/asset_key_health.py — keep the two in sync.
-_CF_BLOCK_RE = re.compile(rb"error code:\s*(10\d\d)")
+_CF_BLOCK_RE = re.compile(
+    rb"error code:?\s*(10\d\d)|cf-error-code[^>]*>\s*(10\d\d)",
+    re.IGNORECASE,
+)
 
 
 def _cloudflare_block_code(err: HTTPError) -> str | None:
     """Cloudflare block code ("1010"…) from the error body; None if not a WAF block."""
     try:
-        body = err.read(256)
+        # Cloudflare's HTML block pages are long — read deep enough to see the code.
+        body = err.read(4096)
     except Exception:
         return None
     m = _CF_BLOCK_RE.search(body or b"")
-    return m.group(1).decode() if m else None
+    if not m:
+        return None
+    return next(g for g in m.groups() if g).decode()
 
 
 def get_video_duration(video_path: str) -> float:


### PR DESCRIPTION
## Root cause (issue #97)

urllib mặc định gửi User-Agent `Python-urllib/3.x` → **Cloudflare chặn với 403, body `error code: 1010`** — Pexels/Replicate "chết" từ 01/07 dù key hoàn toàn đúng, và log lại đổ oan cho key (`Pexels API key invalid or expired`), khiến người vận hành debug nhầm hướng suốt gần 3 tuần.

## Thay đổi

### 1. `config.HTTP_USER_AGENT` — một nguồn sự thật cho UA (consistency)
- Env-overridable, mặc định `Mozilla/5.0 (compatible; ContentPipelineBot/1.0)` — dạng đã được chứng minh pass Cloudflare trong phần debug của issue, và trùng pattern `seed_bot.py` đang dùng.
- Theo đúng precedent `REDDIT_USER_AGENT`/`LEMMY_USER_AGENT` (2 UA đó giữ nguyên vì theo quy định API riêng của Reddit/Lemmy).
- Ghi chú vào `.env.example` + `CLAUDE.md` để module mới sau này không lặp lại lỗi.

### 2. `video/pexels_downloader.py`
- `_search_videos` (đúng call gây lỗi trong log) gửi `User-Agent`.
- Font/file download bỏ chuỗi lẻ `"ContentPipeline/1.0"`, dùng chung config.
- **Sửa chẩn đoán sai:** 403 kèm body Cloudflare `error code: 10xx` → log `blocked by Cloudflare — NOT an API key problem` (sentinel `'blocked'`) thay vì "key invalid"; vẫn dừng vòng query như `'auth'` (nã tiếp WAF chỉ phí request — giữ nguyên hành vi fail-fast).

### 3. `video/image_generator.py`
- Cả 3 request Replicate (create/poll/download) gửi `User-Agent`.

### 4. `video/asset_key_health.py`
- `_probe` gửi `User-Agent`; thêm trạng thái **`BLOCKED`** phân biệt với `INVALID` bằng cách đọc body lỗi.
- Alert Telegram cho `BLOCKED` nói rõ: **"Key KHÔNG sai — đừng thay key"**, trỏ vào `HTTP_USER_AGENT`/IP — để nếu Cloudflare siết rule lần nữa, monitor nói đúng sự thật thay vì xúi đi thay key vô ích.
- Không log giá trị key (giữ nguyên nguyên tắc security của module).

## Test

- `test_asset_key_health.py`: UA được gửi + header caller không bị mất, 403 body Cloudflare → `BLOCKED` (403 rỗng vẫn → `INVALID`), alert BLOCKED nói "KHÔNG sai".
- `test_pexels_downloader.py`: UA + Authorization đúng, phân loại `blocked`/`auth`/transient, cả 2 loại fatal đều dừng vòng multi-bg (không retry vô ích).
- `test_image_generator.py`: cả 3 request Replicate mang UA.
- Full suite: **978 tests OK** (21 skipped).

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXamcHurtFkWLUHv6KSjLV