### PR TITLE
Drama: Google Sheets source bridge, 2-3 minute shorts, fix duplicated hook + subtitle desync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ content-pipeline/
 │   ├── reddit_collector.py      # Reddit JSON API (r/ChatGPT, r/artificial) — track AI
 │   ├── reddit_drama_collector.py # Reddit JSON listing (AITA, ProRevenge, ...) — track Drama (Phase 2, #78)
 │   ├── lemmy_drama_collector.py # Lemmy public API (open Reddit-alt) — track Drama (#78 follow-up)
-│   └── hf_drama_importer.py     # Bulk import HuggingFace AITA dataset → stories (#78 follow-up)
+│   ├── hf_drama_importer.py     # Bulk import HuggingFace AITA dataset → stories (#78 follow-up)
+│   └── gsheet_drama_importer.py # Google Sheets bridge: Make.com RSS / dán tay → stories (track Drama)
 ├── analytics/
 │   ├── youtube_puller.py       # Pull metric YouTube Analytics API v2 → video_metrics/channel_metrics (Phase 6)
 │   ├── tiktok_csv.py           # Parse CSV TikTok Studio → video_metrics (Phase 6)
@@ -243,6 +244,25 @@ Drama — chưa có logic chấm điểm/rewrite (Phase 3).
   drama do **deep backfill một lần** gánh. Con trỏ KHÔNG advance khi outage (mai
   retry cùng lát). *License:* dataset tái phân phối nội dung Reddit — kiểm tra
   terms từng dataset.
+- **`collectors/gsheet_drama_importer.py`** — cầu nối Google Sheets: phễu nạp
+  chung cho mọi nguồn pipeline KHÔNG cào trực tiếp được (xem
+  `docs/current/gsheet-drama-source.md`). Kiểm chứng 07/2026: Reddit RSS
+  (`/hot/.rss`) vẫn tồn tại nhưng chặn fetcher datacenter TỪNG ĐỢT (Make.com/
+  FreshRSS/RSS-Bridge đều dính 403 theo đợt); Quora topic RSS đã khai tử;
+  Facebook không có RSS chính thức. Nên kiến trúc = tách tầng cào khỏi tầng
+  nạp: **Make.com Free (1.000 ops/tháng, scenario RSS → Google Sheets "Add a
+  Row") hoặc dán tay drama Việt** đổ vào MỘT sheet; importer đọc **CSV export**
+  của sheet (share "Anyone with link – Viewer" hoặc Publish-to-web CSV; nhận cả
+  link `/edit` thường — tự đổi sang `export?format=csv`) bằng stdlib urllib
+  (UA `HTTP_USER_AGENT` #97, timeout + cap `GSHEET_MAX_BYTES`). Auto-dò cột
+  Title/Content/URL/Source (header Anh/Việt có dấu — nhớ map đ→d khi strip
+  accent), gỡ HTML (RSS content là HTML), dedupe `source_id` = hash URL (hoặc
+  hash title+content khi dán tay), cap `GSHEET_IMPORT_LIMIT`/lần chạy (mặc
+  định 30 — chống một cú dán lớn nã hết Haiku; phần dư tự vào lần sau). Sheet
+  chưa share → lỗi rõ "got an HTML page instead of CSV". Rỗng
+  `GSHEET_DRAMA_URL` = tắt (mặc định). Chạy trong bước collect `main_drama`
+  (best-effort như Reddit/Lemmy/HF) hoặc tay:
+  `python -m collectors.gsheet_drama_importer`.
 - **`storage/stories.py`** — CRUD cho bảng `stories`: `insert_story` (raise
   `sqlite3.IntegrityError` nếu `source_id` trùng — unique index từ migration
   002), `dedupe_check`, `get_pending(limit, track)`, `update_status` (chỉ
@@ -309,8 +329,19 @@ phạm vi: TTS/render video thật (Phase 4).
 - **`processors/drama_rewriter.py`** — module quan trọng nhất: Việt hoá story
   bằng Sonnet (đổi tên/địa điểm sang VN, thêm `vn_commentary` ≥20% thời
   lượng). `validate_rewrite()` là heuristic gate độc lập với prompt (word
-  count, `vn_commentary` ≥200 từ, hook ngắn — proxy cho cấu trúc "Hook 3s",
-  chặn tên/từ văn hoá Mỹ lọt qua). Rewrite hợp lệ →
+  count, `vn_commentary` ≥`DRAMA_COMMENTARY_MIN_WORDS`, hook ngắn — proxy cho
+  cấu trúc "Hook 3s", chặn tên/từ văn hoá Mỹ lọt qua).
+  **Format short 2-3 phút (prompt v2, yêu cầu chủ kênh):** format v1 (script
+  800-1200 từ, commentary ≥200) ra video ~6 phút — đo trên output thật, giọng
+  TTS drama đọc ~210-230 từ/phút chứ KHÔNG phải "60-90 giây" như prompt v1
+  ghi (cùng lớp lỗi word-count/duration của Phase 3/4). Mục tiêu 2-3 phút ⇒
+  tổng narration ~420-650 từ: `prompts/drama/rewriter.v2.txt` nhắm script
+  250-400 từ + commentary 80-120 từ + cấm script mở đầu bằng lặp lại
+  hook/title; các dải validate hạ tương ứng (soft 250-400, hard 150-600,
+  commentary min 60 — đều env-overridable). Rewriter chọn version qua
+  `DRAMA_REWRITER_PROMPT_VERSION` (mặc định **v2**, per-prompt — KHÔNG đụng
+  `PROMPT_VERSION` global vì scorer/theme_detect/longform vẫn v1); rollback
+  format 6 phút = đặt lại `v1` + nới các dải qua env. Rewrite hợp lệ →
   `status='approved'`; không hợp lệ → `status='needs_review'` + alert
   Telegram (nhưng output vẫn được lưu để người xem lại, không bị huỷ).
   **Beat "cộng đồng phán xử" — `vn_reactions` (issue #92 follow-up):** prompt v1
@@ -536,7 +567,20 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   từ issue #90 — HF là nguồn drama TIN CẬY, xem Phase 2). Seed thủ công
   (`seed_bot`) vẫn chảy qua vì score/rewrite/render đọc thẳng bảng `stories`.**
   Chọn story theo `created_at DESC` nên nội dung mới nạp (HF/Lemmy hôm nay) luôn
-  được ưu tiên trước backlog cũ. Resume: trạng
+  được ưu tiên trước backlog cũ.
+  **Fix "đọc tiêu đề 2 lần + phụ đề lệch audio":** model hay lặp lại hook/title
+  ở câu mở đầu script với khác biệt dấu câu/vài chữ; check containment RAW cũ
+  (`hook not in script`) trượt → narration đọc trùng, TỆ HƠN:
+  `subtitle_generator._split_into_segments` lại XOÁ segment trùng khỏi phụ đề
+  (audio vẫn đọc) nên mọi phụ đề sau điểm đó lệch timing (chế độ wordcount chia
+  thời lượng theo tỉ lệ từ). Fix 2 đầu: (1) `build_narration` dedupe theo NỘI
+  DUNG ĐỌC — `_spoken_duplicate()` chuẩn hoá (bỏ dấu câu/hoa thường) rồi check
+  containment + fuzzy match `SequenceMatcher ≥0.8` với ĐOẠN MỞ ĐẦU script (chỉ
+  prefix, không trượt cửa sổ cả bài — câu tình cờ giống ở giữa chuyện không cắt
+  oan hook); (2) `subtitle_generator` KHÔNG xoá segment trùng nữa — phụ đề phải
+  phản chiếu đúng những gì audio đọc, dedupe thuộc về tầng dựng narration (một
+  nguồn text cho cả TTS lẫn SRT). Prompt rewriter v2 cũng cấm script mở đầu
+  bằng hook (phòng từ gốc; check code là enforcement cho story cũ). Resume: trạng
   thái nằm hết trong DB; video row được insert TRƯỚC khi render (gắn
   `videos.story_id`) — lỗi transient PHÁT HIỆN ĐƯỢC (TTS/ffmpeg trả lỗi) →
   row `failed`, lần chạy sau tự retry; crash thật (row kẹt `draft`) chặn

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -99,6 +99,33 @@ HF_DRAMA_DAILY_ENABLED=1
 HF_DRAMA_DAILY_MODE=cursor
 HF_DAILY_LIMIT=10
 
+# --- Google Sheets drama bridge (phễu nguồn ngoài cho track Drama) ---
+# MỘT sheet làm điểm nạp chung cho mọi nguồn pipeline không cào trực tiếp được:
+#   * Make.com Free (1.000 ops/tháng): scenario RSS → Google Sheets "Add a Row"
+#     (vd Reddit https://www.reddit.com/r/AmItheAsshole/hot/.rss — Reddit chặn
+#     fetcher datacenter TỪNG ĐỢT nên coi đây là nguồn best-effort, không phải
+#     nguồn bảo đảm; xem docs/current/gsheet-drama-source.md).
+#   * Dán tay: confession/drama Việt — paste Title + Content vào sheet.
+# Sheet cần share "Anyone with the link – Viewer" (hoặc Publish to web → CSV).
+# Hàng đầu tiên là header: Title, Content (bắt buộc — hoặc "Tiêu đề"/"Nội
+# dung"), URL, Source (tuỳ chọn). Dán link sheet bất kỳ dạng nào vào đây;
+# để trống = tắt nguồn này.
+GSHEET_DRAMA_URL=
+GSHEET_IMPORT_LIMIT=30        # max story MỚI mỗi lần chạy (chống dán 300 dòng nã hết Haiku)
+GSHEET_MIN_BODY_CHARS=200     # bỏ hàng content quá ngắn (item RSS chỉ-có-link)
+
+# --- Drama video length (2-3 phút — yêu cầu chủ kênh) ---
+# Giọng TTS drama đọc ~210-230 từ/phút → tổng narration 2-3 phút ≈ 420-650 từ.
+# Prompt rewriter v2 nhắm script 250-400 từ + commentary 80-120 từ. Đổi các dải
+# validate ở đây nếu chỉnh mục tiêu độ dài; rollback format 6 phút cũ =
+# DRAMA_REWRITER_PROMPT_VERSION=v1 + nới lại các dải bên dưới.
+# DRAMA_REWRITER_PROMPT_VERSION=v2
+# DRAMA_SCRIPT_SOFT_MIN_WORDS=250
+# DRAMA_SCRIPT_SOFT_MAX_WORDS=400
+# DRAMA_SCRIPT_HARD_MIN_WORDS=150
+# DRAMA_SCRIPT_HARD_MAX_WORDS=600
+# DRAMA_COMMENTARY_MIN_WORDS=60
+
 # --- Pexels (free stock video backgrounds) ---
 PEXELS_API_KEY=...
 

--- a/content-pipeline/collectors/gsheet_drama_importer.py
+++ b/content-pipeline/collectors/gsheet_drama_importer.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+"""
+Google Sheets Drama Importer — cầu nối nguồn ngoài cho track Drama.
+
+Bối cảnh: Reddit khoá OAuth tự phục vụ (issue #78), Lemmy drama cạn (issue #90),
+còn các nguồn "béo bở" khác (Reddit RSS, confession Facebook, truyện dịch) đều
+KHÔNG có API ổn định để pipeline cào trực tiếp — Reddit chặn fetcher datacenter
+từng đợt (403), Facebook không có RSS chính thức, Quora đã khai tử RSS. Thay vì
+viết N collector mỏng manh cho N nguồn, module này đọc MỘT Google Sheet làm
+phễu nạp chung:
+
+    [Make.com RSS → Sheets]  ┐
+    [RSS.app / Zapier]       ├──► Google Sheet ──► collect_all_gsheet() ──► stories
+    [dán tay confession VN]  ┘
+
+- Tầng cào (Make.com Free 1.000 ops/tháng, RSS module + Google Sheets "Add a
+  Row") sống NGOÀI pipeline: khi Reddit chặn Make thì scenario nghỉ, sheet còn
+  nguyên, pipeline không hỏng. Đổi/thêm nguồn = sửa scenario, không đổi code.
+- Tầng nạp (module này) chỉ cần sheet share "Anyone with link – Viewer" (hoặc
+  Publish to web → CSV): tải CSV export bằng stdlib urllib, auto-dò cột
+  title/content/url/source (header Anh hoặc Việt), gỡ HTML (RSS content thường
+  là HTML), dedupe qua `source_id` rồi insert vào `stories` — từ đó
+  score → rewrite → render chạy như mọi nguồn khác.
+
+Setup chi tiết (tạo sheet, dựng scenario Make.com): docs/current/gsheet-drama-source.md.
+
+Chạy tay: python -m collectors.gsheet_drama_importer
+Trong pipeline: bước collect của main_drama.py gọi collect_all_gsheet()
+(best-effort như Reddit/Lemmy/HF — nguồn lỗi không kéo sập cả bước).
+"""
+
+import csv
+import hashlib
+import html
+import io
+import logging
+import re
+import urllib.error
+import urllib.request
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
+from storage.stories import insert_story, dedupe_check
+
+logger = logging.getLogger(__name__)
+
+SOURCE_NAME = "gsheet"
+
+# Header candidates per logical column, matched case-insensitively after
+# accent-stripping ("Tiêu đề" == "tieu de"). First hit wins, ordered by how
+# specific the name is. Make.com's RSS module maps naturally onto
+# Title/Content/URL; Vietnamese headers cover hand-maintained sheets.
+_COLUMN_CANDIDATES = {
+    "title": ("title", "tieu de", "headline", "subject", "ten bai"),
+    "content": ("content", "body", "noi dung", "story", "selftext", "text",
+                "description", "summary"),
+    "url": ("url", "link", "duong dan", "lien ket"),
+    "source": ("source", "nguon", "feed", "kenh"),
+}
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+class GSheetFetchError(Exception):
+    """Sheet unreachable/unusable (network, HTTP error, oversized, no CSV)."""
+
+
+def _strip_accents(text: str) -> str:
+    import unicodedata
+    # NFD tách dấu thanh/dấu mũ thành combining mark rồi bỏ; riêng đ/Đ là chữ
+    # cái độc lập (không decompose) nên map tay — thiếu nó "Tiêu đề" không bao
+    # giờ khớp candidate "tieu de".
+    text = text.replace("đ", "d").replace("Đ", "D")
+    return "".join(c for c in unicodedata.normalize("NFD", text)
+                   if unicodedata.category(c) != "Mn")
+
+
+def _export_csv_url(url: str) -> str:
+    """Chuyển link Google Sheet bất kỳ về dạng CSV export tải được.
+
+    Nhận cả 3 dạng người dùng hay dán:
+    - Link edit thường:  .../spreadsheets/d/<ID>/edit#gid=<GID>
+      → .../spreadsheets/d/<ID>/export?format=csv&gid=<GID> (share "Anyone
+      with link" là tải được, không cần Publish to web).
+    - Link đã Publish to web (…/pub?output=csv, /export?format=csv): giữ nguyên.
+    - URL CSV trực tiếp bất kỳ (không phải Google): giữ nguyên — cầu nối này
+      dùng được cho mọi nơi xuất CSV, không khoá vào Google.
+    """
+    m = re.search(r"docs\.google\.com/spreadsheets/d/([a-zA-Z0-9_-]+)", url)
+    if not m or "output=csv" in url or "format=csv" in url:
+        return url
+    sheet_id = m.group(1)
+    gid_match = re.search(r"[#?&]gid=(\d+)", url)
+    gid = gid_match.group(1) if gid_match else "0"
+    return (f"https://docs.google.com/spreadsheets/d/{sheet_id}/export"
+            f"?format=csv&gid={gid}")
+
+
+def _fetch_csv_text(url: str) -> str:
+    """Tải CSV (stdlib urllib, UA theo issue #97, cap dung lượng chống hostile)."""
+    request = urllib.request.Request(
+        _export_csv_url(url), headers={"User-Agent": config.HTTP_USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=config.GSHEET_TIMEOUT) as resp:
+            data = resp.read(config.GSHEET_MAX_BYTES + 1)
+    except (urllib.error.URLError, OSError, TimeoutError) as e:
+        raise GSheetFetchError(f"cannot fetch sheet: {e}") from e
+    if len(data) > config.GSHEET_MAX_BYTES:
+        raise GSheetFetchError(
+            f"sheet exceeds GSHEET_MAX_BYTES={config.GSHEET_MAX_BYTES} — "
+            "refusing oversized download")
+    # utf-8-sig: Google/Excel exports hay kèm BOM; lỗi decode thay bằng U+FFFD
+    # thay vì chết cả batch vì 1 byte hỏng.
+    text = data.decode("utf-8-sig", errors="replace")
+    # Trang HTML (login/permission) thay vì CSV = sheet chưa share công khai.
+    if text.lstrip()[:200].lower().startswith(("<!doctype", "<html")):
+        raise GSheetFetchError(
+            "got an HTML page instead of CSV — sheet chưa share "
+            "'Anyone with the link – Viewer' (hoặc chưa Publish to web dạng CSV)")
+    return text
+
+
+def _resolve_columns(header: list[str]) -> dict[str, int]:
+    """Map cột logic → index từ hàng header. Cần tối thiểu title + content."""
+    normalized = [_strip_accents(h or "").strip().lower() for h in header]
+    resolved: dict[str, int] = {}
+    for logical, candidates in _COLUMN_CANDIDATES.items():
+        for cand in candidates:
+            if cand in normalized:
+                resolved[logical] = normalized.index(cand)
+                break
+    missing = [c for c in ("title", "content") if c not in resolved]
+    if missing:
+        raise GSheetFetchError(
+            f"sheet header {header!r} thiếu cột {missing} — đặt tên cột là "
+            "Title/Content (hoặc 'Tiêu đề'/'Nội dung') ở hàng đầu tiên")
+    return resolved
+
+
+def _clean_html(text: str) -> str:
+    """RSS content (nhất là Reddit) là HTML — gỡ tag/entity về văn bản thuần."""
+    text = html.unescape(text or "")
+    text = re.sub(r"<br\s*/?>|</p>", "\n", text, flags=re.IGNORECASE)
+    text = _TAG_RE.sub(" ", text)
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+
+def _row_source_id(url: str, title: str, content: str) -> str:
+    """Dedupe key. Ưu tiên URL (ổn định khi Make nạp lại cùng bài); không có
+    URL (dán tay) thì hash title+content — dán lại y nguyên sẽ bị bỏ trùng."""
+    basis = url.strip() if url and url.strip() else f"{title}\n{content}"
+    return f"{SOURCE_NAME}:{hashlib.sha256(basis.encode('utf-8')).hexdigest()[:32]}"
+
+
+def collect_all_gsheet() -> int:
+    """Nạp story mới từ Google Sheet đã cấu hình. Trả về số story insert.
+
+    - GSHEET_DRAMA_URL rỗng → nguồn tắt, trả 0 (như REDDIT_ENABLED=0).
+    - Quét TOÀN BỘ hàng để dedupe, nhưng chỉ insert tối đa GSHEET_IMPORT_LIMIT
+      story mới mỗi lần chạy — một cú dán 300 dòng không nã hết ngân sách Haiku
+      của ngày; phần còn lại tự vào ở các lần chạy sau.
+    - Hàng thiếu title, content quá ngắn (< GSHEET_MIN_BODY_CHARS sau khi gỡ
+      HTML — item RSS chỉ-có-link, hàng rác) bị bỏ qua, có đếm log.
+    """
+    if not config.GSHEET_DRAMA_URL:
+        logger.info("Google Sheet drama source disabled (GSHEET_DRAMA_URL empty)")
+        return 0
+
+    text = _fetch_csv_text(config.GSHEET_DRAMA_URL)
+    rows = list(csv.reader(io.StringIO(text)))
+    if not rows:
+        logger.warning("Google Sheet is empty")
+        return 0
+
+    columns = _resolve_columns(rows[0])
+    inserted = skipped_dupe = skipped_thin = 0
+
+    for row in rows[1:]:
+        if inserted >= config.GSHEET_IMPORT_LIMIT:
+            logger.info("GSHEET_IMPORT_LIMIT=%d reached — remaining rows will "
+                        "import on later runs", config.GSHEET_IMPORT_LIMIT)
+            break
+
+        def _cell(logical: str) -> str:
+            idx = columns.get(logical)
+            return row[idx].strip() if idx is not None and idx < len(row) else ""
+
+        title = _cell("title")
+        content = _clean_html(_cell("content"))
+        url = _cell("url")
+        if not title or len(content) < config.GSHEET_MIN_BODY_CHARS:
+            skipped_thin += 1
+            continue
+
+        source_id = _row_source_id(url, title, content)
+        if dedupe_check(source_id):
+            skipped_dupe += 1
+            continue
+
+        feed = _cell("source")
+        metadata = {"origin": "gsheet"}
+        if url:
+            metadata["url"] = url
+        if feed:
+            metadata["feed"] = feed
+        insert_story(
+            source=SOURCE_NAME,
+            source_id=source_id,
+            raw_content=f"{title}\n\n{content}",
+            track="drama",
+            title=title,
+            metadata=metadata,
+        )
+        inserted += 1
+
+    logger.info(
+        "Google Sheet import: %d new, %d duplicate, %d thin/skipped (rows=%d)",
+        inserted, skipped_dupe, skipped_thin, len(rows) - 1,
+    )
+    return inserted
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    from storage.database import init_db
+    init_db()
+    print(f"Imported {collect_all_gsheet()} stories from Google Sheet")

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -322,6 +322,13 @@ def validate_flags(logger=None):
 # Rollback = change this env var, no code change needed.
 PROMPT_VERSION = os.getenv("PROMPT_VERSION", "v1")
 
+# Per-prompt override for the rewriter only. PROMPT_VERSION is global (scorer/
+# theme_detect/longform all resolve through it), so bumping it to v2 would
+# demand a v2 file for every prompt. The rewriter moved to v2 alone (2-3 minute
+# short target — see the word-count bands below); rollback to the old 6-minute
+# format = DRAMA_REWRITER_PROMPT_VERSION=v1.
+DRAMA_REWRITER_PROMPT_VERSION = os.getenv("DRAMA_REWRITER_PROMPT_VERSION", "v2")
+
 # Drama rubric scoring threshold (out of 6 criteria) — story must score
 # >= this AND safe=1 to proceed to the rewriter.
 #
@@ -338,22 +345,17 @@ PROMPT_VERSION = os.getenv("PROMPT_VERSION", "v1")
 DRAMA_SCORE_THRESHOLD = int(os.getenv("DRAMA_SCORE_THRESHOLD", "4"))
 
 # Output token ceiling for drama_rewriter's Sonnet call (issue #82). The
-# rewriter must emit an 800-1200 word Vietnamese script + a >=200 word
-# vn_commentary + title/hook/thumbnail_prompt/tags, all inside a JSON wrapper.
-# Vietnamese tokenizes at roughly ~2 tokens/word (diacritics), so even the
-# shortest valid output runs ~2500+ tokens — the old 2000 ceiling truncated
-# the JSON mid-generation (stop_reason='max_tokens'), leaving no closing brace
-# and yielding the misleading "No JSON object found". 4096 gives headroom over
-# the ~3300-token worst case and matches drama_compiler's ceiling. The rewriter
+# rewriter emits the Vietnamese script + vn_commentary + title/hook/
+# thumbnail_prompt/tags, all inside a JSON wrapper. Vietnamese tokenizes at
+# roughly ~2 tokens/word (diacritics); the old 2000 ceiling truncated the
+# 800-1200-word v1 format mid-JSON (stop_reason='max_tokens'), yielding the
+# misleading "No JSON object found". The v2 short target (~400-550 words total)
+# fits comfortably under 4096; keeping the ceiling unchanged costs nothing
+# (only actual output tokens bill) and still covers a v1 rollback. The rewriter
 # escalates from here (x1.5, x2) if a run still truncates.
 DRAMA_REWRITER_MAX_TOKENS = int(os.getenv("DRAMA_REWRITER_MAX_TOKENS", "4096"))
 
-# Drama rewriter script word-count validation (issue #86). The prompt asks
-# Sonnet for an 800-1200 word script, but an LLM never hits an exact target —
-# story #2 came back at 733 words (a complete, substantial script, just 67 words
-# shy) and was hard-rejected identically to a broken stub, so the whole run
-# rendered 0 videos. The fix separates the "ideal target" from the "reject
-# floor": validation now uses two bands.
+# Drama rewriter script word-count validation (issue #86) — two bands:
 #   - [SOFT_MIN, SOFT_MAX]                    ideal → approve cleanly
 #   - [HARD_MIN, SOFT_MIN) or (SOFT_MAX, HARD_MAX]
 #                                             short/long of ideal but still a
@@ -361,14 +363,26 @@ DRAMA_REWRITER_MAX_TOKENS = int(os.getenv("DRAMA_REWRITER_MAX_TOKENS", "4096"))
 #                                             with a logged note (observability)
 #   - < HARD_MIN or > HARD_MAX                genuinely broken (truncated stub /
 #                                             runaway or looping output) → reject
-# Short-form drama runs ~45-90s TTS, so 600 words is a sane floor for a complete
-# script; 1500 caps runaway output before the video budget blows out. The prompt
-# keeps aiming for 800-1200 (aspirational) — we only widen what we'll *accept*.
-# All env-overridable so the bands can be tuned without a code change.
-DRAMA_SCRIPT_SOFT_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MIN_WORDS", "800"))
-DRAMA_SCRIPT_SOFT_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MAX_WORDS", "1200"))
-DRAMA_SCRIPT_HARD_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MIN_WORDS", "600"))
-DRAMA_SCRIPT_HARD_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MAX_WORDS", "1500"))
+# Recalibrated for the 2-3 MINUTE short target (channel-owner request): the old
+# 800-1200-word v1 prompt produced ~6-minute videos — measured on real output,
+# the drama TTS voice speaks ~210-230 words/minute, NOT the "60-90s" the v1
+# prompt claimed (same class of word-count/duration doc error as Phase 3/4).
+# Total narration for 2-3 min = ~420-650 words; the script's share (after hook
+# ~20 + reactions ~50 + commentary ~100) is ideally 250-400. Floor 150 still
+# rejects truncated stubs; ceiling 600 rejects runaway output that would push
+# the video back past ~3.5 minutes. The prompt (rewriter.v2.txt) aims for
+# 250-400 (aspirational) — the bands are what we *accept*. All env-overridable.
+DRAMA_SCRIPT_SOFT_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MIN_WORDS", "250"))
+DRAMA_SCRIPT_SOFT_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_SOFT_MAX_WORDS", "400"))
+DRAMA_SCRIPT_HARD_MIN_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MIN_WORDS", "150"))
+DRAMA_SCRIPT_HARD_MAX_WORDS = int(os.getenv("DRAMA_SCRIPT_HARD_MAX_WORDS", "600"))
+
+# Minimum vn_commentary length. Was a hardcoded 200-word module constant sized
+# for the ~6-minute v1 format; at 2-3 minutes total, 200 words of commentary
+# alone would eat half the video. 60 words keeps the "unique Vietnamese
+# perspective" transformative beat (still ~20% of a ~2.5-minute narration)
+# without crowding out the story. Env-overridable like the script bands.
+DRAMA_COMMENTARY_MIN_WORDS = int(os.getenv("DRAMA_COMMENTARY_MIN_WORDS", "60"))
 
 # Drama rewriter hook length validation (issue #99) — same two-band design as
 # the script word count above (issue #86); the hook was the one length check
@@ -512,6 +526,30 @@ HF_CSV_MAX_BYTES = int(os.getenv("HF_CSV_MAX_BYTES", str(2 * 1024 ** 3)))
 # Cached CSV freshness in days; 0 = never expire (the default dump is STATIC, so a
 # stale-forever cache is correct). Set >0 only for a dataset you expect to change.
 HF_CSV_CACHE_TTL_DAYS = int(os.getenv("HF_CSV_CACHE_TTL_DAYS", "0"))
+
+# --- Google Sheets drama bridge (external-source funnel) ---
+# One stable, free ingestion point for every source the pipeline can't (or
+# shouldn't) scrape directly: a Google Sheet that external automations write
+# rows into, which collect_all_gsheet() reads back as stories.
+#   * Make.com Free (1,000 ops/tháng): RSS (Reddit hot/.rss, hoặc bất kỳ feed
+#     nào) → Google Sheets "Add a Row". Reddit chặn fetcher datacenter từng đợt
+#     (403) — khi Make bị chặn thì scenario đó nghỉ, sheet vẫn còn, pipeline
+#     không hỏng: cầu nối này cố ý tách "nguồn cào" khỏi "nguồn nạp".
+#   * Dán tay: drama Việt (confession FB, group "hóng biến", truyện dịch) —
+#     paste thẳng title + content vào sheet, không cần Make.
+# Sheet cần share "Anyone with the link – Viewer" (hoặc File → Share → Publish
+# to web → CSV). GSHEET_DRAMA_URL nhận cả link /edit thường lẫn link CSV đã
+# publish — collector tự đổi sang dạng export CSV. Rỗng = tắt (mặc định).
+GSHEET_DRAMA_URL = os.getenv("GSHEET_DRAMA_URL", "")
+# Max NEW stories imported per run (the whole sheet is still scanned for
+# dedupe). Keeps one giant paste-dump from flooding a day's Haiku scoring.
+GSHEET_IMPORT_LIMIT = int(os.getenv("GSHEET_IMPORT_LIMIT", "30"))
+# Rows whose content (after HTML stripping) is shorter than this are skipped —
+# link-only RSS items and junk rows carry no story to rewrite.
+GSHEET_MIN_BODY_CHARS = int(os.getenv("GSHEET_MIN_BODY_CHARS", "200"))
+GSHEET_TIMEOUT = int(os.getenv("GSHEET_TIMEOUT", "30"))
+# Download cap — a sheet is small; 20MB means something is wrong (or hostile).
+GSHEET_MAX_BYTES = int(os.getenv("GSHEET_MAX_BYTES", str(20 * 1024 * 1024)))
 
 # Drama backlog alert (issue #78 follow-up). With Reddit off by default, the
 # Drama channel is fed by manual seeds — so the meaningful health signal is "not

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -34,8 +34,10 @@ import json
 import logging
 import logging.handlers
 import os
+import re
 import sys
 from datetime import date, datetime
+from difflib import SequenceMatcher
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -65,13 +67,48 @@ logger = logging.getLogger(__name__)
 DRAMA_DESTINATION = "drama_youtube"  # khoá trong channels.py
 
 
+def _normalize_speech(text: str) -> str:
+    """Chuẩn hoá text để so trùng NỘI DUNG ĐỌC: bỏ dấu câu, hạ chữ thường,
+    gộp whitespace. Hai câu chỉ khác dấu chấm/phẩy/xuống dòng đọc lên y hệt
+    nhau — so sánh raw string sẽ trượt các bản trùng kiểu đó.
+    """
+    return " ".join(re.sub(r"[^\w\s]", " ", text.lower()).split())
+
+
+def _spoken_duplicate(part: str, whole: str) -> bool:
+    """True nếu `part` đã được đọc bên trong `whole` (trùng nội dung nói).
+
+    Hai tầng — cả hai chạy trên text đã _normalize_speech():
+    1. Containment: `part` xuất hiện nguyên văn (sau chuẩn hoá) trong `whole`.
+    2. Fuzzy prefix: model hay lặp lại hook/title ở CÂU MỞ ĐẦU script với vài
+       chữ xê dịch ("Tôi không ngờ chồng mình..." vs "Không ngờ chồng mình...")
+       — exact match trượt nhưng người nghe vẫn nghe "đọc tiêu đề 2 lần".
+       So SequenceMatcher giữa `part` và đoạn đầu cùng độ dài của `whole`;
+       >= 0.8 coi là trùng. Chỉ so PREFIX (không trượt cửa sổ cả bài) để một
+       câu tình cờ giống ở giữa chuyện không bị cắt oan.
+    """
+    p, w = _normalize_speech(part), _normalize_speech(whole)
+    if not p or not w:
+        return False
+    if p in w:
+        return True
+    p_words, w_words = p.split(), w.split()
+    prefix = " ".join(w_words[:len(p_words)])
+    return SequenceMatcher(None, p, prefix).ratio() >= 0.8
+
+
 def build_narration(rewrite: dict) -> str:
     """Ghép text TTS từ output rewriter: hook + script + vn_reactions + vn_commentary.
 
-    Prompt rewriter (prompts/drama/rewriter.v1.txt) trả hook/vn_commentary/
-    vn_reactions thành FIELD RIÊNG nhưng script cũng có cấu trúc "Hook → ...
-    → Reflection", nên model có thể đã lặp các phần này bên trong script. Kiểm
-    tra containment trước khi ghép để không đọc trùng 2 lần.
+    Prompt rewriter trả hook/vn_commentary/vn_reactions thành FIELD RIÊNG nhưng
+    model có thể đã lặp các phần này bên trong script (nhất là hook/title ở câu
+    mở đầu). Bản cũ chỉ check substring RAW — hook lặp lại với khác biệt dấu
+    câu/vài chữ vẫn lọt, khiến video đọc tiêu đề 2 lần; tệ hơn,
+    subtitle_generator lại XOÁ segment trùng khỏi phụ đề (audio thì vẫn đọc)
+    nên toàn bộ phụ đề phía sau lệch timing. Fix tận gốc tại đây: so trùng
+    theo NỘI DUNG ĐỌC (bỏ dấu câu/hoa thường) + fuzzy match câu mở đầu script
+    (xem _spoken_duplicate). Prompt v2 cũng cấm script mở đầu bằng hook —
+    check này là enforcement cho story cũ lẫn model không nghe lời.
 
     `vn_reactions` (beat "cộng đồng phán xử" Việt hoá từ top comments Reddit —
     issue #92 follow-up) đặt SAU script, TRƯỚC commentary: story → đám đông phán
@@ -89,13 +126,15 @@ def build_narration(rewrite: dict) -> str:
     commentary = strip_nonspeech_artifacts((rewrite.get("vn_commentary") or "").strip())
 
     parts = []
-    if hook and hook not in script:
+    if hook and not _spoken_duplicate(hook, script):
         parts.append(hook)
+    elif hook and script:
+        logger.info("Hook already spoken at the start of script — not repeating it")
     if script:
         parts.append(script)
-    if reactions and reactions not in script:
+    if reactions and not _spoken_duplicate(reactions, script):
         parts.append(reactions)
-    if commentary and commentary not in script:
+    if commentary and not _spoken_duplicate(commentary, script):
         parts.append(commentary)
     return "\n\n".join(parts)
 
@@ -285,15 +324,18 @@ def run_daily(steps: list[str] | None = None, limit: int | None = None) -> dict:
 
     if "collect" in steps:
         collected = 0
-        # Reddit (off by default, issue #78) + Lemmy (open Reddit-alternative).
-        # Each source is independent: one failing doesn't sink the other or the
-        # rest of the pipeline.
-        for name, collector in (("reddit", "collectors.reddit_drama_collector"),
-                                ("lemmy", "collectors.lemmy_drama_collector")):
+        # Reddit (off by default, issue #78) + Lemmy (open Reddit-alternative)
+        # + Google Sheet bridge (external funnel: Make.com RSS / manual paste —
+        # off until GSHEET_DRAMA_URL is set). Each source is independent: one
+        # failing doesn't sink the others or the rest of the pipeline.
+        for name, collector, fn_name in (
+            ("reddit", "collectors.reddit_drama_collector", "collect_all_drama"),
+            ("lemmy", "collectors.lemmy_drama_collector", "collect_all_lemmy"),
+            ("gsheet", "collectors.gsheet_drama_importer", "collect_all_gsheet"),
+        ):
             try:
                 mod = __import__(collector, fromlist=["*"])
-                fn = getattr(mod, "collect_all_drama", None) or getattr(mod, "collect_all_lemmy")
-                collected += fn()
+                collected += getattr(mod, fn_name)()
             except Exception as e:
                 logger.error("Collect (%s) failed: %s", name, e)
                 summary["errors"].append(f"collect[{name}]: {e}")

--- a/content-pipeline/processors/drama_rewriter.py
+++ b/content-pipeline/processors/drama_rewriter.py
@@ -49,7 +49,6 @@ _RESPONSE_SNIPPET_CHARS = 600
 _JSON_PREFILL = "{"
 
 _REQUIRED_FIELDS = ("title", "hook", "script", "vn_commentary", "thumbnail_prompt", "tags")
-_VN_COMMENTARY_MIN_WORDS = 200
 
 # Heuristic guard against the 2 failure modes called out in
 # phase-3-detailed.md's risk section: half-Western character names (e.g.
@@ -151,9 +150,10 @@ def validate_rewrite_verdict(result: dict) -> tuple[list[str], list[str]]:
     Checked (per phase-3-detailed.md EPIC #3.2 "Validation post-rewrite"):
     - all required fields present and non-empty
     - `script` word count within the accepted band [HARD_MIN, HARD_MAX]
-      (issue #86: the ideal is [SOFT_MIN, SOFT_MAX] = 800-1200, but a script
-      merely short/long of ideal is accepted, not blocked)
-    - `vn_commentary` >= 200 words
+      (issue #86: the ideal is [SOFT_MIN, SOFT_MAX], but a script merely
+      short/long of ideal is accepted, not blocked; bands live in config —
+      recalibrated for the 2-3 minute short target)
+    - `vn_commentary` >= config.DRAMA_COMMENTARY_MIN_WORDS
     - `hook` is a short punchy line, not a paragraph (issue #99: two-band —
       slightly-long approves with a note, only a paragraph blocks)
     - no common Western name fragments / US-culture terms leaking through
@@ -185,10 +185,10 @@ def validate_rewrite_verdict(result: dict) -> tuple[list[str], list[str]]:
         notes.append(soft)
 
     commentary_count = len(result["vn_commentary"].split())
-    if commentary_count < _VN_COMMENTARY_MIN_WORDS:
+    if commentary_count < config.DRAMA_COMMENTARY_MIN_WORDS:
         issues.append(
             f"vn_commentary only {commentary_count} words "
-            f"(need >= {_VN_COMMENTARY_MIN_WORDS})"
+            f"(need >= {config.DRAMA_COMMENTARY_MIN_WORDS})"
         )
 
     # vn_reactions is OPTIONAL (only stories carrying comments have it), so it's
@@ -351,7 +351,10 @@ def rewrite_story(story_id: int) -> dict | None:
         logger.error("Story %d not found", story_id)
         return None
 
-    prompt_template = load_prompt("drama", "rewriter")
+    # Per-prompt version: the rewriter moved to v2 (2-3 minute short target)
+    # independently of the global PROMPT_VERSION — see config for the rationale.
+    prompt_template = load_prompt("drama", "rewriter",
+                                  version=config.DRAMA_REWRITER_PROMPT_VERSION)
     prompt = render(prompt_template, RAW_CONTENT=(story["raw_content"] or "")[:4000])
 
     client = anthropic.Anthropic(api_key=config.ANTHROPIC_API_KEY)

--- a/content-pipeline/prompts/drama/rewriter.v2.txt
+++ b/content-pipeline/prompts/drama/rewriter.v2.txt
@@ -1,0 +1,32 @@
+Bạn là người kể chuyện cho kênh YouTube/TikTok drama tiếng Việt.
+Phong cách: kể chuyện ngôi thứ nhất, ngôn ngữ đời thường, có cảm xúc.
+Đối tượng: phụ nữ Việt 22-50 tuổi, nghe khi nấu cơm/đi xe.
+
+Định dạng video: SHORT 2-3 PHÚT — kể nhanh, vào chuyện ngay, không lan man.
+
+Quy tắc bắt buộc:
+1. Đổi tên nhân vật sang tên Việt (Linh, Tuấn, Mai, Hùng, Thu...)
+2. Đổi địa điểm sang Việt Nam (Quận 1, Hà Đông, chung cư X, công ty Y)
+3. Đổi văn hoá đặc thù: mâm cơm Việt, lì xì Tết, sếp người Việt, mẹ chồng nàng dâu, hội bạn nhậu
+4. THÊM 1 đoạn "bình luận góc nhìn Việt" khoảng 80-120 từ - đây là điểm tạo unique value (không có trong Reddit gốc)
+5. Cấu trúc script: Setup nhanh → Leo thang → Twist/Cao trào → Kết. Chỉ giữ 1 tuyến xung đột chính, cắt hết chi tiết phụ không phục vụ cao trào.
+6. Độ dài: "script" 250-400 từ. TỔNG các phần đọc (hook + script + vn_reactions + vn_commentary) khoảng 400-550 từ — tương đương 2-3 phút TTS. TUYỆT ĐỐI không viết dài hơn.
+7. "script" KHÔNG được mở đầu bằng cách lặp lại "title" hay "hook" — hook là field riêng và sẽ được đọc TRƯỚC script, lặp lại sẽ khiến video đọc trùng 2 lần. Script bắt đầu thẳng vào bối cảnh câu chuyện.
+8. KHÔNG dùng ngôn từ 18+, không nhắc tên người thật, không vu khống
+9. Đặt câu chuyện HOÀN TOÀN ở Việt Nam - KHÔNG nhắc tới đô la Mỹ, mall, prom, Thanksgiving, hay bất kỳ chi tiết văn hoá Mỹ nào khác
+10. Tên nhân vật phải THUẦN VIỆT (họ + tên đệm + tên, 2-3 từ, vd "Nguyễn Thị Mai") - KHÔNG đặt tên nửa Tây nửa Việt (vd "Linh Smith")
+11. PHẢN ỨNG CỘNG ĐỒNG: nếu STORY GỐC có mục "TOP COMMENTS FROM REDDIT" (bình luận cư dân mạng), hãy DỰA THEO TINH THẦN các bình luận đó viết field "vn_reactions" - 2-3 câu bình luận NGẮN (tổng dưới 60 từ), gay gắt hoặc hài hước, GIỌNG cư dân mạng Việt (vd "Trời ơi bên nhà trai quá đáng thật sự luôn", "Đọc mà tức thay cho chị"). Đây là beat "cộng đồng phán xử" đặt gần cuối trước Reflection để tăng độ hook và mời người xem vào bình luận. Việt hoá HOÀN TOÀN (KHÔNG giữ verdict tiếng Anh kiểu YTA/NTA/ESH), viết dạng VĂN XUÔI liền mạch để đọc TTS (KHÔNG gạch đầu dòng, KHÔNG emoji). Nếu STORY GỐC KHÔNG có mục bình luận thì để "vn_reactions" là chuỗi RỖNG "".
+
+STORY GỐC (tiếng Anh từ Reddit, hoặc seed VN-original):
+{{RAW_CONTENT}}
+
+Trả lời CHỈ bằng JSON, không giải thích thêm:
+{
+  "title": "<tiêu đề câu hook 1 dòng>",
+  "hook": "<3 giây đầu, KHÁC câu mở đầu của script>",
+  "script": "<full script 250-400 từ, KHÔNG lặp lại hook>",
+  "vn_commentary": "<đoạn bình luận góc nhìn Việt, riêng, khoảng 80-120 từ>",
+  "vn_reactions": "<phản ứng cư dân mạng VN Việt hoá từ TOP COMMENTS; chuỗi rỗng nếu story gốc không có bình luận>",
+  "thumbnail_prompt": "<mô tả ảnh AI cho thumbnail>",
+  "tags": ["<tag1>", "<tag2>"]
+}

--- a/content-pipeline/tests/test_drama_quality.py
+++ b/content-pipeline/tests/test_drama_quality.py
@@ -4,8 +4,9 @@ bằng heuristics (số từ, tên VN, structure)").
 
 Unlike tests/test_drama_rewriter.py's TestValidateRewrite (which isolates
 one failure mode per test case), this module runs whole realistic-looking
-rewrite outputs — the kind processors/drama_rewriter.py actually produces —
-through validate_rewrite() and checks the aggregate verdict. It's the
+rewrite outputs — the kind processors/drama_rewriter.py actually produces
+under the v2 prompt (2-3 minute short: script ~250-400 words, commentary
+~80-120) — through validate_rewrite() and checks the aggregate verdict. It's the
 fixture set a human would use to sanity-check a new prompt version against
 (see docs/current/prompts-decisions.md "Cách tune sang v2").
 """
@@ -41,9 +42,9 @@ GOOD_REWRITE_1 = {
         "Chị dâu tôi, tên Trần Thị Hoa, bắt đầu đòi chia tài sản ngay lập tức.",
         "Cả nhà tôi sốc, không ai nghĩ chị lại làm vậy giữa lúc tang gia bối rối.",
         "Cuối cùng, sự thật về khoản nợ chị giấu kín mới lộ ra.",
-    ], target_words=900),
+    ], target_words=320),
     "vn_commentary": " ".join(
-        ["Góc nhìn của tôi là chuyện tài sản trong gia đình Việt luôn nhạy cảm."] * 40
+        ["Góc nhìn của tôi là chuyện tài sản trong gia đình Việt luôn nhạy cảm."] * 8
     ),
     "thumbnail_prompt": "shocked Vietnamese woman standing in front of family house, dramatic lighting",
     "tags": ["#giadinh", "#drama", "#chiadau"],
@@ -58,9 +59,9 @@ GOOD_REWRITE_2 = {
         "Tôi cắn răng chịu đựng vì sợ mất việc trong lúc kinh tế khó khăn.",
         "Đến khi phát hiện đồng nghiệp khác cũng bị vậy, tôi quyết định lên tiếng.",
         "Kết quả bất ngờ hơn tôi nghĩ rất nhiều.",
-    ], target_words=1000),
+    ], target_words=350),
     "vn_commentary": " ".join(
-        ["Văn hoá làm thêm giờ không lương ở nhiều công ty Việt Nam vẫn còn phổ biến."] * 45
+        ["Văn hoá làm thêm giờ không lương ở nhiều công ty Việt Nam vẫn còn phổ biến."] * 7
     ),
     "thumbnail_prompt": "tired Vietnamese office worker at desk late at night, dramatic office lighting",
     "tags": ["#congso", "#drama", "#luong"],

--- a/content-pipeline/tests/test_drama_rewriter.py
+++ b/content-pipeline/tests/test_drama_rewriter.py
@@ -16,7 +16,7 @@ import storage.stories as stories
 import processors.drama_rewriter as drama_rewriter
 
 
-def _good_rewrite(word_count: int = 900, commentary_words: int = 220) -> dict:
+def _good_rewrite(word_count: int = 300, commentary_words: int = 100) -> dict:
     return {
         "title": "Sếp bắt làm thêm giờ không lương",
         "hook": "Ba năm đi làm, tôi chưa từng nghĩ mình sẽ bị đối xử như vậy.",
@@ -71,19 +71,21 @@ class TestValidateRewrite(unittest.TestCase):
         self.assertTrue(any("missing/empty" in i for i in issues))
 
     def test_script_too_short_flagged(self):
-        # Below the hard floor (600) — a stub, still a blocking issue.
-        issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=100))
+        # Below the hard floor — a stub, still a blocking issue.
+        issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=50))
         self.assertTrue(any("word count" in i for i in issues))
 
     def test_script_too_long_flagged(self):
-        # Above the hard ceiling (1500) — runaway output, still blocked.
+        # Above the hard ceiling — runaway output, still blocked.
         issues = drama_rewriter.validate_rewrite(_good_rewrite(word_count=2000))
         self.assertTrue(any("word count" in i for i in issues))
 
     def test_script_below_ideal_but_above_hard_min_passes(self):
-        # Issue #86: a complete 733-word script (short of the 800 ideal but well
-        # above the 600 floor) must NOT be rejected — that was the whole bug.
-        self.assertEqual(drama_rewriter.validate_rewrite(_good_rewrite(word_count=733)), [])
+        # Issue #86: a complete script short of the ideal band but above the
+        # hard floor must NOT be rejected — that was the whole bug.
+        word_count = drama_rewriter.config.DRAMA_SCRIPT_SOFT_MIN_WORDS - 50
+        self.assertEqual(
+            drama_rewriter.validate_rewrite(_good_rewrite(word_count=word_count)), [])
 
     def test_script_at_hard_min_boundary_passes(self):
         self.assertEqual(
@@ -116,7 +118,9 @@ class TestValidateRewrite(unittest.TestCase):
         self.assertTrue(any("word count" in i for i in issues))
 
     def test_short_vn_commentary_flagged(self):
-        issues = drama_rewriter.validate_rewrite(_good_rewrite(commentary_words=50))
+        too_short = drama_rewriter.config.DRAMA_COMMENTARY_MIN_WORDS - 10
+        issues = drama_rewriter.validate_rewrite(
+            _good_rewrite(commentary_words=too_short))
         self.assertTrue(any("vn_commentary only" in i for i in issues))
 
     def test_overlong_hook_flagged(self):
@@ -164,11 +168,13 @@ class TestValidateRewrite(unittest.TestCase):
     def test_verdict_collects_script_soft_note(self):
         # The two-tier verdict carries the issue #86 script note too, so the
         # approve path logs every soft signal from one call.
+        word_count = drama_rewriter.config.DRAMA_SCRIPT_SOFT_MIN_WORDS - 50
         issues, notes = drama_rewriter.validate_rewrite_verdict(
-            _good_rewrite(word_count=733)
+            _good_rewrite(word_count=word_count)
         )
         self.assertEqual(issues, [])
-        self.assertTrue(any("script word count 733" in n for n in notes))
+        self.assertTrue(
+            any(f"script word count {word_count}" in n for n in notes))
 
     def test_western_name_fragment_flagged(self):
         result = _good_rewrite()
@@ -325,10 +331,11 @@ class TestRewriteStory(RewriterTestBase):
         self.assertIn("Sếp bắt", story["rewritten_content"])
 
     def test_below_ideal_script_still_approved(self):
-        # Issue #86 end-to-end: a 733-word rewrite (short of the 800 ideal but
-        # above the 600 floor) must be APPROVED and produce a video, not sent to
+        # Issue #86 end-to-end: a rewrite short of the ideal band but above the
+        # hard floor must be APPROVED and produce a video, not sent to
         # needs_review. Regression for "pipeline rendered 0 videos".
-        with _mock_anthropic(_good_rewrite(word_count=733)), \
+        word_count = drama_rewriter.config.DRAMA_SCRIPT_SOFT_MIN_WORDS - 50
+        with _mock_anthropic(_good_rewrite(word_count=word_count)), \
              patch("notifier.telegram_bot.send_alert") as alert:
             result = drama_rewriter.rewrite_story(self.story_id)
         self.assertIsNotNone(result)

--- a/content-pipeline/tests/test_gsheet_drama_importer.py
+++ b/content-pipeline/tests/test_gsheet_drama_importer.py
@@ -1,0 +1,147 @@
+"""Tests for collectors/gsheet_drama_importer.py (Google Sheets drama bridge)."""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import storage.database as db
+import storage.migrate as migrate
+import storage.stories as stories
+import collectors.gsheet_drama_importer as importer
+
+
+LONG_BODY = " ".join(["Câu chuyện drama dài đủ để vượt ngưỡng ký tự tối thiểu."] * 10)
+
+
+def _csv(rows: list[list[str]]) -> str:
+    import csv
+    import io
+    buf = io.StringIO()
+    csv.writer(buf).writerows(rows)
+    return buf.getvalue()
+
+
+class TestExportCsvUrl(unittest.TestCase):
+    def test_edit_link_converted_to_export(self):
+        url = "https://docs.google.com/spreadsheets/d/abc123XYZ_-/edit#gid=42"
+        self.assertEqual(
+            importer._export_csv_url(url),
+            "https://docs.google.com/spreadsheets/d/abc123XYZ_-/export?format=csv&gid=42",
+        )
+
+    def test_edit_link_without_gid_defaults_to_zero(self):
+        url = "https://docs.google.com/spreadsheets/d/abc123/edit"
+        self.assertIn("gid=0", importer._export_csv_url(url))
+
+    def test_published_csv_link_untouched(self):
+        url = "https://docs.google.com/spreadsheets/d/e/2PACX/pub?output=csv"
+        self.assertEqual(importer._export_csv_url(url), url)
+
+    def test_non_google_url_untouched(self):
+        url = "https://example.com/stories.csv"
+        self.assertEqual(importer._export_csv_url(url), url)
+
+
+class TestResolveColumns(unittest.TestCase):
+    def test_english_headers(self):
+        cols = importer._resolve_columns(["Title", "Content", "URL", "Source"])
+        self.assertEqual(cols, {"title": 0, "content": 1, "url": 2, "source": 3})
+
+    def test_vietnamese_headers_with_accents(self):
+        cols = importer._resolve_columns(["Tiêu đề", "Nội dung", "Link"])
+        self.assertEqual(cols["title"], 0)
+        self.assertEqual(cols["content"], 1)
+        self.assertEqual(cols["url"], 2)
+
+    def test_missing_content_column_raises(self):
+        with self.assertRaises(importer.GSheetFetchError):
+            importer._resolve_columns(["Title", "Ngày"])
+
+
+class TestCleanHtml(unittest.TestCase):
+    def test_strips_tags_and_entities(self):
+        html_in = "<p>My MIL said &quot;no&quot;.<br/>Then she left.</p>"
+        out = importer._clean_html(html_in)
+        self.assertNotIn("<", out)
+        self.assertIn('"no"', out)
+        self.assertIn("Then she left.", out)
+
+
+class TestCollectAllGsheet(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.dbpath = os.path.join(self.tmp, "test.db")
+        self._patch = patch.object(db.config, "DB_PATH", self.dbpath)
+        self._patch.start()
+        db.init_db()
+        migrate.migrate_up()
+        self._url_patch = patch.object(
+            importer.config, "GSHEET_DRAMA_URL",
+            "https://docs.google.com/spreadsheets/d/test/edit")
+        self._url_patch.start()
+
+    def tearDown(self):
+        self._url_patch.stop()
+        self._patch.stop()
+
+    def _run_with_sheet(self, rows):
+        with patch.object(importer, "_fetch_csv_text", return_value=_csv(rows)):
+            return importer.collect_all_gsheet()
+
+    def test_disabled_when_url_empty(self):
+        with patch.object(importer.config, "GSHEET_DRAMA_URL", ""):
+            self.assertEqual(importer.collect_all_gsheet(), 0)
+
+    def test_imports_rows_and_dedupes_rerun(self):
+        rows = [["Title", "Content", "URL"],
+                ["Chuyện mẹ chồng", LONG_BODY, "https://r.example/1"],
+                ["Chuyện công ty", LONG_BODY, "https://r.example/2"]]
+        self.assertEqual(self._run_with_sheet(rows), 2)
+        # Same sheet fetched again → everything already imported.
+        self.assertEqual(self._run_with_sheet(rows), 0)
+        pending = stories.get_pending(limit=10, track="drama")
+        self.assertEqual(len(pending), 2)
+        self.assertTrue(all(s["source"] == "gsheet" for s in pending))
+
+    def test_row_without_url_dedupes_by_content_hash(self):
+        rows = [["Title", "Content"], ["Dán tay", LONG_BODY]]
+        self.assertEqual(self._run_with_sheet(rows), 1)
+        self.assertEqual(self._run_with_sheet(rows), 0)
+
+    def test_thin_rows_skipped(self):
+        rows = [["Title", "Content"],
+                ["Chỉ có link", "ngắn quá"],
+                ["", LONG_BODY]]
+        self.assertEqual(self._run_with_sheet(rows), 0)
+
+    def test_import_limit_respected(self):
+        rows = [["Title", "Content", "URL"]] + [
+            [f"Story {i}", LONG_BODY, f"https://r.example/{i}"] for i in range(10)
+        ]
+        with patch.object(importer.config, "GSHEET_IMPORT_LIMIT", 3):
+            self.assertEqual(self._run_with_sheet(rows), 3)
+        # Next run picks up where the cap stopped (dedupe skips the first 3).
+        with patch.object(importer.config, "GSHEET_IMPORT_LIMIT", 30):
+            self.assertEqual(self._run_with_sheet(rows), 7)
+
+    def test_html_content_cleaned_before_insert(self):
+        body_html = "<p>" + LONG_BODY + "</p><br/>"
+        rows = [["Title", "Content"], ["HTML row", body_html]]
+        self.assertEqual(self._run_with_sheet(rows), 1)
+        story = stories.get_pending(limit=1, track="drama")[0]
+        self.assertNotIn("<p>", story["raw_content"])
+
+    def test_html_login_page_raises_clear_error(self):
+        with patch.object(importer, "_fetch_csv_text",
+                          side_effect=importer.GSheetFetchError("got an HTML page")):
+            with self.assertRaises(importer.GSheetFetchError):
+                importer.collect_all_gsheet()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -62,6 +62,43 @@ class TestBuildNarration(unittest.TestCase):
                    "vn_commentary": "C"}
         self.assertEqual(main_drama.build_narration(rewrite), "H\n\nS\n\nC")
 
+    def test_hook_repeated_with_different_punctuation_not_duplicated(self):
+        # The "title read twice" bug: the model restates the hook as the
+        # script's opening line with only punctuation/case differences, which
+        # a raw substring check missed.
+        rewrite = {"hook": "Tôi không ngờ chồng mình lại làm vậy!",
+                   "script": ("Tôi không ngờ, chồng mình lại làm vậy. "
+                              "Chuyện bắt đầu từ một buổi tối..."),
+                   "vn_commentary": "Bình luận dài về góc nhìn Việt."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.lower().count("không ngờ"), 1)
+        self.assertTrue(narration.startswith("Tôi không ngờ, chồng mình"))
+
+    def test_hook_paraphrased_at_script_start_not_duplicated(self):
+        # Fuzzy prefix match: a few words shifted, still the same spoken line.
+        rewrite = {"hook": "Tôi không ngờ chồng mình lại đối xử như vậy",
+                   "script": ("Không ngờ chồng mình lại đối xử như vậy. "
+                              "Hôm đó tôi đi làm về sớm hơn thường lệ...")}
+        narration = main_drama.build_narration(rewrite)
+        self.assertTrue(narration.startswith("Không ngờ chồng mình"))
+
+    def test_exact_repeat_mid_script_not_duplicated(self):
+        # Normalized containment scans the whole script, not just its opening —
+        # a hook restated verbatim mid-story is still a spoken duplicate.
+        rewrite = {"hook": "Mẹ chồng tôi đã nói dối suốt ba năm",
+                   "script": ("Chuyện bắt đầu từ ngày cưới. "
+                              "Sau này tôi mới biết mẹ chồng tôi đã nói dối "
+                              "suốt ba năm, nhưng lúc đó tôi không hề hay.")}
+        narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.lower().count("nói dối suốt ba năm"), 1)
+
+    def test_unrelated_short_hook_kept(self):
+        # A genuinely distinct hook must never be fuzzy-matched away.
+        rewrite = {"hook": "Cả nhà tôi sốc nặng!",
+                   "script": "Hôm đó là một ngày bình thường như mọi ngày khác."}
+        narration = main_drama.build_narration(rewrite)
+        self.assertTrue(narration.startswith("Cả nhà tôi sốc nặng!"))
+
 
 class RenderBase(unittest.TestCase):
     def setUp(self):

--- a/content-pipeline/tests/test_subtitle_generator.py
+++ b/content-pipeline/tests/test_subtitle_generator.py
@@ -61,11 +61,16 @@ class TestSplitIntoSegments(unittest.TestCase):
         segs = _split_into_segments(sentence)
         self.assertGreaterEqual(len(segs), 2)
 
-    def test_consecutive_duplicates_removed(self):
-        # AI scripts sometimes repeat the closing line; dedup consecutive ones.
+    def test_consecutive_duplicates_kept(self):
+        # Subtitles must mirror the audio EXACTLY: TTS synthesizes from the
+        # same text, so a repeated line IS spoken twice. The old behavior
+        # (dropping the duplicate from subtitles only) re-distributed the
+        # word-count timing and desynced every subtitle after the repeat —
+        # the drama-track "title read twice, subtitles drift" bug. Repeats
+        # are now removed at the source (main_drama.build_narration).
         text = "Cảm ơn các bạn. Cảm ơn các bạn."
         segs = _split_into_segments(text)
-        self.assertEqual(segs, ["Cảm ơn các bạn."])
+        self.assertEqual(segs, ["Cảm ơn các bạn.", "Cảm ơn các bạn."])
 
     def test_no_segments_for_whitespace(self):
         self.assertEqual(_split_into_segments("   "), [])

--- a/content-pipeline/video/subtitle_generator.py
+++ b/content-pipeline/video/subtitle_generator.py
@@ -135,16 +135,22 @@ def _split_into_segments(text: str) -> list[str]:
                 if remaining_words:
                     segments.append(" ".join(remaining_words))
 
-    # Remove empty segments and deduplicate consecutive identical segments.
-    # AI-generated scripts sometimes repeat the closing sentence in both the
-    # body and the outro, which would cause the subtitle to appear twice at
-    # the end of the video.
+    # Keep segments EXACTLY as spoken — including repeats. An earlier version
+    # deduplicated consecutive identical segments here, but the TTS audio is
+    # synthesized from the SAME text and still speaks the repeat: dropping it
+    # from the subtitles only re-distributed the word-count timing and threw
+    # every following subtitle out of sync with the audio (the drama-track
+    # "title read twice, subtitles drift" bug). Repeated text must be fixed at
+    # the source — main_drama.build_narration dedupes hook/reactions/commentary
+    # against the script BEFORE the narration reaches both TTS and here.
     result: list[str] = []
     for seg in segments:
-        if seg.strip() and (not result or seg.strip() != result[-1].strip()):
+        if seg.strip():
+            if result and seg.strip() == result[-1].strip():
+                logger.warning(
+                    "Consecutive duplicate segment kept (audio speaks it too): '%s...'",
+                    seg[:60])
             result.append(seg)
-        elif seg.strip() and result and seg.strip() == result[-1].strip():
-            logger.warning("Duplicate subtitle segment removed: '%s...'", seg[:60])
     return result
 
 

--- a/docs/current/gsheet-drama-source.md
+++ b/docs/current/gsheet-drama-source.md
@@ -1,0 +1,89 @@
+# Google Sheets drama bridge — phễu nguồn ngoài cho track Drama
+
+## Tại sao là Google Sheets, không phải N collector?
+
+Các nguồn drama "béo bở" còn lại đều **không có API ổn định** để pipeline cào
+trực tiếp:
+
+| Nguồn | Thực trạng (kiểm chứng 07/2026) |
+|---|---|
+| Reddit RSS (`/hot/.rss`) | Vẫn tồn tại, nhưng Reddit **chặn fetcher datacenter từng đợt** (403) — Make.com, FreshRSS, RSS-Bridge đều có báo cáo dính chặn kéo dài từ vài phút tới vài ngày. KHÔNG phải "không bị chặn vì đi qua cổng phân phối công khai" — RSS vẫn là server Reddit, chỉ là IP của Make chưa/ít bị flag. Dùng được, nhưng là **best-effort**. |
+| Quora topic RSS (`/topic/X/rss`) | **Đã khai tử** từ nhiều năm (hỏng từ ~2017). Không dùng được. |
+| Facebook confession/group | **Không có RSS chính thức**; API chặn gắt. RSS.app/PageUnify là dịch vụ trả phí (free trial ngắn), độ bền phụ thuộc bên thứ ba. |
+| Zhihu/Douyin (dịch qua group VN) | Không có đường tự động; bản chất là **dán tay** truyện đã dịch. |
+
+Vì tầng cào nào cũng mỏng manh, kiến trúc đúng là **tách tầng cào khỏi tầng
+nạp**: mọi nguồn đổ vào MỘT Google Sheet (miễn phí, bền, không rate-limit khi
+đọc CSV export), pipeline chỉ đọc sheet:
+
+```
+[Make.com: RSS Reddit]   ┐
+[Make.com: RSS bất kỳ]   ├──► Google Sheet ──► collect_all_gsheet() ──► stories
+[RSS.app / Zapier]       │        (CSV export)      (dedupe + insert)
+[dán tay drama VN]       ┘
+```
+
+- Reddit chặn Make → scenario nghỉ vài ngày, sheet còn nguyên, pipeline không hỏng.
+- Thêm/đổi nguồn = sửa scenario Make hoặc dán thêm dòng — **không đổi code**.
+- Nguồn drama TIN CẬY hàng ngày vẫn là HF AITA dump (issue #90); sheet này là
+  kênh bổ sung cho nội dung tươi + drama Việt bản địa.
+
+## Bước 1 — Tạo Google Sheet
+
+1. Tạo sheet mới, hàng đầu tiên đặt header (không phân biệt hoa thường, nhận
+   cả tiếng Việt có dấu):
+   - `Title` (hoặc `Tiêu đề`) — **bắt buộc**
+   - `Content` (hoặc `Nội dung`, `Body`) — **bắt buộc**
+   - `URL` (hoặc `Link`) — nên có: dùng làm khoá dedupe ổn định
+   - `Source` (hoặc `Nguồn`) — tuỳ chọn, ghi feed gốc để trace
+2. Share: **Anyone with the link – Viewer** (hoặc File → Share → Publish to
+   web → chọn CSV). KHÔNG cần quyền edit công khai — Make ghi bằng OAuth riêng.
+3. Dán link sheet (dạng `/edit#gid=...` bình thường là được) vào `.env`:
+
+   ```
+   GSHEET_DRAMA_URL=https://docs.google.com/spreadsheets/d/<ID>/edit#gid=0
+   ```
+
+Chạy thử: `cd content-pipeline && python -m collectors.gsheet_drama_importer`
+
+## Bước 2 — Dựng scenario Make.com (tự động hoá RSS)
+
+Tài khoản Free của Make.com cho 1.000 operations/tháng — đủ cho vài feed chạy
+2-4 lần/ngày.
+
+1. Make.com → Create a new scenario.
+2. Module 1: **RSS → Watch RSS feed items**, URL ví dụ:
+   `https://www.reddit.com/r/AmItheAsshole/hot/.rss`
+   (các sub khác: `relationship_advice`, `ProRevenge`, `MaliciousCompliance` —
+   thay tên sub trong URL). Nếu Make báo 403: đặt custom User-Agent trong
+   module RSS (Show advanced settings), hoặc chấp nhận chờ hết đợt chặn.
+3. Module 2: **Google Sheets → Add a Row**, map:
+   - `Title` ← RSS Title
+   - `Content` ← RSS Content/Description (importer tự gỡ HTML)
+   - `URL` ← RSS URL
+   - `Source` ← tên feed (gõ tay, vd `reddit/AmItheAsshole`)
+4. Schedule: 2-4 lần/ngày là đủ (top-of-day đổi chậm; tiết kiệm ops).
+
+Bài RSS chỉ có link không có nội dung sẽ bị importer bỏ qua
+(`GSHEET_MIN_BODY_CHARS`) — chọn feed có full content.
+
+## Bước 3 — Dán tay drama Việt (không cần Make)
+
+Confession FB, group "hóng biến", truyện Trung dịch sẵn: mở sheet, dán 1 dòng
+`Title` + `Content` (cột URL để trống — importer dedupe bằng hash nội dung, dán
+trùng không sao). Lần chạy `main_drama` kế tiếp sẽ nạp, chấm điểm, Việt hoá như
+mọi story khác. Với truyện đã là tiếng Việt, rewriter vẫn chạy để chuẩn format
+hook/script/commentary.
+
+> **Bản quyền & an toàn:** nội dung sheet là nguồn NGOÀI chưa kiểm chứng — vẫn
+> đi qua đủ rubric SAFE của `drama_scorer` và luật không-tên-thật của rewriter
+> như mọi nguồn. Không dán nội dung nhận diện người thật.
+
+## Vận hành
+
+- `main_drama.py` bước collect gọi `collect_all_gsheet()` best-effort (nguồn
+  lỗi không kéo sập bước collect; lỗi hiện trong summary Telegram).
+- Mỗi lần chạy nạp tối đa `GSHEET_IMPORT_LIMIT` (mặc định 30) story MỚI; sheet
+  dài hơn sẽ tự nạp tiếp các lần sau (dedupe theo `source_id`).
+- Sheet chưa share đúng → lỗi rõ ràng "got an HTML page instead of CSV".
+- Không cần dọn sheet: hàng đã nạp bị dedupe vĩnh viễn (hash URL/nội dung).

--- a/docs/current/prompts-decisions.md
+++ b/docs/current/prompts-decisions.md
@@ -57,6 +57,28 @@ prompt sau này không bị nhầm lẫn thêm.
 (1100-2100 từ cho video long-form 8-15 phút) được suy ra từ tốc độ đọc
 ~140 từ/phút này — xem comment trong code.
 
+## v2 (rewriter-only) — 2026-07-21 (short 2-3 phút)
+
+`rewriter.v2.txt` — các prompt khác giữ v1. Chọn qua env
+`DRAMA_REWRITER_PROMPT_VERSION` (mặc định `v2`, per-prompt) thay vì bump
+`PROMPT_VERSION` global (sẽ bắt scorer/theme_detect/longform cũng phải có v2).
+
+Lý do đổi:
+
+1. **Độ dài (yêu cầu chủ kênh):** v1 nhắm 800-1200 từ và ghi chú "tương đương
+   60-90 giây TTS" — SAI thực nghiệm: video thật ra ~6 phút, tức giọng drama
+   đọc ~210-230 từ/phút. Mục tiêu mới 2-3 phút ⇒ script 250-400 từ,
+   commentary 80-120 từ, tổng các phần đọc ~400-550 từ. Dải validate trong
+   `config.py` hạ theo (soft 250-400, hard 150-600, commentary min 60).
+2. **Cấm lặp hook (rule 7 mới):** model hay mở đầu script bằng chính câu
+   hook/title → video đọc tiêu đề 2 lần. v2 cấm tường minh;
+   `main_drama.build_narration` vẫn giữ check `_spoken_duplicate()` làm
+   enforcement (story cũ + model không nghe lời).
+3. `vn_reactions` rút còn 2-3 câu (<60 từ) cho vừa format ngắn.
+
+Rollback format 6 phút: `DRAMA_REWRITER_PROMPT_VERSION=v1` + nới lại
+`DRAMA_SCRIPT_*_WORDS`/`DRAMA_COMMENTARY_MIN_WORDS` qua env.
+
 ## A/B harness
 
 `processors/ab_harness.py` — thiết kế rút gọn so với `phase-3-issues.md`


### PR DESCRIPTION
Ba yêu cầu của chủ kênh cho track Drama, xử lý trong một PR:

## 1. Nguồn drama mới — cầu nối Google Sheets (`collectors/gsheet_drama_importer.py`)

Kiểm chứng các nguồn được đề xuất (07/2026):
- **Reddit RSS qua Make.com**: dùng được nhưng **chập chờn** — Reddit chặn fetcher datacenter từng đợt (Make.com/FreshRSS/RSS-Bridge đều có báo cáo 403 kéo dài từ phút tới ngày). Cơ chế "không bị chặn vì đi qua cổng phân phối công khai" là KHÔNG đúng — RSS vẫn là server Reddit.
- **Quora topic RSS** (`/topic/X/rss`): đã khai tử từ ~2017.
- **Facebook confession**: không có RSS chính thức; RSS.app/PageUnify là dịch vụ trả phí bên thứ ba.

Vì tầng cào nào cũng mỏng manh → tách tầng cào khỏi tầng nạp: **một Google Sheet làm phễu chung** (Make.com Free 1.000 ops/tháng chạy scenario RSS → Sheets "Add a Row", hoặc dán tay drama Việt). Importer đọc CSV export của sheet (stdlib urllib, UA #97, cap dung lượng), auto-dò header Anh/Việt (kể cả "Tiêu đề"/"Nội dung" — có xử lý đ→d khi strip accent), gỡ HTML, dedupe theo hash URL/nội dung, cap `GSHEET_IMPORT_LIMIT`/lần chạy. Nối vào bước collect best-effort của `main_drama`. Hướng dẫn setup từng bước: `docs/current/gsheet-drama-source.md`.

Reddit chặn Make → scenario nghỉ, sheet còn nguyên, pipeline không hỏng. Thêm/đổi nguồn = sửa scenario, không đổi code.

## 2. Video drama rút xuống 2-3 phút (`prompts/drama/rewriter.v2.txt`)

Prompt v1 ghi "800-1200 từ ≈ 60-90 giây TTS" — sai thực nghiệm: video thật ~6 phút, tức giọng drama đọc ~210-230 từ/phút. Mục tiêu 2-3 phút ⇒ tổng narration ~420-650 từ (ước lượng "200 từ" sẽ chỉ ra <1 phút):
- v2 nhắm **script 250-400 từ + commentary 80-120 từ** (tổng phần đọc ~400-550 từ)
- Dải validate hạ theo: soft 250-400, hard 150-600, commentary min 60 (`DRAMA_COMMENTARY_MIN_WORDS`, hết hardcode 200) — đều env-overridable
- Chọn version qua `DRAMA_REWRITER_PROMPT_VERSION` (mặc định v2, per-prompt — không đụng `PROMPT_VERSION` global của scorer/theme_detect/longform)
- Rollback format 6 phút = `DRAMA_REWRITER_PROMPT_VERSION=v1` + nới dải qua env

## 3. Fix "đọc tiêu đề 2 lần + phụ đề lệch audio"

Hai lỗi chồng nhau:
1. Model hay lặp lại hook/title ở câu mở đầu script với khác biệt dấu câu/vài chữ — check substring RAW cũ (`hook not in script`) trượt → narration đọc trùng.
2. `subtitle_generator._split_into_segments` lại **xoá** segment trùng khỏi phụ đề trong khi audio TTS (cùng text) vẫn đọc → ở chế độ wordcount, toàn bộ phụ đề sau điểm đó lệch timing.

Fix:
- `build_narration` dedupe theo **nội dung đọc**: chuẩn hoá (bỏ dấu câu/hoa thường) + containment + fuzzy match `SequenceMatcher ≥ 0.8` với đoạn mở đầu script (chỉ prefix — câu tình cờ giống ở giữa chuyện không cắt oan hook)
- `subtitle_generator` giữ segment đúng như audio đọc (phụ đề phải phản chiếu audio; dedupe thuộc tầng dựng narration)
- Prompt v2 cấm script mở đầu bằng hook (phòng từ gốc; check code là enforcement cho story cũ)

## Test

- Full suite: **1012 tests OK** (21 skipped — pre-existing, thiếu optional deps)
- Mới: `tests/test_gsheet_drama_importer.py` (16 test: URL normalize, header VN, HTML strip, dedupe, import limit, lỗi sheet chưa share)
- Cập nhật: fixtures/bands trong `test_drama_rewriter`/`test_drama_quality` tham chiếu config thay vì hardcode; test fuzzy-dedupe narration; test phụ đề giữ segment trùng

## Lưu ý vận hành sau merge

- Story `approved` cũ (Việt hoá theo v1, ~1000 từ) vẫn sẽ render ra video dài ~6 phút — nếu không muốn, đổi status các story đó trước lần render kế.
- Muốn bật nguồn Sheet: tạo sheet + điền `GSHEET_DRAMA_URL` vào `.env` theo `docs/current/gsheet-drama-source.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nvRyQnR5Lm7EHwJL8zhnW