### PR TITLE
Fix #103: trần bitrate cho final encode + nền drama illustration-first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1060,18 +1060,22 @@ Các endpoint con suy ra từ `TTS_API_URL` nên không cần đổi config URL.
 `config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
 fallback về hành vi cũ.
 
-**CTA đăng ký kênh (yêu cầu chủ kênh 07/2026):** mọi narration đăng YouTube
-phải KẾT bằng câu kêu gọi đăng ký kênh. Script long track AI đã có sẵn trong
-prompt; short AI trước chỉ có "Follow..." (giọng TikTok) và drama không có chỉ
-dẫn CTA. Fix 2 tầng: (1) prompt — `SHORT_SCRIPT_PROMPT` đổi CTA thành kêu gọi
-đăng ký kênh, `prompts/drama/rewriter.v2.txt` dặn `vn_commentary` kết bằng mời
-bình luận + đăng ký kênh; (2) **guarantee tầng code** —
-`video.text_preprocessor.ensure_subscribe_cta(text, cta)` soi ĐOẠN CUỐI
-narration (cụm hẹp "đăng ký kênh"/"subscribe"/"theo dõi kênh" — "đăng ký
-ChatGPT Plus" giữa bài không tính), thiếu thì nối câu CTA
+**CTA cuối narration (yêu cầu chủ kênh 07/2026):** mọi narration phải KẾT bằng
+câu CTA theo giọng của từng track — **AI: kêu gọi ĐĂNG KÝ KÊNH** (script long
+đã có sẵn trong prompt; short trước chỉ có "Follow..." giọng TikTok);
+**Drama: giọng "follow"** — "Follow để nghe chuyện đời mỗi ngày" (chủ kênh
+chọn, hợp cả YouTube lẫn TikTok kênh drama). Fix 2 tầng: (1) prompt —
+`SHORT_SCRIPT_PROMPT` đổi CTA thành kêu gọi đăng ký kênh,
+`prompts/drama/rewriter.v2.txt` dặn `vn_commentary` kết bằng mời bình luận +
+follow kênh; (2) **guarantee tầng code** —
+`video.text_preprocessor.ensure_subscribe_cta(text, cta, extra_markers)` soi
+ĐOẠN CUỐI narration (cụm hẹp "đăng ký kênh"/"subscribe"/"theo dõi kênh" —
+"đăng ký ChatGPT Plus" giữa bài không tính), thiếu thì nối câu CTA
 (`AI_SUBSCRIBE_CTA`/`DRAMA_SUBSCRIBE_CTA`, env-overridable), có rồi thì không
-đụng (không đọc 2 lần). Áp tại `main._create_video` (TRƯỚC khi lưu DB/TTS/
-subtitle — một nguồn text nên audio và phụ đề luôn khớp) và
+đụng (không đọc 2 lần). Drama truyền thêm `extra_markers=("follow",)` để câu
+"follow..." được tính là đã có CTA; track AI KHÔNG — "Follow..." kiểu cũ vẫn
+bị coi là thiếu CTA đăng ký. Áp tại `main._create_video` (TRƯỚC khi lưu DB/
+TTS/subtitle — một nguồn text nên audio và phụ đề luôn khớp) và
 `main_drama.build_narration` (cứu cả story cũ rewrite trước khi prompt đổi).
 
 **Composer:** phụ đề được gộp thành **một track trong suốt** (concat-demuxer →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,7 +461,26 @@ gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
   đó làm `bg_video` cho `compose_video()` **đã có sẵn** (video_composer.py)
   để tái dùng pipeline audio/phụ đề/crop đã ổn định — không viết lại logic
   đó. Scene reel lỗi → fallback về compose đơn-nền cũ (không bao giờ ra
-  video rỗng). Nhạc nền: nếu `ENABLE_BGM=1`, mix nhạc từ
+  video rỗng).
+  **Nền scene "đơn sắc" (issue #103):** template gốc CHỦ ĐÍCH chỉ cho 3/6
+  scene dùng illustration (còn lại gradient/solid), và mỗi lần Replicate lỗi
+  scene rơi thẳng về `solid_blue` — video thật ra 1 ảnh AI + 5 mảng màu (ảnh
+  scene 0 thường chỉ là CACHE HIT từ thumbnail cùng `(prompt, index=0)`, các
+  scene index khác gọi API thật và chết chùm). Fix 4 lớp: (1) template
+  illustration-first cho MỌI scene, màu cũ chuyển vào field `fallback`
+  declarative (chỉ dùng khi hết đường ảnh); scene i dùng variant
+  `i % DRAMA_ILLUSTRATION_VARIANTS` (mặc định 3 — đa dạng mà không nhân call
+  theo số scene, variant 0 trùng cache thumbnail nên 1 call luôn tái dùng);
+  (2) thứ tự resolve: `generate_illustration` (cache-hit free) → **memo lỗi
+  trong run** (fail live 1 lần = các scene sau bỏ qua API, khỏi đốt poll-timeout
+  90s×5) → `image_generator.cached_illustration()` tái dùng BẤT KỲ variant đã
+  cache của prompt (zero cost) → `fallback` của scene → `solid_blue` chót;
+  (3) scene nền ảnh có **Ken Burns** (zoompan, hướng zoom xen kẽ theo scene,
+  `DRAMA_SCENE_MOTION=1`; render motion lỗi tự retry static — nice-to-have
+  không được phá video); `illustration_dark` giờ thật sự TỐI (eq dim +
+  desaturate, áp TRƯỚC overlay nên commentary card giữ nguyên độ sáng);
+  (4) mọi segment chuẩn hoá `fps=30` (lavfi mặc định 25 ≠ zoompan 30 sẽ làm
+  concat `-c copy` lệch timestamp). Nhạc nền: nếu `ENABLE_BGM=1`, mix nhạc từ
   `config.DRAMA_MUSIC_DIR` (pool riêng, khác `MUSIC_DIR` của track AI) —
   ưu tiên file tên trùng `template["music_track"]`, thiếu thì chọn ngẫu
   nhiên trong pool (không chặn render nếu chưa có file nhạc, xem
@@ -996,6 +1015,23 @@ Các flag bật/tắt nâng cấp video, mặc định = hành vi cũ (xem
 | `TTS_POLL_TIMEOUT` | `600` | Tổng thời gian chờ tối đa 1 job; quá hạn → fallback provider |
 | `TTS_POLL_MAX_FAILURES` | `3` | Số lần poll `/status` lỗi liên tiếp trước khi fallback (fail fast) |
 | `TTS_ALLOW_INSECURE_SSL` | `0` | **Security:** chỉ bật cho endpoint TLS tự ký tin cậy; mặc định verify cert |
+| `VIDEO_CRF_LONG` / `VIDEO_CRF_SHORT` | `23` / `26` | CRF final encode theo loại video (issue #103). Short dùng CRF cao hơn — xem trên điện thoại + platform re-encode lại |
+| `VIDEO_MAXRATE_KBPS_LONG` / `VIDEO_MAXRATE_KBPS_SHORT` | `4000` / `3000` | Trần bitrate final encode (kbps, bufsize = 2×); `0` = không cap (issue #103) |
+| `DRAMA_ILLUSTRATION_VARIANTS` | `3` | Số ảnh minh hoạ AI riêng biệt cho 1 story drama; scene i dùng variant `i % N` (issue #103) |
+| `DRAMA_SCENE_MOTION` | `1` | Zoom chậm (Ken Burns) trên scene drama nền ảnh tĩnh; `0` = ảnh đứng yên như cũ (issue #103) |
+
+**Kích thước file output (issue #103):** cả 2 composer trước đây encode y hệt
+nhau (`libx264 -crf 23`, KHÔNG set `-b:v` ở đâu cả — mô tả trong issue sai chỗ
+này), nhưng CRF là "chất lượng cố định, bitrate thả nổi" nên AI short nền
+b-roll chuyển động mạnh phình ~7.8Mbps/50MB trong khi drama nền tĩnh chỉ
+~355kbps — cùng setting, khác nội dung. Fix: giữ CRF (quality-driven) nhưng
+THÊM trần `-maxrate`/`-bufsize` per video type + CRF 26 cho short, qua
+`config.encode_settings(video_type)` (single source of truth, cả engine ffmpeg
+lẫn moviepy dùng chung). Chỉ áp cho FINAL encode — intermediate (scene segment,
+multi-bg pre-pass) giữ CRF 23 vì sẽ được encode lại. Đo thật: nền chuyển động
+mạnh 10s từ 23.4Mbps/29MB → 3.2Mbps/4.2MB (~7×), nền tĩnh không đổi (cap chỉ
+chặn đỉnh). `-b:v 500k` như issue gợi ý bị TỪ CHỐI — bitrate ép cứng 500k làm
+b-roll motion vỡ hình rõ ở 1080x1920.
 
 **Phụ đề theo định dạng:** với `BURN_SUBTITLES=short_only`, video **short** được nung
 phụ đề (xem tắt tiếng trên TikTok/Shorts), còn video **long** không nung mà upload

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,7 +474,13 @@ gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
   (2) thứ tự resolve: `generate_illustration` (cache-hit free) → **memo lỗi
   trong run** (fail live 1 lần = các scene sau bỏ qua API, khỏi đốt poll-timeout
   90s×5) → `image_generator.cached_illustration()` tái dùng BẤT KỲ variant đã
-  cache của prompt (zero cost) → `fallback` của scene → `solid_blue` chót;
+  cache của prompt (zero cost) → **Pexels PHOTO fallback** (yêu cầu chủ kênh
+  07/2026: mọi scene drama phải là ẢNH — `pexels_downloader.get_photos()` search
+  theo chính `thumbnail_prompt`, không ra thì query mood chung
+  `DRAMA_PHOTO_GENERIC_QUERY`; cache-first theo (query, orientation, index),
+  memo kết quả trong run — 1 lookup/video; tắt qua
+  `DRAMA_PHOTO_FALLBACK_ENABLED=0`) → `fallback` của scene → `solid_blue` chót
+  (chỉ còn thấy khi CẢ Replicate lẫn Pexels đều bất khả dụng);
   (3) scene nền ảnh có **Ken Burns** (zoompan, hướng zoom xen kẽ theo scene,
   `DRAMA_SCENE_MOTION=1`; render motion lỗi tự retry static — nice-to-have
   không được phá video); `illustration_dark` giờ thật sự TỐI (eq dim +
@@ -1054,6 +1060,20 @@ Các endpoint con suy ra từ `TTS_API_URL` nên không cần đổi config URL.
 `config.validate_flags(logger)` cảnh báo nếu giá trị không hợp lệ và pipeline tự
 fallback về hành vi cũ.
 
+**CTA đăng ký kênh (yêu cầu chủ kênh 07/2026):** mọi narration đăng YouTube
+phải KẾT bằng câu kêu gọi đăng ký kênh. Script long track AI đã có sẵn trong
+prompt; short AI trước chỉ có "Follow..." (giọng TikTok) và drama không có chỉ
+dẫn CTA. Fix 2 tầng: (1) prompt — `SHORT_SCRIPT_PROMPT` đổi CTA thành kêu gọi
+đăng ký kênh, `prompts/drama/rewriter.v2.txt` dặn `vn_commentary` kết bằng mời
+bình luận + đăng ký kênh; (2) **guarantee tầng code** —
+`video.text_preprocessor.ensure_subscribe_cta(text, cta)` soi ĐOẠN CUỐI
+narration (cụm hẹp "đăng ký kênh"/"subscribe"/"theo dõi kênh" — "đăng ký
+ChatGPT Plus" giữa bài không tính), thiếu thì nối câu CTA
+(`AI_SUBSCRIBE_CTA`/`DRAMA_SUBSCRIBE_CTA`, env-overridable), có rồi thì không
+đụng (không đọc 2 lần). Áp tại `main._create_video` (TRƯỚC khi lưu DB/TTS/
+subtitle — một nguồn text nên audio và phụ đề luôn khớp) và
+`main_drama.build_narration` (cứu cả story cũ rewrite trước khi prompt đổi).
+
 **Composer:** phụ đề được gộp thành **một track trong suốt** (concat-demuxer →
 overlay 1 lần) nên số input ffmpeg là hằng số, không phụ thuộc số dòng phụ đề.
 
@@ -1063,6 +1083,15 @@ mà vẫn dùng nguồn Pexels miễn phí:
    `broll_terms` (3-5 cụm tiếng Anh cụ thể, vd `"AI robot assistant"`). `main._extract_keywords`
    ưu tiên dùng các từ này để search Pexels (bám chủ đề hơn tiêu đề tiếng Việt);
    thiếu thì fallback heuristic cũ.
+   **Pool nền đóng băng (fix 07/2026):** `get_background`/`get_backgrounds` cũ
+   trả từ cache ngay khi BẤT KỲ query nào có cache — 5 query generic luôn được
+   nối vào danh sách và cache từ ngày đầu, nên clip theo `broll_terms` KHÔNG
+   BAO GIỜ được tải nữa → mọi AI video xoay quanh vài clip generic giống nhau,
+   chẳng khớp nội dung. Fix 2 nửa: (a) **Pass 0** `_ensure_keyword_clips` tải
+   tối đa `BG_KEYWORD_DOWNLOADS` (mặc định 2, 0 = hành vi cũ) clip MỚI cho
+   keyword của chính bài chưa có cache mỗi video (tôn trọng sentinel lỗi
+   auth/blocked của #97); (b) khi chọn, clip cache theo keyword CỦA BÀI thắng
+   pool generic (content match), anti-repeat variety vẫn áp dụng.
 2. **Chống lặp nền (anti-repeat):** `pexels_downloader._select_with_variety` chọn
    ngẫu nhiên trong `BG_VARIETY_TOPK` clip khớp thời lượng nhất và tránh
    `BG_RECENT_WINDOW` clip vừa dùng (lưu ở `cache/.recent_backgrounds.json`) — fix

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -244,6 +244,14 @@ BG_CLIP_COUNT = int(os.getenv("BG_CLIP_COUNT", "6"))  # max distinct clips to ga
 # Set BG_VARIETY_TOPK=1 to restore the old deterministic closest-fit pick.
 BG_VARIETY_TOPK = int(os.getenv("BG_VARIETY_TOPK", "3"))
 BG_RECENT_WINDOW = int(os.getenv("BG_RECENT_WINDOW", "8"))
+# Số clip nền MỚI tải theo keyword của CHÍNH bài viết mỗi video (chủ kênh 07/2026:
+# nền các AI video giống hệt nhau + không khớp nội dung). Root cause: get_background
+# trả từ cache ngay khi BẤT KỲ query nào có cache — 5 query generic luôn được nối
+# vào danh sách và cache từ ngày đầu, nên clip theo broll_terms KHÔNG BAO GIỜ được
+# tải nữa → pool đóng băng ở vài clip generic. Giá trị này cho phép tải tối đa N
+# clip mới cho keyword chưa cache mỗi lần render (Pexels free ~200 req/giờ nên
+# 2 call/video là không đáng kể). 0 = hành vi cũ (chỉ dùng cache).
+BG_KEYWORD_DOWNLOADS = int(os.getenv("BG_KEYWORD_DOWNLOADS", "2"))
 # Background music (ENABLE_BGM=1): directory + level under the narration.
 MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music")
 # Drama track uses its own pool (tense/dramatic loops) instead of the AI
@@ -277,6 +285,28 @@ DRAMA_ILLUSTRATION_VARIANTS = max(1, int(os.getenv("DRAMA_ILLUSTRATION_VARIANTS"
 # "đứng hình". 0 = ảnh tĩnh như cũ (và composer tự retry static nếu render
 # motion lỗi, không bao giờ chặn video).
 DRAMA_SCENE_MOTION = os.getenv("DRAMA_SCENE_MOTION", "1") == "1"
+# Tầng ảnh dự phòng bằng Pexels PHOTO khi Replicate không sinh được ảnh AI và
+# story chưa có ảnh cache (chủ kênh 07/2026: mọi scene drama phải là ẢNH, không
+# chấp nhận nền màu đơn sắc). Search theo chính thumbnail_prompt (tiếng Anh);
+# prompt quá đặc thù không ra kết quả thì thử query mood chung. Chỉ khi CẢ
+# Replicate lẫn Pexels đều bất khả dụng mới còn thấy màu fallback.
+DRAMA_PHOTO_FALLBACK_ENABLED = os.getenv("DRAMA_PHOTO_FALLBACK_ENABLED", "1") == "1"
+DRAMA_PHOTO_GENERIC_QUERY = os.getenv("DRAMA_PHOTO_GENERIC_QUERY",
+                                      "dramatic cinematic mood dark")
+
+# --- Subscribe CTA (chủ kênh 07/2026) ---
+# Mọi narration đăng YouTube phải KẾT bằng câu kêu gọi đăng ký kênh (script
+# long track AI đã có sẵn trong prompt; short AI trước đây chỉ "Follow...",
+# drama không có chỉ dẫn CTA). Prompt đã được sửa để LLM tự viết CTA tự nhiên;
+# 2 câu dưới là lưới an toàn tầng code (video.text_preprocessor.
+# ensure_subscribe_cta): cuối narration chưa có cụm "đăng ký kênh"/"subscribe"
+# thì tự nối thêm — có rồi thì không đụng (không đọc CTA 2 lần).
+AI_SUBSCRIBE_CTA = os.getenv(
+    "AI_SUBSCRIBE_CTA",
+    "Đăng ký kênh để không bỏ lỡ tin AI mỗi ngày nhé!")
+DRAMA_SUBSCRIBE_CTA = os.getenv(
+    "DRAMA_SUBSCRIBE_CTA",
+    "Nếu thấy câu chuyện đáng suy ngẫm, đăng ký kênh để nghe chuyện mới mỗi ngày nhé!")
 
 
 def encode_settings(video_type: str) -> tuple[int, int]:

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -294,19 +294,22 @@ DRAMA_PHOTO_FALLBACK_ENABLED = os.getenv("DRAMA_PHOTO_FALLBACK_ENABLED", "1") ==
 DRAMA_PHOTO_GENERIC_QUERY = os.getenv("DRAMA_PHOTO_GENERIC_QUERY",
                                       "dramatic cinematic mood dark")
 
-# --- Subscribe CTA (chủ kênh 07/2026) ---
-# Mọi narration đăng YouTube phải KẾT bằng câu kêu gọi đăng ký kênh (script
-# long track AI đã có sẵn trong prompt; short AI trước đây chỉ "Follow...",
-# drama không có chỉ dẫn CTA). Prompt đã được sửa để LLM tự viết CTA tự nhiên;
-# 2 câu dưới là lưới an toàn tầng code (video.text_preprocessor.
-# ensure_subscribe_cta): cuối narration chưa có cụm "đăng ký kênh"/"subscribe"
-# thì tự nối thêm — có rồi thì không đụng (không đọc CTA 2 lần).
+# --- CTA cuối narration (chủ kênh 07/2026) ---
+# Mọi narration phải KẾT bằng câu CTA theo giọng của từng track:
+# - Track AI: kêu gọi ĐĂNG KÝ KÊNH (script long đã có sẵn trong prompt; short
+#   trước đây chỉ "Follow..." giọng TikTok).
+# - Track Drama: chủ kênh chọn giọng "follow" — "Follow để nghe chuyện đời
+#   mỗi ngày" (phù hợp cả YouTube lẫn TikTok của kênh drama).
+# Prompt đã được sửa để LLM tự viết CTA tự nhiên; 2 câu dưới là lưới an toàn
+# tầng code (video.text_preprocessor.ensure_subscribe_cta): cuối narration
+# chưa có cụm CTA thì tự nối thêm — có rồi thì không đụng (không đọc 2 lần).
+# Drama nhận diện thêm cụm "follow" (extra marker trong build_narration).
 AI_SUBSCRIBE_CTA = os.getenv(
     "AI_SUBSCRIBE_CTA",
     "Đăng ký kênh để không bỏ lỡ tin AI mỗi ngày nhé!")
 DRAMA_SUBSCRIBE_CTA = os.getenv(
     "DRAMA_SUBSCRIBE_CTA",
-    "Nếu thấy câu chuyện đáng suy ngẫm, đăng ký kênh để nghe chuyện mới mỗi ngày nhé!")
+    "Follow để nghe chuyện đời mỗi ngày nhé!")
 
 
 def encode_settings(video_type: str) -> tuple[int, int]:

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -252,6 +252,50 @@ MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music")
 DRAMA_MUSIC_DIR = os.path.join(os.path.dirname(__file__), "video", "assets", "music_drama")
 BGM_VOLUME_DB = float(os.getenv("BGM_VOLUME_DB", "-18"))  # music gain relative to voice
 
+# --- Output encode size control (issue #103) ---
+# Both composers already encode with CRF (quality-based, bitrate floats free),
+# so a motion-heavy multi-clip AI short ballooned to ~7.8 Mbps / 50 MB per 53s
+# while static-background drama sat at ~355 kbps — same CRF 23, different
+# content. Fix = keep CRF (quality-driven) but CAP the bitrate with
+# -maxrate/-bufsize, and use a slightly higher CRF for shorts (phone viewing;
+# YouTube/TikTok re-encode anyway). 0 kbps = no cap. Applies to the FINAL
+# encode only — intermediates (scene segments, multi-bg pre-pass) keep CRF 23
+# since they get re-encoded by the final pass.
+VIDEO_CRF_LONG = int(os.getenv("VIDEO_CRF_LONG", "23"))
+VIDEO_CRF_SHORT = int(os.getenv("VIDEO_CRF_SHORT", "26"))
+VIDEO_MAXRATE_KBPS_LONG = int(os.getenv("VIDEO_MAXRATE_KBPS_LONG", "4000"))
+VIDEO_MAXRATE_KBPS_SHORT = int(os.getenv("VIDEO_MAXRATE_KBPS_SHORT", "3000"))
+
+
+# --- Drama scene backgrounds (issue #103) ---
+# Số ảnh minh hoạ AI RIÊNG BIỆT tối đa cho một story: scene i dùng variant
+# (i % N) nên 6 scene mặc định chia nhau 3 ảnh — đủ đa dạng mà không nhân
+# chi phí Replicate theo số scene. Variant 0 trùng cache key với thumbnail
+# (main_drama.py dùng index=0) nên 1 call luôn được tái dùng.
+DRAMA_ILLUSTRATION_VARIANTS = max(1, int(os.getenv("DRAMA_ILLUSTRATION_VARIANTS", "3")))
+# Hiệu ứng zoom chậm (Ken Burns) trên các scene nền ảnh tĩnh — đỡ cảm giác
+# "đứng hình". 0 = ảnh tĩnh như cũ (và composer tự retry static nếu render
+# motion lỗi, không bao giờ chặn video).
+DRAMA_SCENE_MOTION = os.getenv("DRAMA_SCENE_MOTION", "1") == "1"
+
+
+def encode_settings(video_type: str) -> tuple[int, int]:
+    """(crf, maxrate_kbps) cho final encode của một video type.
+
+    Single source of truth để video_composer/drama_composer không rải hằng số
+    encode khắp nơi. Giá trị ngoài dải hợp lệ tự kẹp về mặc định an toàn
+    (validate_flags() cũng cảnh báo) thay vì để ffmpeg fail giữa render.
+    """
+    if video_type == "short":
+        crf, maxrate = VIDEO_CRF_SHORT, VIDEO_MAXRATE_KBPS_SHORT
+    else:
+        crf, maxrate = VIDEO_CRF_LONG, VIDEO_MAXRATE_KBPS_LONG
+    if not 0 <= crf <= 51:          # dải hợp lệ của libx264
+        crf = 23
+    if maxrate < 0:
+        maxrate = 0
+    return crf, maxrate
+
 # Allowed values for the string-valued flags above (used by validate_flags()).
 _FLAG_CHOICES = {
     "SUBTITLE_TIMING_MODE": {"wordcount", "whisper"},
@@ -311,6 +355,24 @@ def validate_flags(logger=None):
         if value not in allowed:
             msg = (f"{name}={value!r} is not one of {sorted(allowed)}; "
                    f"falling back to legacy behaviour")
+            issues.append(msg)
+            if logger is not None:
+                logger.warning("Invalid video flag: %s", msg)
+
+    # Encode size controls (issue #103): CRF must be 0-51 (libx264), maxrate
+    # must be >= 0 kbps (0 = uncapped). encode_settings() clamps at use time;
+    # this just surfaces the misconfiguration.
+    for name, value in (("VIDEO_CRF_LONG", VIDEO_CRF_LONG),
+                        ("VIDEO_CRF_SHORT", VIDEO_CRF_SHORT)):
+        if not 0 <= value <= 51:
+            msg = f"{name}={value} outside libx264 range 0-51; using CRF 23"
+            issues.append(msg)
+            if logger is not None:
+                logger.warning("Invalid video flag: %s", msg)
+    for name, value in (("VIDEO_MAXRATE_KBPS_LONG", VIDEO_MAXRATE_KBPS_LONG),
+                        ("VIDEO_MAXRATE_KBPS_SHORT", VIDEO_MAXRATE_KBPS_SHORT)):
+        if value < 0:
+            msg = f"{name}={value} is negative; treating as 0 (uncapped)"
             issues.append(msg)
             if logger is not None:
                 logger.warning("Invalid video flag: %s", msg)

--- a/content-pipeline/main.py
+++ b/content-pipeline/main.py
@@ -313,7 +313,11 @@ def _create_video(narrative: str, video_type: str, date_str: str,
         logger.error("Script generation failed for %s video", video_type)
         return None
 
-    script_text = script_data["script"]
+    # CTA đăng ký kênh (chủ kênh 07/2026): prompt đã yêu cầu nhưng LLM có thể
+    # quên — guarantee ở đây TRƯỚC khi lưu DB/TTS/subtitle để cả 3 dùng chung
+    # một text (audio và phụ đề luôn khớp). Đã có CTA thì hàm không đụng gì.
+    from video.text_preprocessor import ensure_subscribe_cta
+    script_text = ensure_subscribe_cta(script_data["script"], config.AI_SUBSCRIBE_CTA)
     youtube_title = script_data.get("youtube_title", "")
     youtube_desc = script_data.get("youtube_description", "")
     tiktok_caption = script_data.get("tiktok_caption", "")

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -137,12 +137,14 @@ def build_narration(rewrite: dict) -> str:
     if commentary and not _spoken_duplicate(commentary, script):
         parts.append(commentary)
 
-    # CTA đăng ký kênh (chủ kênh 07/2026): narration drama phải kết bằng câu
-    # kêu gọi đăng ký như narrative track AI. Guarantee tầng code — prompt
+    # CTA cuối narration (chủ kênh 07/2026): drama kết bằng giọng "follow"
+    # ("Follow để nghe chuyện đời mỗi ngày"). Guarantee tầng code — prompt
     # rewriter đã dặn nhưng story cũ/model không nghe lời vẫn được cứu; đã có
-    # CTA trong commentary thì hàm không nối gì (không đọc 2 lần).
+    # CTA trong commentary (kể cả biến thể "follow"/"đăng ký kênh") thì hàm
+    # không nối gì (không đọc 2 lần).
     from video.text_preprocessor import ensure_subscribe_cta
-    return ensure_subscribe_cta("\n\n".join(parts), config.DRAMA_SUBSCRIBE_CTA)
+    return ensure_subscribe_cta("\n\n".join(parts), config.DRAMA_SUBSCRIBE_CTA,
+                                extra_markers=("follow",))
 
 
 def _dispatch_stuck_videos() -> int:

--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -136,7 +136,13 @@ def build_narration(rewrite: dict) -> str:
         parts.append(reactions)
     if commentary and not _spoken_duplicate(commentary, script):
         parts.append(commentary)
-    return "\n\n".join(parts)
+
+    # CTA đăng ký kênh (chủ kênh 07/2026): narration drama phải kết bằng câu
+    # kêu gọi đăng ký như narrative track AI. Guarantee tầng code — prompt
+    # rewriter đã dặn nhưng story cũ/model không nghe lời vẫn được cứu; đã có
+    # CTA trong commentary thì hàm không nối gì (không đọc 2 lần).
+    from video.text_preprocessor import ensure_subscribe_cta
+    return ensure_subscribe_cta("\n\n".join(parts), config.DRAMA_SUBSCRIBE_CTA)
 
 
 def _dispatch_stuck_videos() -> int:

--- a/content-pipeline/prompts/drama/rewriter.v2.txt
+++ b/content-pipeline/prompts/drama/rewriter.v2.txt
@@ -8,7 +8,7 @@ Quy tắc bắt buộc:
 1. Đổi tên nhân vật sang tên Việt (Linh, Tuấn, Mai, Hùng, Thu...)
 2. Đổi địa điểm sang Việt Nam (Quận 1, Hà Đông, chung cư X, công ty Y)
 3. Đổi văn hoá đặc thù: mâm cơm Việt, lì xì Tết, sếp người Việt, mẹ chồng nàng dâu, hội bạn nhậu
-4. THÊM 1 đoạn "bình luận góc nhìn Việt" khoảng 80-120 từ - đây là điểm tạo unique value (không có trong Reddit gốc). Đoạn này KẾT bằng câu hỏi mời người xem bình luận + câu kêu gọi ĐĂNG KÝ KÊNH (vd "Còn bạn thì sao, kể mình nghe dưới bình luận, và đăng ký kênh để nghe chuyện mới mỗi ngày nhé!")
+4. THÊM 1 đoạn "bình luận góc nhìn Việt" khoảng 80-120 từ - đây là điểm tạo unique value (không có trong Reddit gốc). Đoạn này KẾT bằng câu hỏi mời người xem bình luận + câu kêu gọi FOLLOW kênh (vd "Còn bạn thì sao, kể mình nghe dưới bình luận, và follow để nghe chuyện đời mỗi ngày nhé!")
 5. Cấu trúc script: Setup nhanh → Leo thang → Twist/Cao trào → Kết. Chỉ giữ 1 tuyến xung đột chính, cắt hết chi tiết phụ không phục vụ cao trào.
 6. Độ dài: "script" 250-400 từ. TỔNG các phần đọc (hook + script + vn_reactions + vn_commentary) khoảng 400-550 từ — tương đương 2-3 phút TTS. TUYỆT ĐỐI không viết dài hơn.
 7. "script" KHÔNG được mở đầu bằng cách lặp lại "title" hay "hook" — hook là field riêng và sẽ được đọc TRƯỚC script, lặp lại sẽ khiến video đọc trùng 2 lần. Script bắt đầu thẳng vào bối cảnh câu chuyện.

--- a/content-pipeline/prompts/drama/rewriter.v2.txt
+++ b/content-pipeline/prompts/drama/rewriter.v2.txt
@@ -8,7 +8,7 @@ Quy tắc bắt buộc:
 1. Đổi tên nhân vật sang tên Việt (Linh, Tuấn, Mai, Hùng, Thu...)
 2. Đổi địa điểm sang Việt Nam (Quận 1, Hà Đông, chung cư X, công ty Y)
 3. Đổi văn hoá đặc thù: mâm cơm Việt, lì xì Tết, sếp người Việt, mẹ chồng nàng dâu, hội bạn nhậu
-4. THÊM 1 đoạn "bình luận góc nhìn Việt" khoảng 80-120 từ - đây là điểm tạo unique value (không có trong Reddit gốc)
+4. THÊM 1 đoạn "bình luận góc nhìn Việt" khoảng 80-120 từ - đây là điểm tạo unique value (không có trong Reddit gốc). Đoạn này KẾT bằng câu hỏi mời người xem bình luận + câu kêu gọi ĐĂNG KÝ KÊNH (vd "Còn bạn thì sao, kể mình nghe dưới bình luận, và đăng ký kênh để nghe chuyện mới mỗi ngày nhé!")
 5. Cấu trúc script: Setup nhanh → Leo thang → Twist/Cao trào → Kết. Chỉ giữ 1 tuyến xung đột chính, cắt hết chi tiết phụ không phục vụ cao trào.
 6. Độ dài: "script" 250-400 từ. TỔNG các phần đọc (hook + script + vn_reactions + vn_commentary) khoảng 400-550 từ — tương đương 2-3 phút TTS. TUYỆT ĐỐI không viết dài hơn.
 7. "script" KHÔNG được mở đầu bằng cách lặp lại "title" hay "hook" — hook là field riêng và sẽ được đọc TRƯỚC script, lặp lại sẽ khiến video đọc trùng 2 lần. Script bắt đầu thẳng vào bối cảnh câu chuyện.

--- a/content-pipeline/tests/test_drama_composer.py
+++ b/content-pipeline/tests/test_drama_composer.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import config as dc_config
 from video.drama_composer import (
     _lavfi_source,
     _resolve_scene_background,
@@ -92,6 +93,70 @@ class TestBuildSceneSegmentCommand(unittest.TestCase):
         self.assertIn("-t", cmd)
         self.assertIn("3.0", cmd)
 
+    def test_all_segments_normalized_to_scene_fps(self):
+        # Mixed lavfi (default 25fps) + zoompan segments feed a stream-copy
+        # concat — every path must emit the same frame rate.
+        lavfi_cmd = build_scene_segment_command(
+            "color=c=0x000000:s=1080x1920", is_lavfi=True, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg0.mp4",
+        )
+        static_cmd = build_scene_segment_command(
+            "/tmp/ill.png", is_lavfi=False, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg1.mp4",
+        )
+        self.assertIn("fps=30", lavfi_cmd[lavfi_cmd.index("-vf") + 1])
+        self.assertIn("fps=30", static_cmd[static_cmd.index("-vf") + 1])
+
+    def test_motion_uses_zoompan_single_frame_input(self):
+        cmd = build_scene_segment_command(
+            "/tmp/ill.png", is_lavfi=False, duration=2.0,
+            width=1080, height=1920, output_path="/tmp/seg.mp4",
+            motion=True, zoom_in=True,
+        )
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertIn("zoompan=", vf)
+        self.assertIn("d=60", vf)          # 2.0s * 30fps
+        self.assertIn("s=1080x1920", vf)
+        # zoompan synthesizes frames from ONE still — no input loop needed.
+        self.assertNotIn("-stream_loop", cmd)
+
+    def test_motion_zoom_out_expression(self):
+        cmd = build_scene_segment_command(
+            "/tmp/ill.png", is_lavfi=False, duration=2.0,
+            width=1080, height=1920, output_path="/tmp/seg.mp4",
+            motion=True, zoom_in=False,
+        )
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertIn("z='1+0.1-0.1*on/60'", vf)
+
+    def test_motion_ignored_for_lavfi(self):
+        cmd = build_scene_segment_command(
+            "color=c=0x000000:s=1080x1920", is_lavfi=True, duration=3.0,
+            width=1080, height=1920, output_path="/tmp/seg.mp4", motion=True,
+        )
+        self.assertNotIn("zoompan", " ".join(cmd))
+
+    def test_darken_appends_eq_filter(self):
+        cmd = build_scene_segment_command(
+            "/tmp/ill.png", is_lavfi=False, duration=2.0,
+            width=1080, height=1920, output_path="/tmp/seg.mp4", darken=True,
+        )
+        vf = cmd[cmd.index("-vf") + 1]
+        self.assertIn("eq=brightness=", vf)
+
+    def test_darken_applied_before_overlay(self):
+        # The overlay PNG (lower third / commentary card) must keep full
+        # brightness — darken belongs to the background chain only.
+        cmd = build_scene_segment_command(
+            "/tmp/ill.png", is_lavfi=False, duration=2.0,
+            width=1080, height=1920, output_path="/tmp/seg.mp4",
+            overlay_png="/tmp/card.png", darken=True,
+        )
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        base_chain, overlay_chain = fc.split(";", 1)
+        self.assertIn("eq=brightness=", base_chain)
+        self.assertNotIn("eq=brightness=", overlay_chain)
+
 
 class TestBuildSceneConcatCommand(unittest.TestCase):
     def test_stream_copy_concat(self):
@@ -152,13 +217,61 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertEqual(source, "/tmp/illustration_0.png")
         mock_gen.assert_called_once_with("a lonely office", index=0)
 
+    @patch("video.drama_composer.cached_illustration")
     @patch("video.drama_composer.generate_illustration")
-    def test_illustration_failure_falls_back(self, mock_gen):
+    def test_illustration_failure_falls_back(self, mock_gen, mock_cached):
         mock_gen.return_value = None
+        mock_cached.return_value = None
         scene = {"background": "illustration_dark"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 1, "a prompt")
         self.assertTrue(is_lavfi)
         self.assertIn("color=c=0x1B3A5C", source)
+
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_illustration_failure_reuses_cached_variant(self, mock_gen, mock_cached):
+        # Issue #103: a Replicate failure must reuse the story's cached
+        # illustration (e.g. the thumbnail's index 0), not drop to a color.
+        mock_gen.return_value = None
+        mock_cached.return_value = "/tmp/cached_0.png"
+        scene = {"background": "illustration", "fallback": "gradient_warm"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 2, "a prompt")
+        self.assertFalse(is_lavfi)
+        self.assertEqual(source, "/tmp/cached_0.png")
+        mock_cached.assert_called_once_with("a prompt", preferred_index=2)
+
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_illustration_failure_uses_scene_fallback_key(self, mock_gen, mock_cached):
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        scene = {"background": "illustration", "fallback": "gradient_warm"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
+        self.assertTrue(is_lavfi)
+        self.assertIn("gradients=", source)
+
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_generation_failure_memoized_across_scenes(self, mock_gen, mock_cached):
+        # One live failure must stop API attempts for the rest of the run
+        # (each failed attempt can burn up to the Replicate poll timeout).
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        gen_state = {}
+        for i in range(4):
+            scene = {"background": "illustration", "fallback": "solid_blue"}
+            _resolve_scene_background(scene, 1080, 1920, i, "a prompt", gen_state)
+        mock_gen.assert_called_once()
+        self.assertEqual(mock_cached.call_count, 4)
+
+    @patch("video.drama_composer.config")
+    @patch("video.drama_composer.generate_illustration")
+    def test_variant_mapping_wraps_by_config(self, mock_gen, mock_config):
+        mock_config.DRAMA_ILLUSTRATION_VARIANTS = 3
+        mock_gen.return_value = "/tmp/ill.png"
+        scene = {"background": "illustration"}
+        _resolve_scene_background(scene, 1080, 1920, 4, "a prompt")
+        mock_gen.assert_called_once_with("a prompt", index=1)  # 4 % 3
 
     def test_illustration_without_prompt_falls_back(self):
         scene = {"background": "illustration"}
@@ -238,6 +351,37 @@ class TestBuildDramaSceneReelMocked(unittest.TestCase):
         }
         build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp, lower_third=None)
         mock_lt.assert_not_called()
+
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    @patch("video.drama_composer._run_ffmpeg")
+    def test_motion_segment_failure_retries_static(self, mock_run, mock_gen, mock_cached):
+        # Ken Burns is best-effort: if the zoompan render fails, the scene is
+        # retried without motion instead of aborting the reel.
+        mock_gen.return_value = "/tmp/ill.png"
+        mock_cached.return_value = None
+        calls = []
+
+        def run_side_effect(cmd, out):
+            calls.append(cmd)
+            if any("zoompan" in str(a) for a in cmd):
+                return None
+            return out
+
+        mock_run.side_effect = run_side_effect
+        template = {
+            "duration_target": 10,
+            "scenes": [
+                {"type": "hook", "duration": 10, "background": "illustration",
+                 "fallback": "gradient_warm", "lower_third": False, "commentary": False},
+            ],
+        }
+        with patch.object(dc_config, "DRAMA_SCENE_MOTION", True):
+            reel = build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp,
+                                          thumbnail_prompt="a prompt")
+        self.assertIsNotNone(reel)
+        # 1 failed motion attempt + 1 static retry + 1 concat
+        self.assertEqual(len(calls), 3)
 
     @patch("video.drama_composer.render_commentary_card")
     @patch("video.drama_composer._run_ffmpeg")

--- a/content-pipeline/tests/test_drama_composer.py
+++ b/content-pipeline/tests/test_drama_composer.py
@@ -217,9 +217,10 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertEqual(source, "/tmp/illustration_0.png")
         mock_gen.assert_called_once_with("a lonely office", index=0)
 
+    @patch("video.pexels_downloader.get_photos", return_value=[])
     @patch("video.drama_composer.cached_illustration")
     @patch("video.drama_composer.generate_illustration")
-    def test_illustration_failure_falls_back(self, mock_gen, mock_cached):
+    def test_illustration_failure_falls_back(self, mock_gen, mock_cached, _photos):
         mock_gen.return_value = None
         mock_cached.return_value = None
         scene = {"background": "illustration_dark"}
@@ -240,9 +241,67 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertEqual(source, "/tmp/cached_0.png")
         mock_cached.assert_called_once_with("a prompt", preferred_index=2)
 
+    @patch("video.pexels_downloader.get_photos")
     @patch("video.drama_composer.cached_illustration")
     @patch("video.drama_composer.generate_illustration")
-    def test_illustration_failure_uses_scene_fallback_key(self, mock_gen, mock_cached):
+    def test_photo_fallback_when_no_illustration_at_all(self, mock_gen,
+                                                        mock_cached, mock_photos):
+        # Owner request 07/2026: no AI illustration AND no cache must still
+        # yield an IMAGE (Pexels photo), not a solid color.
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        mock_photos.return_value = ["/tmp/p0.jpg", "/tmp/p1.jpg"]
+        scene = {"background": "illustration", "fallback": "gradient_warm"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 1, "a prompt")
+        self.assertFalse(is_lavfi)
+        self.assertEqual(source, "/tmp/p1.jpg")  # variant 1 % 2 photos
+
+    @patch("video.pexels_downloader.get_photos")
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_photo_lookup_memoized_per_run(self, mock_gen, mock_cached, mock_photos):
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        mock_photos.return_value = ["/tmp/p0.jpg"]
+        gen_state = {}
+        for i in range(4):
+            scene = {"background": "illustration", "fallback": "solid_blue"}
+            _resolve_scene_background(scene, 1080, 1920, i, "a prompt", gen_state)
+        mock_photos.assert_called_once()
+
+    @patch("video.pexels_downloader.get_photos")
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_photo_generic_query_tried_when_prompt_finds_nothing(
+            self, mock_gen, mock_cached, mock_photos):
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        mock_photos.side_effect = [[], ["/tmp/generic0.jpg"]]
+        scene = {"background": "illustration", "fallback": "solid_blue"}
+        source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
+        self.assertFalse(is_lavfi)
+        self.assertEqual(source, "/tmp/generic0.jpg")
+        self.assertEqual(mock_photos.call_count, 2)
+
+    @patch("video.pexels_downloader.get_photos")
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_photo_fallback_disabled_falls_to_color(self, mock_gen,
+                                                    mock_cached, mock_photos):
+        mock_gen.return_value = None
+        mock_cached.return_value = None
+        scene = {"background": "illustration", "fallback": "gradient_warm"}
+        with patch.object(dc_config, "DRAMA_PHOTO_FALLBACK_ENABLED", False):
+            source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
+        mock_photos.assert_not_called()
+        self.assertTrue(is_lavfi)
+        self.assertIn("gradients=", source)
+
+    @patch("video.pexels_downloader.get_photos", return_value=[])
+    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.generate_illustration")
+    def test_illustration_failure_uses_scene_fallback_key(self, mock_gen,
+                                                          mock_cached, _photos):
         mock_gen.return_value = None
         mock_cached.return_value = None
         scene = {"background": "illustration", "fallback": "gradient_warm"}
@@ -250,9 +309,11 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertTrue(is_lavfi)
         self.assertIn("gradients=", source)
 
+    @patch("video.pexels_downloader.get_photos", return_value=[])
     @patch("video.drama_composer.cached_illustration")
     @patch("video.drama_composer.generate_illustration")
-    def test_generation_failure_memoized_across_scenes(self, mock_gen, mock_cached):
+    def test_generation_failure_memoized_across_scenes(self, mock_gen,
+                                                       mock_cached, _photos):
         # One live failure must stop API attempts for the rest of the run
         # (each failed attempt can burn up to the Replicate poll timeout).
         mock_gen.return_value = None

--- a/content-pipeline/tests/test_image_generator.py
+++ b/content-pipeline/tests/test_image_generator.py
@@ -235,5 +235,34 @@ class TestGenerateIllustrations(ImageGeneratorTestBase):
         self.assertEqual(call_count["n"], 3)
 
 
+class TestCachedIllustration(ImageGeneratorTestBase):
+    """cached_illustration — zero-cost reuse of on-disk variants (issue #103)."""
+
+    def _write_variant(self, prompt: str, index: int) -> str:
+        path = image_generator._cache_path(prompt, index)
+        with open(path, "wb") as f:
+            f.write(b"png")
+        return path
+
+    def test_empty_prompt_returns_none(self):
+        self.assertIsNone(image_generator.cached_illustration(""))
+
+    def test_no_cache_returns_none(self):
+        self.assertIsNone(image_generator.cached_illustration("a prompt", 2))
+
+    def test_exact_variant_preferred(self):
+        self._write_variant("a prompt", 0)
+        want = self._write_variant("a prompt", 2)
+        self.assertEqual(image_generator.cached_illustration("a prompt", 2), want)
+
+    def test_missing_variant_reuses_another_deterministically(self):
+        only = self._write_variant("a prompt", 0)
+        self.assertEqual(image_generator.cached_illustration("a prompt", 5), only)
+
+    def test_other_prompts_cache_not_reused(self):
+        self._write_variant("some other prompt", 0)
+        self.assertIsNone(image_generator.cached_illustration("a prompt", 0))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -108,28 +108,39 @@ class TestBuildNarration(unittest.TestCase):
 
 
 class TestNarrationCta(unittest.TestCase):
-    """Owner request 07/2026: drama narration must end with a subscribe CTA."""
+    """Owner request 07/2026: drama narration ends with a follow-style CTA."""
+
+    CTA = "Follow để nghe chuyện đời mỗi ngày nhé!"
 
     def test_cta_appended_when_missing(self):
         rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
                    "vn_commentary": "Góc nhìn của mình là vậy đó."}
-        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
-                          "Đăng ký kênh nhé!"):
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA", self.CTA):
             narration = main_drama.build_narration(rewrite)
-        self.assertTrue(narration.endswith("Đăng ký kênh nhé!"))
+        self.assertTrue(narration.endswith(self.CTA))
 
-    def test_cta_not_duplicated_when_commentary_already_has_one(self):
+    def test_cta_not_duplicated_when_commentary_already_follows(self):
+        # The drama CTA is follow-flavored — a commentary that already ends
+        # with a "follow" call must not get a second CTA appended.
+        rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
+                   "vn_commentary": ("Còn bạn thì sao? Follow để nghe chuyện "
+                                     "đời mỗi ngày nhé!")}
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA", self.CTA):
+            narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.lower().count("follow"), 1)
+
+    def test_cta_not_duplicated_when_commentary_says_subscribe(self):
+        # Old stories rewritten before the prompt change may say "đăng ký
+        # kênh" — that still counts as a CTA.
         rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
                    "vn_commentary": ("Còn bạn thì sao? Đăng ký kênh để nghe "
                                      "chuyện mới mỗi ngày nhé!")}
-        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
-                          "Đăng ký kênh nhé!"):
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA", self.CTA):
             narration = main_drama.build_narration(rewrite)
-        self.assertEqual(narration.lower().count("đăng ký kênh"), 1)
+        self.assertNotIn("Follow để nghe", narration)
 
     def test_empty_rewrite_gets_no_cta(self):
-        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
-                          "Đăng ký kênh nhé!"):
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA", self.CTA):
             self.assertEqual(main_drama.build_narration({}), "")
 
 

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -16,6 +16,13 @@ import main_drama
 
 
 class TestBuildNarration(unittest.TestCase):
+    def setUp(self):
+        # The subscribe-CTA guarantee is tested separately (TestNarrationCta);
+        # blank it here so the dedupe/ordering assertions stay byte-exact.
+        self._cta = patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA", "")
+        self._cta.start()
+        self.addCleanup(self._cta.stop)
+
     def test_joins_hook_script_commentary(self):
         rewrite = {"hook": "Hook sốc!", "script": "Chuyện là thế này...",
                    "vn_commentary": "Ở Việt Nam mình..."}
@@ -98,6 +105,32 @@ class TestBuildNarration(unittest.TestCase):
                    "script": "Hôm đó là một ngày bình thường như mọi ngày khác."}
         narration = main_drama.build_narration(rewrite)
         self.assertTrue(narration.startswith("Cả nhà tôi sốc nặng!"))
+
+
+class TestNarrationCta(unittest.TestCase):
+    """Owner request 07/2026: drama narration must end with a subscribe CTA."""
+
+    def test_cta_appended_when_missing(self):
+        rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
+                   "vn_commentary": "Góc nhìn của mình là vậy đó."}
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
+                          "Đăng ký kênh nhé!"):
+            narration = main_drama.build_narration(rewrite)
+        self.assertTrue(narration.endswith("Đăng ký kênh nhé!"))
+
+    def test_cta_not_duplicated_when_commentary_already_has_one(self):
+        rewrite = {"hook": "Hook!", "script": "Câu chuyện.",
+                   "vn_commentary": ("Còn bạn thì sao? Đăng ký kênh để nghe "
+                                     "chuyện mới mỗi ngày nhé!")}
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
+                          "Đăng ký kênh nhé!"):
+            narration = main_drama.build_narration(rewrite)
+        self.assertEqual(narration.lower().count("đăng ký kênh"), 1)
+
+    def test_empty_rewrite_gets_no_cta(self):
+        with patch.object(main_drama.config, "DRAMA_SUBSCRIBE_CTA",
+                          "Đăng ký kênh nhé!"):
+            self.assertEqual(main_drama.build_narration({}), "")
 
 
 class RenderBase(unittest.TestCase):

--- a/content-pipeline/tests/test_pexels_downloader.py
+++ b/content-pipeline/tests/test_pexels_downloader.py
@@ -355,5 +355,129 @@ class TestFatalErrorStopsLoop(SearchVideosBase):
         self.assertEqual(result, [])
 
 
+class TestEnsureKeywordClips(unittest.TestCase):
+    """Owner report 07/2026: pool froze on generic clips because the
+    cache-first pass never downloaded article-keyword clips again."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._cache = patch.object(pex, "CACHE_DIR", self.tmp)
+        self._cache.start()
+        self.addCleanup(self._cache.stop)
+        self._key = patch.object(pex.config, "PEXELS_API_KEY", "pk_live")
+        self._key.start()
+        self.addCleanup(self._key.stop)
+        pex._last_pexels_error = None
+        self.addCleanup(lambda: setattr(pex, "_last_pexels_error", None))
+
+    def test_downloads_uncached_keywords_up_to_budget(self):
+        calls = []
+        with patch.object(pex.config, "BG_KEYWORD_DOWNLOADS", 2), \
+             patch.object(pex, "_search_and_download",
+                          side_effect=lambda q, o: calls.append(q)):
+            pex._ensure_keyword_clips(["a", "b", "c"], "portrait")
+        self.assertEqual(calls, ["a", "b"])
+
+    def test_cached_keyword_does_not_consume_budget(self):
+        cached = pex._cached_path("a", "portrait")
+        with open(cached, "wb") as f:
+            f.write(b"x")
+        calls = []
+        with patch.object(pex.config, "BG_KEYWORD_DOWNLOADS", 1), \
+             patch.object(pex, "_search_and_download",
+                          side_effect=lambda q, o: calls.append(q)):
+            pex._ensure_keyword_clips(["a", "b"], "portrait")
+        self.assertEqual(calls, ["b"])
+
+    def test_zero_budget_or_no_key_is_noop(self):
+        with patch.object(pex.config, "BG_KEYWORD_DOWNLOADS", 0), \
+             patch.object(pex, "_search_and_download") as mock_dl:
+            pex._ensure_keyword_clips(["a"], "portrait")
+        mock_dl.assert_not_called()
+        with patch.object(pex.config, "PEXELS_API_KEY", ""), \
+             patch.object(pex, "_search_and_download") as mock_dl:
+            pex._ensure_keyword_clips(["a"], "portrait")
+        mock_dl.assert_not_called()
+
+    def test_fatal_error_stops_immediately(self):
+        calls = []
+
+        def fake(q, o):
+            calls.append(q)
+            pex._last_pexels_error = "blocked"
+            return None
+
+        with patch.object(pex.config, "BG_KEYWORD_DOWNLOADS", 3), \
+             patch.object(pex, "_search_and_download", side_effect=fake):
+            pex._ensure_keyword_clips(["a", "b", "c"], "portrait")
+        self.assertEqual(calls, ["a"])
+
+
+class TestKeywordPrioritySelection(unittest.TestCase):
+    def test_keyword_cached_clip_beats_generic(self):
+        # A clip cached for THIS article's keyword must win over the generic
+        # pool — that's the content-match half of the owner's request.
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.object(pex, "CACHE_DIR", tmp), \
+             patch.object(pex.config, "BG_KEYWORD_DOWNLOADS", 0):
+            keyword_clip = pex._cached_path("AI robot assistant", "portrait")
+            generic_clip = pex._cached_path(pex.SEARCH_QUERIES[0], "portrait")
+            for p in (keyword_clip, generic_clip):
+                with open(p, "wb") as f:
+                    f.write(b"x")
+            chosen = pex.get_background(keywords=["AI robot assistant"],
+                                        orientation="portrait")
+        self.assertEqual(chosen, keyword_clip)
+
+
+class TestGetPhotos(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._cache = patch.object(pex, "PHOTO_CACHE_DIR", self.tmp)
+        self._cache.start()
+        self.addCleanup(self._cache.stop)
+        self._key = patch.object(pex.config, "PEXELS_API_KEY", "pk_live")
+        self._key.start()
+        self.addCleanup(self._key.stop)
+
+    def test_empty_query_returns_empty(self):
+        self.assertEqual(pex.get_photos(""), [])
+
+    def test_no_key_returns_empty_without_search(self):
+        with patch.object(pex.config, "PEXELS_API_KEY", ""), \
+             patch.object(pex, "_search_photos") as mock_search:
+            self.assertEqual(pex.get_photos("sad woman"), [])
+        mock_search.assert_not_called()
+
+    def test_cache_hit_skips_search(self):
+        key = pex._cache_key("sad woman", "portrait")
+        cached = os.path.join(self.tmp, f"{key}_0.jpg")
+        with open(cached, "wb") as f:
+            f.write(b"jpg")
+        with patch.object(pex, "_search_photos") as mock_search:
+            result = pex.get_photos("sad woman", count=3)
+        mock_search.assert_not_called()
+        self.assertEqual(result, [cached])
+
+    def test_downloads_up_to_count(self):
+        photos = [{"src": {"large2x": f"https://x/{i}.jpg"}} for i in range(5)]
+
+        def fake_download(url, out):
+            with open(out, "wb") as f:
+                f.write(b"jpg")
+            return True
+
+        with patch.object(pex, "_search_photos", return_value=photos), \
+             patch.object(pex, "_download_file", side_effect=fake_download):
+            result = pex.get_photos("sad woman", count=2)
+        self.assertEqual(len(result), 2)
+        for p in result:
+            self.assertTrue(os.path.exists(p))
+
+    def test_search_failure_returns_empty(self):
+        with patch.object(pex, "_search_photos", return_value=[]):
+            self.assertEqual(pex.get_photos("sad woman"), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_templates.py
+++ b/content-pipeline/tests/test_templates.py
@@ -68,6 +68,18 @@ class TestTemplateStructure(unittest.TestCase):
         self.assertEqual(len(lt_scenes), 1)
         self.assertEqual(lt_scenes[0]["type"], "escalation")
 
+    def test_drama_scenes_are_illustration_first_with_lavfi_fallback(self):
+        # Issue #103: every drama scene prefers an AI illustration; the color
+        # look lives in `fallback` and must be a resolvable lavfi key so the
+        # composer can never dead-end.
+        from video.drama_composer import GRADIENT_SPECS, SOLID_SPECS
+        lavfi_keys = set(GRADIENT_SPECS) | set(SOLID_SPECS)
+        for scene in DRAMA_SHORTS_TEMPLATE["scenes"]:
+            self.assertIn(scene["background"], ("illustration", "illustration_dark"),
+                          f"scene {scene['type']} is not illustration-first")
+            self.assertIn(scene["fallback"], lavfi_keys,
+                          f"scene {scene['type']} fallback is not a lavfi key")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_text_preprocessor.py
+++ b/content-pipeline/tests/test_text_preprocessor.py
@@ -206,6 +206,15 @@ class TestEnsureSubscribeCta(unittest.TestCase):
         self.assertEqual(tp.ensure_subscribe_cta("", self.CTA), "")
         self.assertEqual(tp.ensure_subscribe_cta("Nội dung.", ""), "Nội dung.")
 
+    def test_follow_only_counts_with_extra_marker(self):
+        # Track AI: "Follow..." kiểu TikTok cũ KHÔNG được tính là CTA đăng ký
+        # kênh; track drama truyền extra_markers=("follow",) thì được tính.
+        text = "Follow để nghe chuyện đời mỗi ngày nhé!"
+        appended = tp.ensure_subscribe_cta(text, self.CTA)
+        self.assertTrue(appended.endswith(self.CTA))
+        kept = tp.ensure_subscribe_cta(text, self.CTA, extra_markers=("follow",))
+        self.assertEqual(kept, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_text_preprocessor.py
+++ b/content-pipeline/tests/test_text_preprocessor.py
@@ -177,5 +177,35 @@ class TestFallbackPath(unittest.TestCase):
         self.assertIn("một phẩy năm", preprocess_for_tts("1.5 lần"))
 
 
+class TestEnsureSubscribeCta(unittest.TestCase):
+    """Owner request 07/2026: YouTube narrations must end with a subscribe CTA."""
+
+    CTA = "Đăng ký kênh để không bỏ lỡ tin AI mỗi ngày nhé!"
+
+    def test_appends_when_missing(self):
+        out = tp.ensure_subscribe_cta("Tin nóng hôm nay là vậy.", self.CTA)
+        self.assertTrue(out.endswith(self.CTA))
+
+    def test_noop_when_cta_already_at_end(self):
+        text = "Tin nóng hôm nay. Đăng ký kênh để cập nhật AI mỗi ngày nhé!"
+        self.assertEqual(tp.ensure_subscribe_cta(text, self.CTA), text)
+
+    def test_noop_for_subscribe_keyword_variant(self):
+        text = "Nhớ subscribe để không bỏ lỡ video sau nhé."
+        self.assertEqual(tp.ensure_subscribe_cta(text, self.CTA), text)
+
+    def test_mid_text_product_signup_does_not_count(self):
+        # "đăng ký ChatGPT Plus" ở giữa bài không phải CTA kênh — vẫn phải nối.
+        text = ("Bạn có thể đăng ký ChatGPT Plus để dùng thử. "
+                + "Nội dung khác kéo dài thêm. " * 20
+                + "Hẹn gặp lại ngày mai.")
+        out = tp.ensure_subscribe_cta(text, self.CTA)
+        self.assertTrue(out.endswith(self.CTA))
+
+    def test_empty_text_or_cta_untouched(self):
+        self.assertEqual(tp.ensure_subscribe_cta("", self.CTA), "")
+        self.assertEqual(tp.ensure_subscribe_cta("Nội dung.", ""), "Nội dung.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/tests/test_video_composer.py
+++ b/content-pipeline/tests/test_video_composer.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import config
 from video.video_composer import (
     _parse_srt,
     _srt_time_to_sec,
@@ -167,6 +168,49 @@ class TestBuildComposeCommand(unittest.TestCase):
         fc = cmd[cmd.index("-filter_complex") + 1]
         self.assertIn("crop=1080:1920", fc)
         self.assertNotIn("pad=", fc)
+
+    def test_default_crf_23_no_bitrate_cap(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1920, 1080, 12.0)
+        self.assertEqual(cmd[cmd.index("-crf") + 1], "23")
+        self.assertNotIn("-maxrate", cmd)
+        self.assertNotIn("-bufsize", cmd)
+
+    def test_crf_and_maxrate_flags(self):
+        # Issue #103: CRF alone let motion-heavy shorts hit ~8 Mbps; the cap
+        # bounds the peak while bufsize gives a 2x VBV window.
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1080, 1920, 53.0, fill=True,
+                                    crf=26, maxrate_kbps=3000)
+        self.assertEqual(cmd[cmd.index("-crf") + 1], "26")
+        self.assertEqual(cmd[cmd.index("-maxrate") + 1], "3000k")
+        self.assertEqual(cmd[cmd.index("-bufsize") + 1], "6000k")
+
+    def test_zero_maxrate_means_uncapped(self):
+        cmd = build_compose_command("bg.mp4", "a.mp3", "out.mp4",
+                                    1920, 1080, 12.0, crf=23, maxrate_kbps=0)
+        self.assertNotIn("-maxrate", cmd)
+
+
+class TestEncodeSettings(unittest.TestCase):
+    """config.encode_settings — single source of truth for final-encode size."""
+
+    def test_short_defaults(self):
+        crf, maxrate = config.encode_settings("short")
+        self.assertEqual((crf, maxrate),
+                         (config.VIDEO_CRF_SHORT, config.VIDEO_MAXRATE_KBPS_SHORT))
+
+    def test_long_defaults(self):
+        crf, maxrate = config.encode_settings("long")
+        self.assertEqual((crf, maxrate),
+                         (config.VIDEO_CRF_LONG, config.VIDEO_MAXRATE_KBPS_LONG))
+
+    def test_out_of_range_values_clamped(self):
+        with patch.object(config, "VIDEO_CRF_SHORT", 99), \
+             patch.object(config, "VIDEO_MAXRATE_KBPS_SHORT", -5):
+            crf, maxrate = config.encode_settings("short")
+        self.assertEqual(crf, 23)
+        self.assertEqual(maxrate, 0)
 
 
 class TestScaleFilter(unittest.TestCase):

--- a/content-pipeline/video/composer_moviepy.py
+++ b/content-pipeline/video/composer_moviepy.py
@@ -132,8 +132,15 @@ def compose(audio_path: str, subtitle_path: str, output_path: str,
             layers.append(txt)
 
         final = CompositeVideoClip(layers, size=(width, height)).with_audio(audio)
+        # Same final-encode size controls as the FFmpeg engine (issue #103) —
+        # the two engines must not produce wildly different file sizes.
+        crf, maxrate_kbps = config.encode_settings(video_type)
+        ffmpeg_params = ["-crf", str(crf)]
+        if maxrate_kbps > 0:
+            ffmpeg_params += ["-maxrate", f"{maxrate_kbps}k",
+                              "-bufsize", f"{maxrate_kbps * 2}k"]
         final.write_videofile(output_path, codec="libx264", audio_codec="aac",
-                              fps=30, preset="medium")
+                              fps=30, preset="medium", ffmpeg_params=ffmpeg_params)
         logger.info("MoviePy composed: %s", output_path)
         return output_path
     except Exception as e:

--- a/content-pipeline/video/drama_composer.py
+++ b/content-pipeline/video/drama_composer.py
@@ -176,6 +176,34 @@ def scaled_scene_durations(template: dict, total_duration: float) -> list[float]
     return [max(0.1, s["duration"] * scale) for s in scenes]
 
 
+def _pexels_photo_for_scene(prompt: str, variant: int,
+                            state: dict) -> str | None:
+    """Stock-photo fallback so every drama scene stays an IMAGE (owner request).
+
+    Order: photos matching the story's own thumbnail_prompt (on-topic), then a
+    generic dramatic-mood query. Both are cache-first inside get_photos, so a
+    story costs at most one search + a few downloads once. The result list is
+    memoized in `state` for the rest of the reel run (one lookup per video,
+    not per scene); a total miss is memoized too so later scenes skip straight
+    to their color fallback.
+    """
+    if not config.DRAMA_PHOTO_FALLBACK_ENABLED:
+        return None
+    if "photos" not in state:
+        from video.pexels_downloader import get_photos
+        photos = get_photos(prompt[:80], count=config.DRAMA_ILLUSTRATION_VARIANTS,
+                            orientation="portrait")
+        if not photos and config.DRAMA_PHOTO_GENERIC_QUERY:
+            photos = get_photos(config.DRAMA_PHOTO_GENERIC_QUERY,
+                                count=config.DRAMA_ILLUSTRATION_VARIANTS,
+                                orientation="portrait")
+        state["photos"] = photos
+    photos = state["photos"]
+    if not photos:
+        return None
+    return photos[variant % len(photos)]
+
+
 def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
                               thumbnail_prompt: str | None,
                               gen_state: dict | None = None) -> tuple[str, bool]:
@@ -193,7 +221,10 @@ def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
        next five.
     2. cached_illustration() — reuse ANY cached variant of this story's
        prompt (e.g. the thumbnail's index 0) at zero cost.
-    3. The scene's declarative `fallback` lavfi key (its designed color
+    3. Pexels stock photo matching the prompt (then a generic dramatic-mood
+       query) — every scene stays an IMAGE even when Replicate is down
+       (_pexels_photo_for_scene, owner request 07/2026).
+    4. The scene's declarative `fallback` lavfi key (its designed color
        mood), then _FALLBACK_BACKGROUND as the absolute last resort.
     """
     background_key = scene["background"]
@@ -220,6 +251,11 @@ def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
             logger.info("Scene %d: reusing cached illustration %s",
                         index, os.path.basename(cached))
             return cached, False
+        photo = _pexels_photo_for_scene(thumbnail_prompt, variant, state)
+        if photo is not None:
+            logger.info("Scene %d: using Pexels photo fallback %s",
+                        index, os.path.basename(photo))
+            return photo, False
         logger.info("No AI illustration available for scene %d — using fallback background", index)
 
     # Unresolvable symbolic background (e.g. "screen_record" outside the AI

--- a/content-pipeline/video/drama_composer.py
+++ b/content-pipeline/video/drama_composer.py
@@ -19,6 +19,7 @@ overlay when it's not supplied — never a hard failure.
 """
 
 import logging
+import math
 import os
 import tempfile
 
@@ -29,7 +30,7 @@ from video.video_composer import _scale_filter, _run_ffmpeg, compose_video
 from video.templates import load_template
 from video.lower_third import render_lower_third
 from video.commentary_card import render_commentary_card
-from video.image_generator import generate_illustration
+from video.image_generator import generate_illustration, cached_illustration
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,18 @@ SOLID_SPECS = {
     "solid_brand": "0x0D1B2A",
 }
 _FALLBACK_BACKGROUND = "solid_blue"
+
+# All scene segments are normalized to one frame rate so the stream-copy
+# concat never mixes fps (lavfi sources default to 25, zoompan is told its
+# own fps — without this the reel's timestamps would drift between scenes).
+_SCENE_FPS = 30
+# Ken Burns zoom travel over a scene (1.0 → 1.0+range). Subtle on purpose:
+# strong zooms on AI stills read as cheap slideshow.
+_ZOOM_RANGE = 0.10
+# eq filter params for "illustration_dark" scenes: dim + slightly desaturate
+# so the twist scene reads darker and the commentary card stays legible on
+# top of a busy image.
+_DARKEN_FILTER = "eq=brightness=-0.18:saturation=0.85"
 
 
 def _lavfi_source(background: str, width: int, height: int) -> str | None:
@@ -63,7 +76,9 @@ def _lavfi_source(background: str, width: int, height: int) -> str | None:
 def build_scene_segment_command(background: str, is_lavfi: bool, duration: float,
                                 width: int, height: int, output_path: str,
                                 overlay_png: str | None = None,
-                                fill: bool = True) -> list[str]:
+                                fill: bool = True, motion: bool = False,
+                                zoom_in: bool = True,
+                                darken: bool = False) -> list[str]:
     """Build the ffmpeg command for ONE scene segment (pure, unit-testable).
 
     Args:
@@ -71,23 +86,51 @@ def build_scene_segment_command(background: str, is_lavfi: bool, duration: float
             file path to loop (is_lavfi=False, e.g. an AI illustration PNG).
         overlay_png: lower-third or commentary-card PNG, composited for the
             full segment duration when given.
+        motion: still-image sources only — animate a slow Ken Burns zoom via
+            zoompan instead of holding a frozen frame (issue #103: static
+            AI-image scenes read as dead air). Ignored for lavfi sources.
+        zoom_in: zoom direction for `motion` (alternate per scene for variety).
+        darken: dim + desaturate the background (illustration_dark scenes),
+            applied AFTER scaling so the overlay PNG keeps full brightness.
     """
     scale_pad = _scale_filter(width, height, fill)
 
     if is_lavfi:
         cmd = ["ffmpeg", "-y", "-f", "lavfi", "-i", f"{background}:d={duration}"]
+        chain = f"{scale_pad},fps={_SCENE_FPS}"
+    elif motion:
+        # A single still frame in; zoompan synthesizes every output frame, so
+        # no -stream_loop is needed. Pre-scaling to 2x the target size keeps
+        # the subpixel pan smooth (zoompan at 1:1 visibly jitters).
+        frames = max(1, math.ceil(duration * _SCENE_FPS))
+        big_w, big_h = width * 2, height * 2
+        if zoom_in:
+            zexpr = f"1+{_ZOOM_RANGE}*on/{frames}"
+        else:
+            zexpr = f"1+{_ZOOM_RANGE}-{_ZOOM_RANGE}*on/{frames}"
+        cmd = ["ffmpeg", "-y", "-i", background]
+        chain = (
+            f"scale={big_w}:{big_h}:force_original_aspect_ratio=increase,"
+            f"crop={big_w}:{big_h},"
+            f"zoompan=z='{zexpr}':x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)'"
+            f":d={frames}:s={width}x{height}:fps={_SCENE_FPS}"
+        )
     else:
         cmd = ["ffmpeg", "-y", "-stream_loop", "-1", "-i", background]
+        chain = f"{scale_pad},fps={_SCENE_FPS}"
+
+    if darken:
+        chain += f",{_DARKEN_FILTER}"
 
     if overlay_png:
         cmd += ["-i", overlay_png]
         cmd += [
             "-filter_complex",
-            f"[0:v]{scale_pad}[base];[base][1:v]overlay=shortest=0[v]",
+            f"[0:v]{chain}[base];[base][1:v]overlay=shortest=0[v]",
             "-map", "[v]",
         ]
     else:
-        cmd += ["-vf", scale_pad, "-map", "0:v"]
+        cmd += ["-vf", chain, "-map", "0:v"]
 
     cmd += [
         "-t", str(duration),
@@ -134,27 +177,57 @@ def scaled_scene_durations(template: dict, total_duration: float) -> list[float]
 
 
 def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
-                              thumbnail_prompt: str | None) -> tuple[str, bool]:
+                              thumbnail_prompt: str | None,
+                              gen_state: dict | None = None) -> tuple[str, bool]:
     """Resolve a scene's symbolic `background` key to an ffmpeg input source.
 
-    Returns (source, is_lavfi). AI illustrations that fail to generate (no
-    API token, network error, ...) fall back to a plain gradient rather than
-    failing the whole scene.
+    Returns (source, is_lavfi). Resolution order for illustration scenes
+    (issue #103 — a Replicate failure used to drop a scene straight to a
+    solid color even when the same story had illustrations sitting in cache):
+
+    1. generate_illustration() for variant (index % DRAMA_ILLUSTRATION_VARIANTS)
+       — a cache hit is free; a live API call otherwise. After the FIRST live
+       failure in this reel run (`gen_state`), later scenes skip the API
+       entirely: each failed attempt can burn up to the Replicate poll
+       timeout, and one hard failure (revoked token, rate limit) predicts the
+       next five.
+    2. cached_illustration() — reuse ANY cached variant of this story's
+       prompt (e.g. the thumbnail's index 0) at zero cost.
+    3. The scene's declarative `fallback` lavfi key (its designed color
+       mood), then _FALLBACK_BACKGROUND as the absolute last resort.
     """
     background_key = scene["background"]
+    state = gen_state if gen_state is not None else {}
 
     lavfi = _lavfi_source(background_key, width, height)
     if lavfi is not None:
         return lavfi, True
 
     if background_key in ("illustration", "illustration_dark") and thumbnail_prompt:
-        illustration = generate_illustration(thumbnail_prompt, index=index)
-        if illustration is not None:
-            return illustration, False
+        variant = index % config.DRAMA_ILLUSTRATION_VARIANTS
+        if not state.get("generation_failed"):
+            illustration = generate_illustration(thumbnail_prompt, index=variant)
+            if illustration is not None:
+                return illustration, False
+            state["generation_failed"] = True
+            logger.warning(
+                "Illustration generation failed (scene %d) — remaining scenes "
+                "will reuse cached illustrations or color fallbacks this run",
+                index,
+            )
+        cached = cached_illustration(thumbnail_prompt, preferred_index=variant)
+        if cached is not None:
+            logger.info("Scene %d: reusing cached illustration %s",
+                        index, os.path.basename(cached))
+            return cached, False
         logger.info("No AI illustration available for scene %d — using fallback background", index)
 
     # Unresolvable symbolic background (e.g. "screen_record" outside the AI
-    # track, or illustration unavailable) — safe, always-available fallback.
+    # track, or illustration unavailable) — the scene's declared fallback
+    # color first, then the safe always-available default.
+    fallback = _lavfi_source(scene.get("fallback", ""), width, height)
+    if fallback is not None:
+        return fallback, True
     return _lavfi_source(_FALLBACK_BACKGROUND, width, height), True
 
 
@@ -177,6 +250,11 @@ def build_drama_scene_reel(
     scenes = template["scenes"]
     durations = scaled_scene_durations(template, total_duration)
 
+    # Shared across this run's scenes: after one live Replicate failure the
+    # remaining scenes go straight to cache-reuse instead of re-hitting the
+    # API (see _resolve_scene_background).
+    gen_state: dict = {}
+
     segment_paths = []
     for i, (scene, duration) in enumerate(zip(scenes, durations)):
         overlay_png = None
@@ -190,12 +268,27 @@ def build_drama_scene_reel(
                 vn_commentary, width, height, os.path.join(tmpdir, f"overlay_{i}.png"),
             )
 
-        source, is_lavfi = _resolve_scene_background(scene, width, height, i, thumbnail_prompt)
+        source, is_lavfi = _resolve_scene_background(scene, width, height, i,
+                                                     thumbnail_prompt, gen_state)
+        darken = (not is_lavfi) and scene["background"] == "illustration_dark"
+        motion = (not is_lavfi) and config.DRAMA_SCENE_MOTION
 
         seg_path = os.path.join(tmpdir, f"scene_{i}.mp4")
         cmd = build_scene_segment_command(source, is_lavfi, duration, width, height,
-                                          seg_path, overlay_png=overlay_png, fill=fill)
-        if _run_ffmpeg(cmd, seg_path) is None:
+                                          seg_path, overlay_png=overlay_png, fill=fill,
+                                          motion=motion, zoom_in=(i % 2 == 0),
+                                          darken=darken)
+        rendered = _run_ffmpeg(cmd, seg_path)
+        if rendered is None and motion:
+            # Ken Burns is a nice-to-have — a zoompan hiccup (odd ffmpeg build,
+            # unusual image) must not cost the whole video. Retry static.
+            logger.warning("Scene %d motion render failed — retrying static", i)
+            cmd = build_scene_segment_command(source, is_lavfi, duration, width,
+                                              height, seg_path,
+                                              overlay_png=overlay_png, fill=fill,
+                                              darken=darken)
+            rendered = _run_ffmpeg(cmd, seg_path)
+        if rendered is None:
             logger.error("Failed to render scene %d (%s) — aborting scene reel",
                          i, scene["type"])
             return None

--- a/content-pipeline/video/image_generator.py
+++ b/content-pipeline/video/image_generator.py
@@ -48,6 +48,38 @@ def _cache_path(prompt: str, index: int) -> str:
     return os.path.join(CACHE_DIR, f"{digest}_{index}.png")
 
 
+def cached_illustration(prompt: str, preferred_index: int = 0) -> str | None:
+    """Return an ALREADY-CACHED illustration for `prompt` without any API call.
+
+    Prefers the exact (prompt, preferred_index) file; otherwise picks a
+    deterministic variant among whatever cache exists for this prompt (so two
+    scenes asking for different missing variants still get different images
+    when possible). Returns None when nothing is cached.
+
+    Issue #103: when Replicate fails mid-story (rate limit, revoked token,
+    network), scenes used to drop straight to a solid color even though a
+    perfectly good illustration for the SAME story sat in cache (e.g. the
+    thumbnail's index 0). This is the no-cost reuse path.
+    """
+    if not prompt or not prompt.strip():
+        return None
+    exact = _cache_path(prompt, preferred_index)
+    if os.path.exists(exact):
+        return exact
+
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+    try:
+        variants = sorted(
+            f for f in os.listdir(CACHE_DIR)
+            if f.startswith(f"{digest}_") and f.endswith(".png")
+        )
+    except OSError:
+        return None
+    if not variants:
+        return None
+    return os.path.join(CACHE_DIR, variants[preferred_index % len(variants)])
+
+
 def generate_illustration(prompt: str, index: int = 0) -> str | None:
     """Generate (or reuse a cached) AI illustration for `prompt`.
 

--- a/content-pipeline/video/pexels_downloader.py
+++ b/content-pipeline/video/pexels_downloader.py
@@ -47,6 +47,9 @@ SEARCH_QUERIES = [
 ]
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), "assets", "backgrounds", "cache")
+# Still-photo cache (drama scene fallback — see get_photos). Separate from the
+# video cache so orientation-suffix scans over *.mp4 never see photo files.
+PHOTO_CACHE_DIR = os.path.join(os.path.dirname(__file__), "assets", "backgrounds", "photo_cache")
 
 # Tracks the last FATAL Pexels API error so callers stop retrying:
 #   "auth"    — HTTP 401/403: key rejected for real
@@ -227,19 +230,48 @@ def _select_with_variety(paths: list[str], audio_duration: float) -> str | None:
     return chosen
 
 
+def _ensure_keyword_clips(keyword_queries: list[str], orientation: str) -> None:
+    """Download up to BG_KEYWORD_DOWNLOADS clips for uncached article keywords.
+
+    Channel-owner report (07/2026): every AI video reused the same handful of
+    generic backgrounds. Root cause: the cache-first pass below returns as soon
+    as ANY query has a cached clip — and the generic SEARCH_QUERIES get cached
+    on day one, so article-specific keyword clips were NEVER downloaded again
+    and the pool froze. This pass grows the pool with on-topic clips (bounded
+    per video; Pexels free tier is ~200 req/hour so 2 searches are trivial).
+    Best-effort: any failure just leaves the pool as-is.
+    """
+    budget = config.BG_KEYWORD_DOWNLOADS
+    if budget <= 0 or not config.PEXELS_API_KEY:
+        return
+    for query in keyword_queries:
+        if budget <= 0:
+            return
+        if os.path.exists(_cached_path(query, orientation)):
+            continue
+        path = _search_and_download(query, orientation)
+        if _last_pexels_error in _FATAL_PEXELS_ERRORS:
+            logger.error("Pexels rejected our requests (%s) — skipping keyword downloads",
+                         _last_pexels_error)
+            return
+        budget -= 1  # one search consumed whether or not a clip matched
+
+
 def get_background(keywords: list[str] | None = None,
                    orientation: str = "landscape",
                    audio_duration: float = 0.0) -> str | None:
     """Find or download a background video matching article keywords.
 
     Selection strategy:
-    1. Collect ALL cached videos matching orientation (from keywords + generic queries)
-    2. If cached files exist → pick the one whose duration is closest to
-       *audio_duration* (minimises looping); falls back to random if duration
-       is unknown.
-    3. If no cache → download from Pexels using keywords, then generic queries
-    4. Fall back to any cached file with matching orientation (duration-matched)
-    5. Fall back to default background path from config
+    0. Download up to BG_KEYWORD_DOWNLOADS fresh clips for THIS article's
+       keywords when they aren't cached yet (keeps the pool growing and
+       on-topic — see _ensure_keyword_clips).
+    1. Prefer clips cached for the article's own keywords (content match);
+       otherwise the whole cached pool. Pick the one whose duration is
+       closest to *audio_duration* with the anti-repeat variety window.
+    2. If no cache → download from Pexels using keywords, then generic queries
+    3. Fall back to any cached file with matching orientation (duration-matched)
+    4. Fall back to default background path from config
 
     Args:
         keywords: Article-derived search terms (e.g. ["ChatGPT", "AI productivity"]).
@@ -252,9 +284,22 @@ def get_background(keywords: list[str] | None = None,
     """
     os.makedirs(CACHE_DIR, exist_ok=True)
 
-    queries = list(keywords or []) + SEARCH_QUERIES
+    keyword_queries = [q for q in (keywords or []) if q and q.strip()]
+    queries = keyword_queries + SEARCH_QUERIES
 
-    # Pass 1: collect ALL cached backgrounds matching this orientation.
+    # Pass 0: make sure this article's own keyword clips exist in the cache.
+    _ensure_keyword_clips(keyword_queries, orientation)
+
+    # Pass 1: collect cached backgrounds — article-keyword clips separately, so
+    # a content-matched clip always beats a generic one when both exist.
+    keyword_cached: list[str] = []
+    for query in keyword_queries:
+        cached = _cached_path(query, orientation)
+        if os.path.exists(cached) and cached not in keyword_cached:
+            keyword_cached.append(cached)
+    if keyword_cached:
+        return _select_with_variety(keyword_cached, audio_duration)
+
     cached_paths: list[str] = []
     for query in queries:
         cached = _cached_path(query, orientation)
@@ -309,8 +354,14 @@ def get_backgrounds(keywords: list[str] | None = None,
         return [single] if single else []
 
     os.makedirs(CACHE_DIR, exist_ok=True)
-    queries = list(keywords or []) + SEARCH_QUERIES
+    keyword_queries = [q for q in (keywords or []) if q and q.strip()]
+    queries = keyword_queries + SEARCH_QUERIES
     collected: list[str] = []
+
+    # Pass 0: grow the pool with this article's own keyword clips (bounded) —
+    # keyword queries come first in `queries`, so freshly-downloaded on-topic
+    # clips are also the first ones collected below.
+    _ensure_keyword_clips(keyword_queries, orientation)
 
     # Pass 1: cached clips for this orientation.
     for query in queries:
@@ -341,6 +392,93 @@ def get_backgrounds(keywords: list[str] | None = None,
             collected.append(fallback)
 
     return collected[:count]
+
+
+def get_photos(query: str, count: int = 3,
+               orientation: str = "portrait") -> list[str]:
+    """Return up to *count* cached-or-downloaded Pexels PHOTOS for *query*.
+
+    Drama scene fallback (channel-owner request 07/2026): khi Replicate không
+    sinh được ảnh AI và story chưa có ảnh cache, scene từng rơi về màu đơn
+    sắc — chủ kênh muốn MỌI scene đều là ảnh. Ảnh stock Pexels (cùng API key
+    đang dùng cho video nền) là tầng ảnh dự phòng không phụ thuộc Replicate.
+
+    Cache-first theo (query, orientation, index) — một story chỉ tốn đúng 1
+    search + tối đa *count* download một lần duy nhất; chạy lại là cache hit.
+    Trả về list có thể rỗng (không có key / không có kết quả / bị chặn) —
+    caller tự lo fallback tiếp theo.
+    """
+    if not query or not query.strip():
+        return []
+    count = max(1, count)
+    os.makedirs(PHOTO_CACHE_DIR, exist_ok=True)
+    key = _cache_key(query, orientation)
+
+    cached = sorted(
+        os.path.join(PHOTO_CACHE_DIR, f)
+        for f in os.listdir(PHOTO_CACHE_DIR)
+        if f.startswith(f"{key}_") and f.endswith(".jpg")
+    )
+    if cached:
+        return cached[:count]
+
+    if not config.PEXELS_API_KEY:
+        logger.info("PEXELS_API_KEY not configured — no photo fallback available")
+        return []
+
+    photos = _search_photos(query, per_page=count * 2, orientation=orientation)
+    results: list[str] = []
+    for photo in photos:
+        if len(results) >= count:
+            break
+        src = photo.get("src") or {}
+        # large2x (~1880px wide) upscales cleanly to 1080x1920 after crop-fill;
+        # "original" can be tens of MB — wasteful for a background.
+        url = src.get("large2x") or src.get("large") or src.get("original")
+        if not url:
+            continue
+        out = os.path.join(PHOTO_CACHE_DIR, f"{key}_{len(results)}.jpg")
+        if _download_file(url, out):
+            results.append(out)
+    return results
+
+
+def _search_photos(query: str, per_page: int = 6,
+                   orientation: str = "portrait") -> list[dict]:
+    """Search Pexels photo API. Same auth/UA/error handling as _search_videos."""
+    global _last_pexels_error
+    pexels_orient = "portrait" if orientation == "portrait" else "landscape"
+    url = (f"{PEXELS_API_BASE}/v1/search"
+           f"?query={quote(query)}&per_page={per_page}&orientation={pexels_orient}")
+    try:
+        req = Request(url, headers={
+            "Authorization": config.PEXELS_API_KEY,
+            "User-Agent": config.HTTP_USER_AGENT,
+        })
+        with urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+        _last_pexels_error = None
+        return data.get("photos", [])
+    except HTTPError as e:
+        if e.code in (401, 403):
+            cf = _cloudflare_block_code(e)
+            if cf:
+                _last_pexels_error = "blocked"
+                logger.error(
+                    "Pexels photo request blocked by Cloudflare (HTTP %d, error code %s) — "
+                    "NOT an API key problem; check HTTP_USER_AGENT in .env or a flagged IP",
+                    e.code, cf)
+            else:
+                _last_pexels_error = "auth"
+                logger.error("Pexels API key invalid or expired (HTTP %d) — check PEXELS_API_KEY in .env", e.code)
+        else:
+            _last_pexels_error = None
+            logger.error("Pexels photo search failed for '%s': %s", query, e)
+        return []
+    except Exception as e:
+        _last_pexels_error = None
+        logger.error("Pexels photo search failed for '%s': %s", query, e)
+        return []
 
 
 def download_font(force: bool = False) -> bool:

--- a/content-pipeline/video/script_generator.py
+++ b/content-pipeline/video/script_generator.py
@@ -62,7 +62,7 @@ Từ bài tổng hợp dưới đây, viết SCRIPT NGẮN cho video 60-90 giây
 CẤU TRÚC BẮT BUỘC:
 1. HOOK (3 giây): Câu mở đầu gây sốc/tò mò ngay lập tức
 2. 3 TIN NÓNG (mỗi tin 15-20 giây): Chọn top 3 headline, trình bày nhanh gọn
-3. CTA (5 giây): "Follow để cập nhật AI mỗi ngày"
+3. CTA (5 giây): Kêu gọi ĐĂNG KÝ KÊNH (video đăng cả YouTube Shorts lẫn TikTok), vd "Đăng ký kênh để cập nhật AI mỗi ngày nhé!"
 
 YÊU CẦU:
 - Chọn đúng 3 tin HAY NHẤT, gây tò mò nhất từ bài tổng hợp

--- a/content-pipeline/video/templates/drama.py
+++ b/content-pipeline/video/templates/drama.py
@@ -12,6 +12,16 @@ scales scenes to fit the actual narration length) — not a hard cut.
   falling back to a gradient/solid color if generation is unavailable.
 - "gradient_warm" / "gradient_cool" / "solid_blue" — plain ffmpeg lavfi sources,
   no external dependency.
+
+Issue #103: originally only 3 of 6 scenes used illustrations (the rest were
+gradients/solids BY DESIGN), and any Replicate failure dropped an illustration
+scene to a solid color — a whole video could end up one AI image + five flat
+color slabs. Now every scene is illustration-first; the old gradient/solid key
+moved to the per-scene ``fallback`` field (used only when no illustration can
+be generated OR reused from cache), so the designed color mood is the LAST
+resort, not the default look. Scene i uses illustration variant
+(i % config.DRAMA_ILLUSTRATION_VARIANTS) — variety without one API call per
+scene.
 """
 
 DRAMA_SHORTS_TEMPLATE = {
@@ -26,17 +36,17 @@ DRAMA_SHORTS_TEMPLATE = {
     "duration_target": 90,  # seconds
     "scenes": [
         {"type": "hook", "duration": 3, "background": "illustration",
-         "lower_third": False, "commentary": False},
-        {"type": "setup", "duration": 12, "background": "gradient_warm",
-         "lower_third": False, "commentary": False},
+         "fallback": "gradient_warm", "lower_third": False, "commentary": False},
+        {"type": "setup", "duration": 12, "background": "illustration",
+         "fallback": "gradient_warm", "lower_third": False, "commentary": False},
         {"type": "escalation", "duration": 30, "background": "illustration",
-         "lower_third": True, "commentary": False},
+         "fallback": "gradient_cool", "lower_third": True, "commentary": False},
         {"type": "twist", "duration": 25, "background": "illustration_dark",
-         "lower_third": False, "commentary": False},
-        {"type": "vn_commentary_overlay", "duration": 8, "background": "solid_blue",
-         "lower_third": False, "commentary": True},
-        {"type": "reflection_cta", "duration": 12, "background": "gradient_cool",
-         "lower_third": False, "commentary": False},
+         "fallback": "solid_blue", "lower_third": False, "commentary": False},
+        {"type": "vn_commentary_overlay", "duration": 8, "background": "illustration_dark",
+         "fallback": "solid_blue", "lower_third": False, "commentary": True},
+        {"type": "reflection_cta", "duration": 12, "background": "illustration",
+         "fallback": "gradient_cool", "lower_third": False, "commentary": False},
     ],
     "transitions": "match_cut",
     "music_track": "tense_minimal_loop.mp3",

--- a/content-pipeline/video/text_preprocessor.py
+++ b/content-pipeline/video/text_preprocessor.py
@@ -147,6 +147,31 @@ def strip_nonspeech_artifacts(text: str) -> str:
     return cleaned.strip() if cleaned != text else text
 
 
+# Cụm nhận diện "đã có kêu gọi đăng ký kênh" ở cuối narration. Cố ý HẸP
+# ("đăng ký kênh" chứ không phải "đăng ký" trần — script AI hay nhắc "đăng ký
+# ChatGPT Plus") và chỉ soi ĐOẠN CUỐI (CTA nằm ở cuối; nhắc giữa bài không tính).
+_SUBSCRIBE_MARKERS = ("đăng ký kênh", "subscribe", "theo dõi kênh")
+_CTA_SCAN_TAIL_CHARS = 220
+
+
+def ensure_subscribe_cta(text: str, cta: str) -> str:
+    """Bảo đảm narration kết thúc bằng câu kêu gọi đăng ký kênh (chủ kênh 07/2026).
+
+    Prompt đã yêu cầu CTA nhưng LLM không phải lúc nào cũng nghe lời — đây là
+    guarantee tầng code: cuối text CHƯA có cụm đăng-ký-kênh thì nối thêm *cta*;
+    có rồi thì giữ nguyên (không đọc CTA 2 lần). Dùng cho cả narration AI lẫn
+    drama trước khi TTS/subtitle (một nguồn text cho cả hai nên audio và phụ đề
+    luôn khớp).
+    """
+    if not text or not text.strip() or not cta or not cta.strip():
+        return text
+    tail = text[-_CTA_SCAN_TAIL_CHARS:].lower()
+    if any(marker in tail for marker in _SUBSCRIBE_MARKERS):
+        return text
+    logger.info("Narration thiếu CTA đăng ký kênh — tự nối thêm câu CTA")
+    return f"{text.rstrip()}\n\n{cta.strip()}"
+
+
 # ---------------------------------------------------------------------------
 # Hàm chính
 # ---------------------------------------------------------------------------

--- a/content-pipeline/video/text_preprocessor.py
+++ b/content-pipeline/video/text_preprocessor.py
@@ -154,21 +154,27 @@ _SUBSCRIBE_MARKERS = ("đăng ký kênh", "subscribe", "theo dõi kênh")
 _CTA_SCAN_TAIL_CHARS = 220
 
 
-def ensure_subscribe_cta(text: str, cta: str) -> str:
-    """Bảo đảm narration kết thúc bằng câu kêu gọi đăng ký kênh (chủ kênh 07/2026).
+def ensure_subscribe_cta(text: str, cta: str,
+                         extra_markers: tuple[str, ...] = ()) -> str:
+    """Bảo đảm narration kết thúc bằng câu CTA của kênh (chủ kênh 07/2026).
 
     Prompt đã yêu cầu CTA nhưng LLM không phải lúc nào cũng nghe lời — đây là
-    guarantee tầng code: cuối text CHƯA có cụm đăng-ký-kênh thì nối thêm *cta*;
-    có rồi thì giữ nguyên (không đọc CTA 2 lần). Dùng cho cả narration AI lẫn
-    drama trước khi TTS/subtitle (một nguồn text cho cả hai nên audio và phụ đề
+    guarantee tầng code: cuối text CHƯA có cụm CTA thì nối thêm *cta*; có rồi
+    thì giữ nguyên (không đọc CTA 2 lần). Dùng cho cả narration AI lẫn drama
+    trước khi TTS/subtitle (một nguồn text cho cả hai nên audio và phụ đề
     luôn khớp).
+
+    *extra_markers*: cụm nhận-diện-CTA thêm theo track — track drama dùng CTA
+    giọng "follow" ("Follow để nghe chuyện đời mỗi ngày") nên truyền
+    ("follow",); track AI KHÔNG truyền để câu "Follow..." kiểu TikTok cũ vẫn
+    bị coi là thiếu CTA đăng ký kênh.
     """
     if not text or not text.strip() or not cta or not cta.strip():
         return text
     tail = text[-_CTA_SCAN_TAIL_CHARS:].lower()
-    if any(marker in tail for marker in _SUBSCRIBE_MARKERS):
+    if any(marker in tail for marker in _SUBSCRIBE_MARKERS + extra_markers):
         return text
-    logger.info("Narration thiếu CTA đăng ký kênh — tự nối thêm câu CTA")
+    logger.info("Narration thiếu câu CTA cuối — tự nối thêm")
     return f"{text.rstrip()}\n\n{cta.strip()}"
 
 

--- a/content-pipeline/video/video_composer.py
+++ b/content-pipeline/video/video_composer.py
@@ -106,6 +106,10 @@ def compose_video(audio_path: str, subtitle_path: str | None, output_path: str,
                 logger.error("Failed to generate fallback background")
                 return None
 
+        # Final-encode size controls (issue #103): CRF + bitrate ceiling per
+        # video type, resolved once here so every compose path below agrees.
+        crf, maxrate_kbps = config.encode_settings(video_type)
+
         # subtitle_path may be None when burn-in is disabled for this video type
         # (e.g. long videos using an uploaded caption track instead).
         subtitle_entries = _parse_srt(subtitle_path) if subtitle_path else []
@@ -115,17 +119,20 @@ def compose_video(audio_path: str, subtitle_path: str | None, output_path: str,
             else:
                 logger.info("Subtitle burn-in disabled — composing without subtitles")
             return _compose_without_subtitles(bg_video, audio_path, output_path,
-                                              width, height, audio_duration, fill)
+                                              width, height, audio_duration, fill,
+                                              crf, maxrate_kbps)
 
         sub_pngs = _render_subtitle_pngs(subtitle_entries, width, height, fontsize, tmpdir)
         if not sub_pngs:
             logger.warning("Failed to render subtitle PNGs — composing without subtitles")
             return _compose_without_subtitles(bg_video, audio_path, output_path,
-                                              width, height, audio_duration, fill)
+                                              width, height, audio_duration, fill,
+                                              crf, maxrate_kbps)
 
         return _compose_with_subtitles(bg_video, audio_path, output_path,
                                        width, height, audio_duration,
-                                       subtitle_entries, sub_pngs, tmpdir, fill)
+                                       subtitle_entries, sub_pngs, tmpdir, fill,
+                                       crf, maxrate_kbps)
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +178,8 @@ def _scale_filter(width: int, height: int, fill: bool = False) -> str:
 def build_compose_command(bg_video: str, audio_path: str, output_path: str,
                           width: int, height: int, audio_duration: float,
                           subtitle_track: str | None = None,
-                          fill: bool = False) -> list[str]:
+                          fill: bool = False, crf: int = 23,
+                          maxrate_kbps: int = 0) -> list[str]:
     """Build the final ffmpeg compose command (pure — no I/O, unit-testable).
 
     The number of ffmpeg inputs is CONSTANT regardless of how many subtitle
@@ -184,6 +192,11 @@ def build_compose_command(bg_video: str, audio_path: str, output_path: str,
             qtrle .mov produced by the subtitle-track pass). None → no overlay.
         fill: When True, crop the background to fill the frame instead of
             letterbox-padding it (used for vertical shorts).
+        crf: x264 CRF for the final encode (quality-based VBR).
+        maxrate_kbps: bitrate ceiling in kbps (issue #103 — CRF alone let
+            motion-heavy shorts balloon to ~8 Mbps). 0 = no cap. bufsize is
+            set to 2× maxrate (standard VBV window: cap peaks without choking
+            quality on brief complex sections).
     """
     scale_pad = _scale_filter(width, height, fill)
 
@@ -201,7 +214,11 @@ def build_compose_command(bg_video: str, audio_path: str, output_path: str,
 
     cmd += [
         "-t", str(audio_duration),
-        "-c:v", "libx264", "-preset", "medium", "-crf", "23",
+        "-c:v", "libx264", "-preset", "medium", "-crf", str(crf),
+    ]
+    if maxrate_kbps > 0:
+        cmd += ["-maxrate", f"{maxrate_kbps}k", "-bufsize", f"{maxrate_kbps * 2}k"]
+    cmd += [
         "-c:a", "aac", "-b:a", "128k",
         "-movflags", "+faststart",
         "-shortest",
@@ -341,10 +358,12 @@ def _build_blank_png(width: int, height: int, tmpdir: str) -> str | None:
 
 def _compose_without_subtitles(bg_video: str, audio_path: str, output_path: str,
                                 width: int, height: int, audio_duration: float,
-                                fill: bool = False) -> str | None:
+                                fill: bool = False, crf: int = 23,
+                                maxrate_kbps: int = 0) -> str | None:
     """Compose video without any subtitle overlay (2 ffmpeg inputs)."""
     cmd = build_compose_command(bg_video, audio_path, output_path,
-                                width, height, audio_duration, fill=fill)
+                                width, height, audio_duration, fill=fill,
+                                crf=crf, maxrate_kbps=maxrate_kbps)
     return _run_ffmpeg(cmd, output_path)
 
 
@@ -352,7 +371,8 @@ def _compose_with_subtitles(bg_video: str, audio_path: str, output_path: str,
                             width: int, height: int, audio_duration: float,
                             subtitle_entries: list[tuple[float, float, str]],
                             sub_pngs: list[str], tmpdir: str,
-                            fill: bool = False) -> str | None:
+                            fill: bool = False, crf: int = 23,
+                            maxrate_kbps: int = 0) -> str | None:
     """Compose video by overlaying a single pre-built transparent subtitle track.
 
     Two passes, both O(1) in command-line inputs:
@@ -366,7 +386,8 @@ def _compose_with_subtitles(bg_video: str, audio_path: str, output_path: str,
     blank_png = _build_blank_png(width, height, tmpdir)
     if blank_png is None:
         return _compose_without_subtitles(bg_video, audio_path, output_path,
-                                          width, height, audio_duration, fill)
+                                          width, height, audio_duration, fill,
+                                          crf, maxrate_kbps)
 
     concat_path = os.path.join(tmpdir, "subtitles.concat")
     build_subtitle_concat(subtitle_entries, sub_pngs, blank_png,
@@ -379,11 +400,13 @@ def _compose_with_subtitles(bg_video: str, audio_path: str, output_path: str,
                    track_path) is None:
         logger.warning("Subtitle track build failed — composing without subtitles")
         return _compose_without_subtitles(bg_video, audio_path, output_path,
-                                          width, height, audio_duration, fill)
+                                          width, height, audio_duration, fill,
+                                          crf, maxrate_kbps)
 
     cmd = build_compose_command(bg_video, audio_path, output_path,
                                 width, height, audio_duration,
-                                subtitle_track=track_path, fill=fill)
+                                subtitle_track=track_path, fill=fill,
+                                crf=crf, maxrate_kbps=maxrate_kbps)
     return _run_ffmpeg(cmd, output_path)
 
 


### PR DESCRIPTION
Closes #103.

## Root cause (khác mô tả trong issue)

**1. AI short 50MB (~7.8Mbps):** issue ghi "`video_composer.py` không set `-b:v`, drama composer set bitrate thấp hơn" — thực tế **cả hai composer encode y hệt nhau** (`libx264 -preset medium -crf 23`, không nơi nào set `-b:v`). Khác biệt 355kbps vs 7.8Mbps đến từ **nội dung**: CRF giữ chất lượng cố định và thả nổi bitrate — nền b-roll Pexels chuyển động mạnh của AI short phình lên ~8Mbps, nền tĩnh (ảnh/gradient) của drama nén gần như không tốn bit.

**2. Drama chỉ scene 0 có ảnh:** template gốc **chủ đích** chỉ cho 3/6 scene dùng illustration (scene 1/4/5 là gradient/solid by design), và mỗi lần Replicate lỗi thì scene rơi thẳng về `solid_blue`. Ảnh scene 0 thường chỉ là **cache hit từ thumbnail** (cùng `(prompt, index=0)` — main_drama.py), còn scene 2/3 (index 2, 3) phải gọi API thật và chết chùm → video ra 1 ảnh AI + 5 mảng màu. Mỗi scene fail còn tự gọi lại API từ đầu (poll timeout tới 90s/scene).

## Fix

### Bitrate (`config.encode_settings(video_type)` — single source of truth)
- Giữ CRF (quality-driven) nhưng thêm **trần `-maxrate`/`-bufsize`**: short = CRF 26 + 3000k, long = CRF 23 + 4000k (bufsize 2×, đều env-overridable, `0` = không cap; `validate_flags()` cảnh báo giá trị ngoài dải, `encode_settings` tự kẹp).
- Áp cho **cả engine ffmpeg lẫn moviepy** (consistency); chỉ final encode — intermediate (scene segment, multi-bg pre-pass) giữ nguyên vì được encode lại.
- `-b:v 500k` như issue gợi ý **không dùng**: ép cứng 500k làm b-roll motion vỡ hình rõ ở 1080x1920 (500k chỉ ổn với nền tĩnh như drama — vốn tự nhiên đã ~355k dưới CRF).
- **Đo thật** (ffmpeg 6.1, nền motion worst-case 10s): 23.4Mbps/29MB → **3.2Mbps/4.2MB (~7×)**; video 141 (53s) ước còn ~15-20MB. Nền tĩnh không đổi.

### Nền drama (illustration-first + fallback nhiều lớp — MỌI scene là ảnh)
- **Template**: mọi scene đều `illustration`/`illustration_dark`; màu cũ chuyển vào field `fallback` declarative (chỉ dùng khi hết đường ảnh). Scene i dùng variant `i % DRAMA_ILLUSTRATION_VARIANTS` (mặc định 3 — đa dạng mà không nhân call API theo số scene; variant 0 trùng cache thumbnail nên 1 call luôn được tái dùng).
- **Thứ tự resolve**: `generate_illustration` (cache-hit free) → **memo lỗi trong run** (fail live 1 lần = các scene sau bỏ qua API, không đốt 90s poll timeout ×5) → `cached_illustration()`: tái dùng **bất kỳ variant đã cache** của prompt (zero cost) → **Pexels PHOTO fallback** (yêu cầu chủ kênh: scene drama phải LUÔN là ảnh; `get_photos()` search theo chính `thumbnail_prompt`, không ra thì query mood chung; cache-first, memo trong run, tắt qua `DRAMA_PHOTO_FALLBACK_ENABLED=0`) → `fallback` màu của scene — chỉ còn thấy khi CẢ Replicate lẫn Pexels đều bất khả dụng.
- **Ken Burns** (`zoompan`) cho scene nền ảnh (`DRAMA_SCENE_MOTION=1`, hướng zoom xen kẽ theo scene, pre-scale 2× chống jitter); render motion lỗi **tự retry static** — nice-to-have không được phá video.
- `illustration_dark` giờ thật sự tối (eq dim + desaturate, áp **trước** overlay nên commentary card giữ nguyên độ sáng — UX đọc card trên nền ảnh).
- Chuẩn hoá **fps=30 mọi segment** (lavfi mặc định 25 ≠ zoompan 30 sẽ làm concat `-c copy` lệch timestamp giữa các scene).

### Nền AI video: hết "mọi video cùng một nền" + bám nội dung
- **Root cause pool đóng băng**: `get_background`/`get_backgrounds` trả từ cache ngay khi BẤT KỲ query nào có cache — 5 query generic luôn nối vào danh sách và cache từ ngày đầu → clip theo `broll_terms` của bài **không bao giờ được tải nữa**, mọi video xoay quanh vài clip generic.
- Fix: **Pass 0** `_ensure_keyword_clips` tải tối đa `BG_KEYWORD_DOWNLOADS` (mặc định 2, `0` = hành vi cũ) clip mới cho keyword của chính bài mỗi video (tôn trọng sentinel lỗi auth/Cloudflare-block của #97); khi chọn, **clip cache theo keyword của bài thắng pool generic** (content match); anti-repeat variety giữ nguyên.

### CTA cuối narration theo giọng từng track
- **Track AI**: `SHORT_SCRIPT_PROMPT` đổi CTA "Follow..." → kêu gọi **đăng ký kênh** (script long đã có sẵn).
- **Track Drama** (chủ kênh chọn): CTA giọng follow — **"Follow để nghe chuyện đời mỗi ngày nhé!"**; `rewriter.v2.txt` dặn `vn_commentary` kết bằng mời bình luận + follow kênh.
- **Guarantee tầng code**: `text_preprocessor.ensure_subscribe_cta(text, cta, extra_markers)` soi đoạn cuối narration ("đăng ký kênh"/"subscribe"/"theo dõi kênh"; drama thêm marker "follow"), thiếu thì nối `AI_SUBSCRIBE_CTA`/`DRAMA_SUBSCRIBE_CTA` (env-overridable), có rồi thì không đọc 2 lần. Track AI KHÔNG nhận marker "follow" — câu "Follow..." kiểu TikTok cũ vẫn bị coi là thiếu CTA đăng ký. Áp ở `main._create_video` (trước khi lưu DB/TTS/subtitle — audio và phụ đề luôn khớp) và `main_drama.build_narration` (cứu cả story cũ).

## Test

- Full suite: **1062 tests pass** (unittest discover).
- Test mới: crf/maxrate + clamp; memo lỗi 1-call; reuse cache variant; photo fallback chain (dùng/memo/generic-query/tắt flag); keyword-clip Pass 0 (budget/cache-skip/fatal-stop); keyword-priority selection; `get_photos` (cache-first/no-key/count); `ensure_subscribe_cta` (nối/không lặp/không nhầm "đăng ký ChatGPT"/extra_markers per-track); narration drama kết bằng CTA follow; template invariant; zoompan/darken/fps command shape; motion-fail-retry-static.
- Smoke ffmpeg thật (6.1.1): segment zoompan in/out đúng 30fps + số frame; `compose_drama_video` end-to-end 6 scene → 1080x1920@30fps; đường generation-chết-hoàn-toàn vẫn ra video với đúng **1** call API.

Lưu ý vận hành: nếu Replicate token trên máy đã chết/hết hạn, drama giờ chạy bằng ảnh cache + ảnh Pexels (không còn nền màu) — `video/asset_key_health.py` (08:10) vẫn alert để cấp lại token tại https://replicate.com/account/api-tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgAExPp5KoLd5TP4RFL8mB