### PR TITLE
Drama rewriter: hook 2-band validation + recovery cho story kẹt needs_review (issue #99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,20 @@ phạm vi: TTS/render video thật (Phase 4).
   approve + log note (quan sát model có hay ngắn/dài không); chỉ dưới `HARD_MIN`
   (stub/cắt cụt) hoặc trên `HARD_MAX` (runaway/lặp) mới block. Cả 4 ngưỡng
   env-overridable (`DRAMA_SCRIPT_{SOFT,HARD}_{MIN,MAX}_WORDS`).
+  **Hook 2 dải (issue #99):** hook là length-check duy nhất còn sót hard
+  threshold sau #86 — story 574 có hook **26 từ** (vượt đúng 1 từ so với trần
+  cứng 25) bị block y như script gãy → `needs_review`, mà `needs_review` với
+  STORY là ngõ cụt (review_bot chỉ review video; `rewrite_all_scored` chủ động
+  skip). Fix cùng thiết kế 2 dải: `validate_rewrite_verdict()` trả
+  `(blocking, soft_notes)` — hook ≤`DRAMA_HOOK_SOFT_MAX_WORDS` (25) = lý tưởng;
+  vượt tới `DRAMA_HOOK_HARD_MAX_WORDS` (35) = **approve + log note** (không
+  alert Telegram — alert là cho story cần người, note thì không); chỉ >35 từ
+  (đoạn văn, không phải hook) mới block. `validate_rewrite()` giữ nguyên API
+  (chỉ trả blocking). **Gỡ kẹt story cũ:** `python -m processors.drama_rewriter
+  --revalidate` re-chạy validation trên story drama `needs_review` bằng
+  ngưỡng HIỆN TẠI từ `rewritten_content` đã lưu (zero call AI, zero cost),
+  approve story giờ pass; envelope `_rewrite_error` (reply không parse được)
+  bị bỏ qua. Chạy 1 lần sau khi deploy để cứu story 574.
   **Cải tiến so với tài liệu gốc:** 2 rule phòng rủi ro mà tài liệu liệt kê
   ở mục "Rủi ro" (tên thuần Việt 2-3 từ, không nhắc văn hoá Mỹ) được đưa
   thẳng vào prompt v1 luôn, không đợi tune sang v2 — xem

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -370,6 +370,19 @@ DRAMA_SCRIPT_SOFT_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MAX_WORDS", "1200
 DRAMA_SCRIPT_HARD_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MIN_WORDS", "600"))
 DRAMA_SCRIPT_HARD_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MAX_WORDS", "1500"))
 
+# Drama rewriter hook length validation (issue #99) — same two-band design as
+# the script word count above (issue #86); the hook was the one length check
+# left as a single hard threshold. Story 574's hook came back at 26 words —
+# ONE word over the old limit of 25, on an otherwise complete script — and was
+# hard-blocked to 'needs_review', which for *stories* is a dead end (review_bot
+# reviews videos; rewrite_all_scored deliberately skips needs_review stories).
+#   - <= SOFT_MAX          ideal ~3s hook → approve cleanly
+#   - (SOFT_MAX, HARD_MAX] slightly long but still a hook → approve + logged note
+#   - > HARD_MAX           a paragraph, not a hook → needs_review
+# 35 words ≈ 10-12s spoken Vietnamese — past that it stops working as a 3s hook.
+DRAMA_HOOK_SOFT_MAX_WORDS = int(os.getenv("DRAMA_HOOK_SOFT_MAX_WORDS", "25"))
+DRAMA_HOOK_HARD_MAX_WORDS = int(os.getenv("DRAMA_HOOK_HARD_MAX_WORDS", "35"))
+
 # --- Lemmy (issue #78 follow-up: Reddit-alternative source for Drama) ---
 # Lemmy is a federated, open Reddit alternative with a public read API (no
 # OAuth, no approval — unlike Reddit post-Nov-2025). Drama stories come out in

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -476,7 +476,7 @@ def rewrite_all_scored(limit: int = 10) -> int:
     return done
 
 
-def revalidate_needs_review(limit: int = 100) -> int:
+def revalidate_needs_review(limit: int | None = None) -> int:
     """Re-validate 'needs_review' drama stories against the CURRENT thresholds.
 
     Recovery path for issue #99: a story hard-blocked by a validation rule that
@@ -487,6 +487,11 @@ def revalidate_needs_review(limit: int = 100) -> int:
     zero cost) and approves stories that now pass; still-blocked stories are
     left untouched, and unparseable-reply error envelopes (`_rewrite_error`,
     see _handle_unparseable) are skipped — they hold no rewrite to validate.
+
+    Sweeps ALL stuck stories by default (Codex review, PR #100): get_by_status
+    sorts newest-first, so any fixed page size would forever hide older rows
+    behind still-blocked newer ones once the backlog exceeds it. A one-shot
+    manual command over a small SQLite table doesn't need paging.
 
     Run manually after a threshold change: `python -m processors.drama_rewriter
     --revalidate`. Returns the number of stories approved.

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import config
 from processors.prompt_loader import load_prompt, render
 from processors.ai_usage import log_token_usage
-from storage.stories import get_pending, update_status, get_story
+from storage.stories import get_pending, get_by_status, update_status, get_story
 
 logger = logging.getLogger(__name__)
 
@@ -50,11 +50,6 @@ _JSON_PREFILL = "{"
 
 _REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
 _VN_COMMENTARY_MIN_WORDS = 200
-# Structure heuristic ("Hook 3s → Setup → Escalation → Twist → Reflection"):
-# a real 3-second hook is one short punchy line, not a paragraph. Can't
-# heuristically verify the other 4 structure beats without real NLP, but a
-# hook that's suspiciously long is a good, cheap signal something went wrong.
-_HOOK_MAX_WORDS = 25
 
 # Heuristic guard against the 2 failure modes called out in
 # phase-3-detailed.md's risk section: half-Western character names (e.g.
@@ -110,19 +105,57 @@ def _script_length_verdict(word_count: int) -> tuple[str | None, str | None]:
     return (None, None)
 
 
-def validate_rewrite(result: dict) -> list[str]:
-    """Heuristic quality gate for a rewriter JSON result.
+def _hook_length_verdict(word_count: int) -> tuple[str | None, str | None]:
+    """Classify a hook's word count — two bands, same design as the script check.
 
-    Pure function, no network — returns a list of human-readable *blocking*
-    issues; an empty list means the rewrite passes. Checked (per
-    phase-3-detailed.md EPIC #3.2 "Validation post-rewrite"):
+    Issue #99: the old single hard threshold (25 words) blocked a hook that ran
+    ONE word over, sending an otherwise complete rewrite to 'needs_review' —
+    which for stories is a dead end (no review UI; rewrite_all_scored skips
+    them). A real 3-second hook is one short punchy line, and length is the
+    cheap proxy we have for that — but "slightly long" and "a paragraph" are
+    different failures:
+    - <= SOFT_MAX: ideal → (None, None)
+    - (SOFT_MAX, HARD_MAX]: still a hook, just wordy → soft note, approve
+    - > HARD_MAX: a paragraph, structure went wrong → blocking
+    """
+    soft_max = config.DRAMA_HOOK_SOFT_MAX_WORDS
+    hard_max = config.DRAMA_HOOK_HARD_MAX_WORDS
+
+    if word_count > hard_max:
+        return (
+            f"hook has {word_count} words — a paragraph, not a ~3s line "
+            f"(hard max {hard_max})",
+            None,
+        )
+    if word_count > soft_max:
+        return (
+            None,
+            f"hook has {word_count} words, over the ideal ~3s length "
+            f"({soft_max}) but within accepted ({hard_max}) — approving",
+        )
+    return (None, None)
+
+
+def validate_rewrite_verdict(result: dict) -> tuple[list[str], list[str]]:
+    """Two-tier heuristic quality gate for a rewriter JSON result (issue #99).
+
+    Pure function, no network — returns ``(blocking_issues, soft_notes)``:
+    - ``blocking_issues``: the rewrite is broken/unusable → 'needs_review'
+      (missing fields, script outside the accepted band, commentary too short,
+      Western names / US-culture terms leaking through, bad tags, hook so long
+      it's a paragraph).
+    - ``soft_notes``: imperfect but production-worthy → the caller still
+      approves and logs these for prompt/threshold tuning (script short/long
+      of the ideal band, hook slightly over the ideal length).
+
+    Checked (per phase-3-detailed.md EPIC #3.2 "Validation post-rewrite"):
     - all required fields present and non-empty
     - `script` word count within the accepted band [HARD_MIN, HARD_MAX]
       (issue #86: the ideal is [SOFT_MIN, SOFT_MAX] = 800-1200, but a script
-      merely short/long of ideal is accepted, not blocked — see
-      `_script_length_verdict`)
+      merely short/long of ideal is accepted, not blocked)
     - `vn_commentary` >= 200 words
-    - `hook` is a short punchy line, not a paragraph (structure heuristic)
+    - `hook` is a short punchy line, not a paragraph (issue #99: two-band —
+      slightly-long approves with a note, only a paragraph blocks)
     - no common Western name fragments / US-culture terms leaking through
       (scanned across title/script/vn_commentary AND the optional vn_reactions)
     - `tags` is a non-empty list
@@ -131,23 +164,25 @@ def validate_rewrite(result: dict) -> list[str]:
     is OPTIONAL — only stories carrying comments have it — so its absence never
     blocks; when present it's held to the same localization rules.
     """
-    issues = []
+    issues: list[str] = []
+    notes: list[str] = []
     missing = [k for k in _REQUIRED_FIELDS if not result.get(k)]
     if missing:
         issues.append(f"missing/empty field(s): {missing}")
-        return issues  # other checks need these fields to make sense
+        return issues, notes  # other checks need these fields to make sense
 
     script = result["script"]
-    blocking, _soft = _script_length_verdict(len(script.split()))
+    blocking, soft = _script_length_verdict(len(script.split()))
     if blocking:
         issues.append(blocking)
+    if soft:
+        notes.append(soft)
 
-    hook_word_count = len(result["hook"].split())
-    if hook_word_count > _HOOK_MAX_WORDS:
-        issues.append(
-            f"hook has {hook_word_count} words — expected a short ~3s line "
-            f"(<= {_HOOK_MAX_WORDS})"
-        )
+    blocking, soft = _hook_length_verdict(len(result["hook"].split()))
+    if blocking:
+        issues.append(blocking)
+    if soft:
+        notes.append(soft)
 
     commentary_count = len(result["vn_commentary"].split())
     if commentary_count < _VN_COMMENTARY_MIN_WORDS:
@@ -173,6 +208,16 @@ def validate_rewrite(result: dict) -> list[str]:
     if not isinstance(result.get("tags"), list) or not result["tags"]:
         issues.append("tags must be a non-empty list")
 
+    return issues, notes
+
+
+def validate_rewrite(result: dict) -> list[str]:
+    """Blocking issues only — thin wrapper kept for existing callers/tests.
+
+    See `validate_rewrite_verdict` for the two-tier version (blocking vs. soft
+    notes); an empty return here means the rewrite is approvable.
+    """
+    issues, _notes = validate_rewrite_verdict(result)
     return issues
 
 
@@ -379,7 +424,7 @@ def rewrite_story(story_id: int) -> dict | None:
     if result is None:
         return _handle_unparseable(story_id, got_reply, last_stop_reason, last_snippet)
 
-    issues = validate_rewrite(result)
+    issues, soft_notes = validate_rewrite_verdict(result)
     rewritten_json = json.dumps(result, ensure_ascii=False)
 
     if issues:
@@ -387,12 +432,12 @@ def rewrite_story(story_id: int) -> dict | None:
         logger.warning("Story %d rewrite failed validation: %s", story_id, issues)
         _alert_validation_failure(story_id, issues)
     else:
-        # Passed the gate. If the script is short/long of the ideal band (but
-        # still within the accepted range), surface it — a model that keeps
-        # landing here is a signal to tune the prompt or thresholds (issue #86).
-        _, soft_note = _script_length_verdict(len(result["script"].split()))
-        if soft_note:
-            logger.info("Story %d approved with note: %s", story_id, soft_note)
+        # Passed the gate. Soft notes (script short/long of ideal, hook a bit
+        # wordy) don't block — but a model that keeps landing here is a signal
+        # to tune the prompt or thresholds (issues #86/#99). Log only, no
+        # Telegram: alerts are for stories needing a human, notes are not.
+        for note in soft_notes:
+            logger.info("Story %d approved with note: %s", story_id, note)
         update_status(story_id, "approved", rewritten_content=rewritten_json)
         logger.info("Story %d rewritten and validated OK", story_id)
 
@@ -431,6 +476,52 @@ def rewrite_all_scored(limit: int = 10) -> int:
     return done
 
 
+def revalidate_needs_review(limit: int = 100) -> int:
+    """Re-validate 'needs_review' drama stories against the CURRENT thresholds.
+
+    Recovery path for issue #99: a story hard-blocked by a validation rule that
+    was later relaxed (e.g. story 574's 26-word hook under the old 25-word hard
+    limit) has no other way out — there is no story review UI, and
+    rewrite_all_scored deliberately skips 'needs_review'. This re-runs
+    `validate_rewrite_verdict` over the ALREADY-SAVED rewrite (zero AI calls,
+    zero cost) and approves stories that now pass; still-blocked stories are
+    left untouched, and unparseable-reply error envelopes (`_rewrite_error`,
+    see _handle_unparseable) are skipped — they hold no rewrite to validate.
+
+    Run manually after a threshold change: `python -m processors.drama_rewriter
+    --revalidate`. Returns the number of stories approved.
+    """
+    stuck = get_by_status("needs_review", limit=limit, track="drama")
+    recovered = 0
+    for story in stuck:
+        raw = story.get("rewritten_content")
+        if not raw:
+            continue
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(result, dict) or "_rewrite_error" in result:
+            continue
+        issues, soft_notes = validate_rewrite_verdict(result)
+        if issues:
+            logger.info("Story %d still blocked: %s", story["id"], issues)
+            continue
+        for note in soft_notes:
+            logger.info("Story %d approved with note: %s", story["id"], note)
+        update_status(story["id"], "approved")
+        logger.info("Story %d re-validated OK — approved", story["id"])
+        recovered += 1
+    logger.info(
+        "Re-validated %d needs_review drama stories, approved %d",
+        len(stuck), recovered,
+    )
+    return recovered
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    rewrite_all_scored()
+    if "--revalidate" in sys.argv:
+        revalidate_needs_review()
+    else:
+        rewrite_all_scored()

--- a/content-pipeline/storage/stories.py
+++ b/content-pipeline/storage/stories.py
@@ -85,7 +85,8 @@ def get_pending(limit: int = 10, track: Optional[str] = None) -> list[dict]:
     return get_by_status("pending", limit=limit, track=track)
 
 
-def get_by_status(status: str, limit: int = 10, track: Optional[str] = None) -> list[dict]:
+def get_by_status(status: str, limit: Optional[int] = 10,
+                  track: Optional[str] = None) -> list[dict]:
     """Lấy story theo `status` bất kỳ, sort theo created_at DESC.
 
     Tie-broken bằng `id DESC`: SQLite's CURRENT_TIMESTAMP chỉ có độ chính xác
@@ -95,22 +96,27 @@ def get_by_status(status: str, limit: int = 10, track: Optional[str] = None) -> 
 
     Args:
         status: 'pending', 'approved', 'rejected', 'needs_review', 'produced', ...
+        limit: số story tối đa; ``None`` = KHÔNG giới hạn (SQLite ``LIMIT -1``).
+            Dùng cho tác vụ quét-toàn-bộ như `drama_rewriter --revalidate`
+            (review PR #100): sort DESC + limit khiến story CŨ không bao giờ
+            lọt vào trang đầu khi tồn đọng nhiều hơn `limit`.
         track: lọc theo track ('drama', 'ai', ...) nếu truyền vào, mặc định
             lấy mọi track.
     """
+    sql_limit = -1 if limit is None else limit
     conn = get_connection()
     try:
         if track:
             rows = conn.execute(
                 "SELECT * FROM stories WHERE status = ? AND track = ? "
                 "ORDER BY created_at DESC, id DESC LIMIT ?",
-                (status, track, limit),
+                (status, track, sql_limit),
             ).fetchall()
         else:
             rows = conn.execute(
                 "SELECT * FROM stories WHERE status = ? "
                 "ORDER BY created_at DESC, id DESC LIMIT ?",
-                (status, limit),
+                (status, sql_limit),
             ).fetchall()
         return [_row_to_dict(r) for r in rows]
     finally:

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -577,6 +577,22 @@ class TestRevalidateNeedsReview(RewriterTestBase):
             stories.get_story(self.story_id)["status"], "needs_review"
         )
 
+    def test_sweeps_beyond_a_fixed_page_size(self):
+        # Codex review (PR #100): with a fixed limit and newest-first ordering,
+        # recoverable OLD stories would stay hidden behind newer ones once the
+        # backlog exceeds the page. The default sweep must cover everything.
+        recoverable = json.dumps(_good_rewrite(), ensure_ascii=False)
+        ids = [self.story_id]
+        for i in range(120):
+            sid = stories.insert_story("reddit", f"stuck{i}", "raw", track="drama")
+            ids.append(sid)
+        for sid in ids:
+            stories.update_status(sid, "needs_review", rewritten_content=recoverable)
+        count = drama_rewriter.revalidate_needs_review()
+        self.assertEqual(count, len(ids))
+        # The OLDEST row (created first, sorted last) must also be recovered.
+        self.assertEqual(stories.get_story(ids[0])["status"], "approved")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -120,8 +120,9 @@ class TestValidateRewrite(unittest.TestCase):
         self.assertTrue(any("vn_commentary only" in i for i in issues))
 
     def test_overlong_hook_flagged(self):
+        # Above the hard max (35) — a paragraph, not a 3s line: still blocking.
         result = _good_rewrite()
-        result["hook"] = " ".join(["từ"] * 40)  # a paragraph, not a 3s line
+        result["hook"] = " ".join(["từ"] * 40)
         issues = drama_rewriter.validate_rewrite(result)
         self.assertTrue(any("hook has" in i for i in issues))
 
@@ -129,6 +130,45 @@ class TestValidateRewrite(unittest.TestCase):
         result = _good_rewrite()
         result["hook"] = "Ba năm đi làm, tôi chưa từng nghĩ mình sẽ bị đối xử như vậy."
         self.assertEqual(drama_rewriter.validate_rewrite(result), [])
+
+    def test_hook_one_word_over_ideal_passes(self):
+        # Issue #99: story 574's hook ran 26 words — ONE over the old hard
+        # limit of 25 — and was blocked to needs_review (a dead end for
+        # stories). Slightly-long hooks must now approve with a soft note.
+        result = _good_rewrite()
+        result["hook"] = " ".join(["từ"] * 26)
+        issues, notes = drama_rewriter.validate_rewrite_verdict(result)
+        self.assertEqual(issues, [])
+        self.assertTrue(any("hook has 26 words" in n for n in notes))
+
+    def test_hook_at_hard_max_boundary_passes(self):
+        result = _good_rewrite()
+        result["hook"] = " ".join(
+            ["từ"] * drama_rewriter.config.DRAMA_HOOK_HARD_MAX_WORDS
+        )
+        self.assertEqual(drama_rewriter.validate_rewrite(result), [])
+
+    def test_hook_just_above_hard_max_flagged(self):
+        result = _good_rewrite()
+        result["hook"] = " ".join(
+            ["từ"] * (drama_rewriter.config.DRAMA_HOOK_HARD_MAX_WORDS + 1)
+        )
+        issues = drama_rewriter.validate_rewrite(result)
+        self.assertTrue(any("hook has" in i for i in issues))
+
+    def test_ideal_hook_yields_no_soft_note(self):
+        issues, notes = drama_rewriter.validate_rewrite_verdict(_good_rewrite())
+        self.assertEqual(issues, [])
+        self.assertEqual(notes, [])
+
+    def test_verdict_collects_script_soft_note(self):
+        # The two-tier verdict carries the issue #86 script note too, so the
+        # approve path logs every soft signal from one call.
+        issues, notes = drama_rewriter.validate_rewrite_verdict(
+            _good_rewrite(word_count=733)
+        )
+        self.assertEqual(issues, [])
+        self.assertTrue(any("script word count 733" in n for n in notes))
 
     def test_western_name_fragment_flagged(self):
         result = _good_rewrite()
@@ -296,6 +336,32 @@ class TestRewriteStory(RewriterTestBase):
         self.assertEqual(story["status"], "approved")
         alert.assert_not_called()  # accepted scripts must not spam the alert
 
+    def test_slightly_long_hook_still_approved(self):
+        # Issue #99 end-to-end: a rewrite whose hook runs 26 words (one over
+        # the ideal) must be APPROVED and produce a video — not sent to the
+        # needs_review dead end, and not spam a Telegram alert.
+        result = _good_rewrite()
+        result["hook"] = " ".join(["từ"] * 26)
+        with _mock_anthropic(result), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            out = drama_rewriter.rewrite_story(self.story_id)
+        self.assertIsNotNone(out)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+        alert.assert_not_called()
+
+    def test_paragraph_hook_still_blocked(self):
+        # Past the hard max the hook is a paragraph — structure went wrong,
+        # so the rewrite still lands in needs_review with an alert.
+        result = _good_rewrite()
+        result["hook"] = " ".join(["từ"] * 50)
+        with _mock_anthropic(result), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            drama_rewriter.rewrite_story(self.story_id)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "needs_review")
+        alert.assert_called_once()
+
     def test_invalid_rewrite_sets_needs_review_and_alerts(self):
         bad = _good_rewrite(word_count=50)
         with _mock_anthropic(bad), \
@@ -457,6 +523,59 @@ class TestRewriteAllScored(RewriterTestBase):
             count = drama_rewriter.rewrite_all_scored()
         mocked.assert_not_called()
         self.assertEqual(count, 0)
+
+
+class TestRevalidateNeedsReview(RewriterTestBase):
+    """Recovery path for stories stuck in 'needs_review' (issue #99)."""
+
+    def _stick(self, result: dict) -> None:
+        stories.update_status(
+            self.story_id, "needs_review",
+            rewritten_content=json.dumps(result, ensure_ascii=False),
+        )
+
+    def test_recovers_story_blocked_by_relaxed_rule(self):
+        # The story 574 shape: a complete rewrite blocked only by the old
+        # 25-word hook hard limit must be approved on re-validation — with the
+        # saved rewrite untouched and zero AI calls.
+        result = _good_rewrite()
+        result["hook"] = " ".join(["từ"] * 26)
+        self._stick(result)
+        count = drama_rewriter.revalidate_needs_review()
+        self.assertEqual(count, 1)
+        story = stories.get_story(self.story_id)
+        self.assertEqual(story["status"], "approved")
+        self.assertEqual(json.loads(story["rewritten_content"]), result)
+
+    def test_still_invalid_story_stays_needs_review(self):
+        self._stick(_good_rewrite(word_count=50))  # genuinely broken stub
+        count = drama_rewriter.revalidate_needs_review()
+        self.assertEqual(count, 0)
+        self.assertEqual(
+            stories.get_story(self.story_id)["status"], "needs_review"
+        )
+
+    def test_error_envelope_skipped(self):
+        # Unparseable-reply envelopes hold no rewrite to validate.
+        stories.update_status(
+            self.story_id, "needs_review",
+            rewritten_content='{"_rewrite_error": "prior failure", "_raw_reply": "x"}',
+        )
+        count = drama_rewriter.revalidate_needs_review()
+        self.assertEqual(count, 0)
+        self.assertEqual(
+            stories.get_story(self.story_id)["status"], "needs_review"
+        )
+
+    def test_malformed_content_skipped(self):
+        stories.update_status(
+            self.story_id, "needs_review", rewritten_content="not json at all"
+        )
+        count = drama_rewriter.revalidate_needs_review()
+        self.assertEqual(count, 0)
+        self.assertEqual(
+            stories.get_story(self.story_id)["status"], "needs_review"
+        )
 
 
 if __name__ == "__main__":

--- a/content-pipeline/tests/test_stories.py
+++ b/content-pipeline/tests/test_stories.py
@@ -155,6 +155,16 @@ class TestGetByStatus(StoriesTestBase):
         stories.insert_story("reddit", "g5", "raw")
         self.assertEqual(stories.get_pending(), stories.get_by_status("pending"))
 
+    def test_limit_none_returns_all(self):
+        # limit=None = unbounded sweep (SQLite LIMIT -1) — used by
+        # drama_rewriter --revalidate so rows beyond any fixed page size
+        # aren't forever hidden behind newer ones (Codex review, PR #100).
+        for i in range(15):
+            stories.insert_story("reddit", f"all{i}", "raw")
+        self.assertEqual(len(stories.get_by_status("pending", limit=None)), 15)
+        # Default stays bounded for the daily-pipeline callers.
+        self.assertEqual(len(stories.get_by_status("pending")), 10)
+
 
 class TestUpdateStatus(StoriesTestBase):
     def test_updates_status(self):


### PR DESCRIPTION
Fixes #99

## Root cause

- `_HOOK_MAX_WORDS = 25` là **hard threshold duy nhất còn sót** sau fix issue #86 (script word-count đã chuyển sang 2 dải soft/hard, hook thì chưa). Hook của story 574 ra **26 từ — vượt đúng 1 từ** — trên một rewrite hoàn chỉnh, và bị block y hệt script gãy.
- `needs_review` với **story** là ngõ cụt thật: `review_bot` chỉ review *video*; `rewrite_all_scored()` chủ động skip story `needs_review` (chống re-burn token Sonnet, issue #84); không có UI/lệnh nào đưa story ra khỏi trạng thái này.

## Thay đổi

- **`config.py`**: `DRAMA_HOOK_SOFT_MAX_WORDS=25` / `DRAMA_HOOK_HARD_MAX_WORDS=35`, env-overridable — mirror đúng thiết kế `DRAMA_SCRIPT_*` của #86.
- **`validate_rewrite_verdict()`** (2-tier như issue đề xuất): trả `(blocking, soft_notes)`.
  - Hook ≤25 từ: lý tưởng. 26–35 từ: **approve + log note** (không alert Telegram — alert là cho story cần người xử lý, note thì không). >35 từ (đoạn văn, không còn là hook 3s): mới block.
  - `validate_rewrite()` giữ nguyên API cũ (chỉ trả blocking) — mọi caller/test hiện có không đổi.
  - Approve path giờ log mọi soft note (cả note script của #86) từ **một** lần gọi verdict, bỏ lần gọi lặp `_script_length_verdict`.
- **`revalidate_needs_review()` + CLI `--revalidate`**: re-chạy validation trên story drama `needs_review` bằng ngưỡng HIỆN TẠI từ `rewritten_content` đã lưu — **zero call AI, zero cost** — approve story giờ pass; envelope `_rewrite_error` và content hỏng bị bỏ qua an toàn.

## Sau khi merge

Chạy 1 lần trên Mac Mini để gỡ kẹt story 574 (và mọi story cùng cảnh):

```bash
cd content-pipeline && python -m processors.drama_rewriter --revalidate
```

## Tests

- Boundary đủ 2 phía: 26 từ (case story 574) pass + có note; 35 pass; 36 block.
- End-to-end: hook 26 từ → `approved`, không alert; hook 50 từ → `needs_review` + alert.
- `revalidate_needs_review`: cứu story bị rule cũ block, giữ nguyên story còn lỗi thật, skip envelope lỗi/JSON hỏng.
- Full suite: **991 tests OK** (21 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrpWTGpLz5QmfziMn9FNkU