### PR TITLE
Fix #105: Fallback ảnh scene drama variety-aware — hết cảnh 6 scene dùng chung 1 ảnh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,14 +473,25 @@ gọi TTS, gọi `compose_drama_video`) — để dành cho bước wiring sau.
   theo số scene, variant 0 trùng cache thumbnail nên 1 call luôn tái dùng);
   (2) thứ tự resolve: `generate_illustration` (cache-hit free) → **memo lỗi
   trong run** (fail live 1 lần = các scene sau bỏ qua API, khỏi đốt poll-timeout
-  90s×5) → `image_generator.cached_illustration()` tái dùng BẤT KỲ variant đã
-  cache của prompt (zero cost) → **Pexels PHOTO fallback** (yêu cầu chủ kênh
-  07/2026: mọi scene drama phải là ẢNH — `pexels_downloader.get_photos()` search
-  theo chính `thumbnail_prompt`, không ra thì query mood chung
-  `DRAMA_PHOTO_GENERIC_QUERY`; cache-first theo (query, orientation, index),
-  memo kết quả trong run — 1 lookup/video; tắt qua
-  `DRAMA_PHOTO_FALLBACK_ENABLED=0`) → `fallback` của scene → `solid_blue` chót
-  (chỉ còn thấy khi CẢ Replicate lẫn Pexels đều bất khả dụng);
+  90s×5) → variant đã cache của prompt **CHƯA dùng trong run** (zero cost) →
+  **Pexels PHOTO fallback chưa dùng** (yêu cầu chủ kênh 07/2026: mọi scene drama
+  phải là ẢNH — `pexels_downloader.get_photos()` search theo chính
+  `thumbnail_prompt`, không ra thì query mood chung `DRAMA_PHOTO_GENERIC_QUERY`;
+  cache-first theo (query, orientation, index), memo kết quả trong run —
+  1 lookup/video; tắt qua `DRAMA_PHOTO_FALLBACK_ENABLED=0`) → hết ảnh mới
+  **reuse xoay vòng trên toàn pool ảnh** → `fallback` của scene → `solid_blue`
+  chót (chỉ còn thấy khi CẢ Replicate lẫn Pexels đều bất khả dụng).
+  **Fallback variety-aware (issue #105):** bản #103 coi "BẤT KỲ ảnh cache nào"
+  > Pexels và không nhớ ảnh nào đã dùng — mà `{digest}_0.png` gần như LUÔN tồn
+  tại (thumbnail sinh trước với index=0), nên khi Replicate fail giữa chừng,
+  `cached_illustration()` với cache 1 file trả `variants[i % 1]` = cùng file
+  cho MỌI scene (video 142: 6 scene 1 ảnh) và tầng Pexels thành dead code. Fix:
+  `gen_state["used_images"]` dedupe per-run (ảnh happy-path cũng được track);
+  `image_generator.cached_illustration_variants(prompt)` trả toàn bộ pool cache
+  (memo 1 listdir/run) để composer biết khi nào cache thật sự cạn. Rotation
+  thiết kế i%N của happy path GIỮ NGUYÊN (cặp scene 0&3/1&4/2&5 chung ảnh là
+  chủ đích); chỉ nhánh fallback dedupe. Pexels tắt + chỉ 1 ảnh cache → vẫn
+  reuse ảnh đó (ảnh > màu, đúng yêu cầu chủ kênh);
   (3) scene nền ảnh có **Ken Burns** (zoompan, hướng zoom xen kẽ theo scene,
   `DRAMA_SCENE_MOTION=1`; render motion lỗi tự retry static — nice-to-have
   không được phá video); `illustration_dark` giờ thật sự TỐI (eq dim +

--- a/content-pipeline/tests/test_drama_composer.py
+++ b/content-pipeline/tests/test_drama_composer.py
@@ -218,50 +218,50 @@ class TestResolveSceneBackground(unittest.TestCase):
         mock_gen.assert_called_once_with("a lonely office", index=0)
 
     @patch("video.pexels_downloader.get_photos", return_value=[])
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_illustration_failure_falls_back(self, mock_gen, mock_cached, _photos):
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         scene = {"background": "illustration_dark"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 1, "a prompt")
         self.assertTrue(is_lavfi)
         self.assertIn("color=c=0x1B3A5C", source)
 
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_illustration_failure_reuses_cached_variant(self, mock_gen, mock_cached):
         # Issue #103: a Replicate failure must reuse the story's cached
         # illustration (e.g. the thumbnail's index 0), not drop to a color.
         mock_gen.return_value = None
-        mock_cached.return_value = "/tmp/cached_0.png"
+        mock_cached.return_value = ["/tmp/cached_0.png"]
         scene = {"background": "illustration", "fallback": "gradient_warm"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 2, "a prompt")
         self.assertFalse(is_lavfi)
         self.assertEqual(source, "/tmp/cached_0.png")
-        mock_cached.assert_called_once_with("a prompt", preferred_index=2)
+        mock_cached.assert_called_once_with("a prompt")
 
     @patch("video.pexels_downloader.get_photos")
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_photo_fallback_when_no_illustration_at_all(self, mock_gen,
                                                         mock_cached, mock_photos):
         # Owner request 07/2026: no AI illustration AND no cache must still
         # yield an IMAGE (Pexels photo), not a solid color.
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         mock_photos.return_value = ["/tmp/p0.jpg", "/tmp/p1.jpg"]
         scene = {"background": "illustration", "fallback": "gradient_warm"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 1, "a prompt")
         self.assertFalse(is_lavfi)
-        self.assertEqual(source, "/tmp/p1.jpg")  # variant 1 % 2 photos
+        self.assertEqual(source, "/tmp/p0.jpg")  # first photo not yet used this run
 
     @patch("video.pexels_downloader.get_photos")
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_photo_lookup_memoized_per_run(self, mock_gen, mock_cached, mock_photos):
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         mock_photos.return_value = ["/tmp/p0.jpg"]
         gen_state = {}
         for i in range(4):
@@ -270,12 +270,12 @@ class TestResolveSceneBackground(unittest.TestCase):
         mock_photos.assert_called_once()
 
     @patch("video.pexels_downloader.get_photos")
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_photo_generic_query_tried_when_prompt_finds_nothing(
             self, mock_gen, mock_cached, mock_photos):
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         mock_photos.side_effect = [[], ["/tmp/generic0.jpg"]]
         scene = {"background": "illustration", "fallback": "solid_blue"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
@@ -284,12 +284,12 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertEqual(mock_photos.call_count, 2)
 
     @patch("video.pexels_downloader.get_photos")
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_photo_fallback_disabled_falls_to_color(self, mock_gen,
                                                     mock_cached, mock_photos):
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         scene = {"background": "illustration", "fallback": "gradient_warm"}
         with patch.object(dc_config, "DRAMA_PHOTO_FALLBACK_ENABLED", False):
             source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
@@ -297,33 +297,85 @@ class TestResolveSceneBackground(unittest.TestCase):
         self.assertTrue(is_lavfi)
         self.assertIn("gradients=", source)
 
+    @patch("video.pexels_downloader.get_photos")
+    @patch("video.drama_composer.cached_illustration_variants")
+    @patch("video.drama_composer.generate_illustration")
+    def test_photo_fallback_disabled_still_reuses_cached_image(
+            self, mock_gen, mock_cached, mock_photos):
+        # Pexels off + one cached image: repeating the image still beats a
+        # color slab (owner request: every drama scene stays an IMAGE).
+        mock_gen.return_value = None
+        mock_cached.return_value = ["/tmp/cached_0.png"]
+        gen_state = {}
+        sources = []
+        with patch.object(dc_config, "DRAMA_PHOTO_FALLBACK_ENABLED", False):
+            for i in range(3):
+                scene = {"background": "illustration", "fallback": "gradient_warm"}
+                source, is_lavfi = _resolve_scene_background(
+                    scene, 1080, 1920, i, "a prompt", gen_state)
+                self.assertFalse(is_lavfi)
+                sources.append(source)
+        self.assertEqual(sources, ["/tmp/cached_0.png"] * 3)
+        mock_photos.assert_not_called()
+
     @patch("video.pexels_downloader.get_photos", return_value=[])
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_illustration_failure_uses_scene_fallback_key(self, mock_gen,
                                                           mock_cached, _photos):
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         scene = {"background": "illustration", "fallback": "gradient_warm"}
         source, is_lavfi = _resolve_scene_background(scene, 1080, 1920, 0, "a prompt")
         self.assertTrue(is_lavfi)
         self.assertIn("gradients=", source)
 
     @patch("video.pexels_downloader.get_photos", return_value=[])
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     def test_generation_failure_memoized_across_scenes(self, mock_gen,
                                                        mock_cached, _photos):
         # One live failure must stop API attempts for the rest of the run
         # (each failed attempt can burn up to the Replicate poll timeout).
         mock_gen.return_value = None
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         gen_state = {}
         for i in range(4):
             scene = {"background": "illustration", "fallback": "solid_blue"}
             _resolve_scene_background(scene, 1080, 1920, i, "a prompt", gen_state)
         mock_gen.assert_called_once()
-        self.assertEqual(mock_cached.call_count, 4)
+        # The cache listing is memoized in gen_state too — one listdir per run.
+        mock_cached.assert_called_once()
+
+    @patch("video.pexels_downloader.get_photos")
+    @patch("video.drama_composer.cached_illustration_variants")
+    @patch("video.drama_composer.generate_illustration")
+    def test_issue_105_scenes_get_distinct_images_after_midrun_failure(
+            self, mock_gen, mock_cached, mock_photos):
+        # Regression for issue #105 (video 142): thumbnail variant 0 is a
+        # cache hit, the first LIVE generation fails, and the old fallback
+        # pinned all six scenes to that one cached file — the Pexels tier
+        # never ran. Scenes must now spread across every available image.
+        mock_gen.side_effect = ["/tmp/cached_0.png", None]
+        mock_cached.return_value = ["/tmp/cached_0.png"]
+        mock_photos.return_value = ["/tmp/p0.jpg", "/tmp/p1.jpg", "/tmp/p2.jpg"]
+        gen_state = {}
+        sources = []
+        for i in range(6):
+            scene = {"background": "illustration", "fallback": "solid_blue"}
+            source, is_lavfi = _resolve_scene_background(
+                scene, 1080, 1920, i, "a prompt", gen_state)
+            self.assertFalse(is_lavfi)
+            sources.append(source)
+        # All 4 available images used before any repeat.
+        self.assertEqual(sources[:4], [
+            "/tmp/cached_0.png", "/tmp/p0.jpg", "/tmp/p1.jpg", "/tmp/p2.jpg",
+        ])
+        self.assertEqual(len(set(sources)), 4)
+        # And the unavoidable repeats rotate instead of pinning to one file.
+        self.assertNotEqual(sources[4], sources[5])
+        self.assertEqual(mock_gen.call_count, 2)  # scene 0 hit + scene 1 fail
+        mock_photos.assert_called_once()
 
     @patch("video.drama_composer.config")
     @patch("video.drama_composer.generate_illustration")
@@ -413,14 +465,14 @@ class TestBuildDramaSceneReelMocked(unittest.TestCase):
         build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp, lower_third=None)
         mock_lt.assert_not_called()
 
-    @patch("video.drama_composer.cached_illustration")
+    @patch("video.drama_composer.cached_illustration_variants")
     @patch("video.drama_composer.generate_illustration")
     @patch("video.drama_composer._run_ffmpeg")
     def test_motion_segment_failure_retries_static(self, mock_run, mock_gen, mock_cached):
         # Ken Burns is best-effort: if the zoompan render fails, the scene is
         # retried without motion instead of aborting the reel.
         mock_gen.return_value = "/tmp/ill.png"
-        mock_cached.return_value = None
+        mock_cached.return_value = []
         calls = []
 
         def run_side_effect(cmd, out):

--- a/content-pipeline/tests/test_image_generator.py
+++ b/content-pipeline/tests/test_image_generator.py
@@ -264,5 +264,36 @@ class TestCachedIllustration(ImageGeneratorTestBase):
         self.assertIsNone(image_generator.cached_illustration("a prompt", 0))
 
 
+class TestCachedIllustrationVariants(ImageGeneratorTestBase):
+    """cached_illustration_variants — the composer's full-pool view (issue #105)."""
+
+    def _write_variant(self, prompt: str, index: int) -> str:
+        path = image_generator._cache_path(prompt, index)
+        with open(path, "wb") as f:
+            f.write(b"png")
+        return path
+
+    def test_empty_prompt_returns_empty(self):
+        self.assertEqual(image_generator.cached_illustration_variants(""), [])
+
+    def test_no_cache_returns_empty(self):
+        self.assertEqual(image_generator.cached_illustration_variants("a prompt"), [])
+
+    def test_returns_all_variants_sorted(self):
+        v2 = self._write_variant("a prompt", 2)
+        v0 = self._write_variant("a prompt", 0)
+        self._write_variant("some other prompt", 0)
+        self.assertEqual(
+            image_generator.cached_illustration_variants("a prompt"), [v0, v2],
+        )
+
+    def test_missing_cache_dir_returns_empty(self):
+        with patch.object(image_generator, "CACHE_DIR",
+                          os.path.join(self.tmp, "does-not-exist")):
+            self.assertEqual(
+                image_generator.cached_illustration_variants("a prompt"), [],
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/content-pipeline/video/drama_composer.py
+++ b/content-pipeline/video/drama_composer.py
@@ -30,7 +30,7 @@ from video.video_composer import _scale_filter, _run_ffmpeg, compose_video
 from video.templates import load_template
 from video.lower_third import render_lower_third
 from video.commentary_card import render_commentary_card
-from video.image_generator import generate_illustration, cached_illustration
+from video.image_generator import generate_illustration, cached_illustration_variants
 
 logger = logging.getLogger(__name__)
 
@@ -176,9 +176,8 @@ def scaled_scene_durations(template: dict, total_duration: float) -> list[float]
     return [max(0.1, s["duration"] * scale) for s in scenes]
 
 
-def _pexels_photo_for_scene(prompt: str, variant: int,
-                            state: dict) -> str | None:
-    """Stock-photo fallback so every drama scene stays an IMAGE (owner request).
+def _pexels_photos(prompt: str, state: dict) -> list[str]:
+    """Stock-photo fallback pool so every drama scene stays an IMAGE (owner request).
 
     Order: photos matching the story's own thumbnail_prompt (on-topic), then a
     generic dramatic-mood query. Both are cache-first inside get_photos, so a
@@ -188,7 +187,7 @@ def _pexels_photo_for_scene(prompt: str, variant: int,
     to their color fallback.
     """
     if not config.DRAMA_PHOTO_FALLBACK_ENABLED:
-        return None
+        return []
     if "photos" not in state:
         from video.pexels_downloader import get_photos
         photos = get_photos(prompt[:80], count=config.DRAMA_ILLUSTRATION_VARIANTS,
@@ -198,10 +197,7 @@ def _pexels_photo_for_scene(prompt: str, variant: int,
                                 count=config.DRAMA_ILLUSTRATION_VARIANTS,
                                 orientation="portrait")
         state["photos"] = photos
-    photos = state["photos"]
-    if not photos:
-        return None
-    return photos[variant % len(photos)]
+    return state["photos"]
 
 
 def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
@@ -211,7 +207,10 @@ def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
 
     Returns (source, is_lavfi). Resolution order for illustration scenes
     (issue #103 — a Replicate failure used to drop a scene straight to a
-    solid color even when the same story had illustrations sitting in cache):
+    solid color even when the same story had illustrations sitting in cache;
+    issue #105 — that cache-reuse tier pinned EVERY scene to the same single
+    file, because the thumbnail's variant 0 always exists, `preferred_index %
+    1 == 0` for any index, and the Pexels tier below it never got a turn):
 
     1. generate_illustration() for variant (index % DRAMA_ILLUSTRATION_VARIANTS)
        — a cache hit is free; a live API call otherwise. After the FIRST live
@@ -219,12 +218,18 @@ def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
        entirely: each failed attempt can burn up to the Replicate poll
        timeout, and one hard failure (revoked token, rate limit) predicts the
        next five.
-    2. cached_illustration() — reuse ANY cached variant of this story's
-       prompt (e.g. the thumbnail's index 0) at zero cost.
-    3. Pexels stock photo matching the prompt (then a generic dramatic-mood
-       query) — every scene stays an IMAGE even when Replicate is down
-       (_pexels_photo_for_scene, owner request 07/2026).
-    4. The scene's declarative `fallback` lavfi key (its designed color
+    2. A cached variant of this story's prompt NOT yet used by an earlier
+       scene of this run (zero cost) — `gen_state["used_images"]` is the
+       per-run dedupe that keeps six scenes from sharing one image.
+    3. A Pexels stock photo (prompt-matched, then generic dramatic-mood) not
+       yet used this run — every scene stays an IMAGE even when Replicate is
+       down (owner request 07/2026).
+    4. Only when every available image has been used: rotate over the whole
+       image pool (variant-indexed) so repeats spread across DIFFERENT images
+       instead of pinning to one file — repeating an image beats a color slab
+       (owner request), but video 142's six-identical-scenes must not recur
+       whenever more than one image exists.
+    5. The scene's declarative `fallback` lavfi key (its designed color
        mood), then _FALLBACK_BACKGROUND as the absolute last resort.
     """
     background_key = scene["background"]
@@ -236,26 +241,39 @@ def _resolve_scene_background(scene: dict, width: int, height: int, index: int,
 
     if background_key in ("illustration", "illustration_dark") and thumbnail_prompt:
         variant = index % config.DRAMA_ILLUSTRATION_VARIANTS
+        used = state.setdefault("used_images", set())
         if not state.get("generation_failed"):
             illustration = generate_illustration(thumbnail_prompt, index=variant)
             if illustration is not None:
+                # Tracked so the fallback tiers below never hand a later
+                # scene the image this scene just used (issue #105).
+                used.add(illustration)
                 return illustration, False
             state["generation_failed"] = True
             logger.warning(
                 "Illustration generation failed (scene %d) — remaining scenes "
-                "will reuse cached illustrations or color fallbacks this run",
-                index,
+                "will reuse cached illustrations, stock photos or color "
+                "fallbacks this run", index,
             )
-        cached = cached_illustration(thumbnail_prompt, preferred_index=variant)
-        if cached is not None:
-            logger.info("Scene %d: reusing cached illustration %s",
-                        index, os.path.basename(cached))
-            return cached, False
-        photo = _pexels_photo_for_scene(thumbnail_prompt, variant, state)
-        if photo is not None:
-            logger.info("Scene %d: using Pexels photo fallback %s",
-                        index, os.path.basename(photo))
-            return photo, False
+        if "cached_pool" not in state:
+            state["cached_pool"] = cached_illustration_variants(thumbnail_prompt)
+        cached_pool = state["cached_pool"]
+        choice = next((p for p in cached_pool if p not in used), None)
+        label = "cached illustration"
+        if choice is None:
+            photos = _pexels_photos(thumbnail_prompt, state)
+            choice = next((p for p in photos if p not in used), None)
+            label = "Pexels photo fallback"
+            if choice is None:
+                pool = cached_pool + photos
+                if pool:
+                    choice = pool[variant % len(pool)]
+                    label = "reused image (variety exhausted)"
+        if choice is not None:
+            used.add(choice)
+            logger.info("Scene %d: using %s %s", index, label,
+                        os.path.basename(choice))
+            return choice, False
         logger.info("No AI illustration available for scene %d — using fallback background", index)
 
     # Unresolvable symbolic background (e.g. "screen_record" outside the AI
@@ -287,8 +305,9 @@ def build_drama_scene_reel(
     durations = scaled_scene_durations(template, total_duration)
 
     # Shared across this run's scenes: after one live Replicate failure the
-    # remaining scenes go straight to cache-reuse instead of re-hitting the
-    # API (see _resolve_scene_background).
+    # remaining scenes go straight to cache/photo reuse instead of re-hitting
+    # the API, and images already given to a scene aren't handed out again
+    # while an unused one exists (see _resolve_scene_background).
     gen_state: dict = {}
 
     segment_paths = []

--- a/content-pipeline/video/image_generator.py
+++ b/content-pipeline/video/image_generator.py
@@ -48,6 +48,28 @@ def _cache_path(prompt: str, index: int) -> str:
     return os.path.join(CACHE_DIR, f"{digest}_{index}.png")
 
 
+def cached_illustration_variants(prompt: str) -> list[str]:
+    """All ALREADY-CACHED illustration paths for `prompt` (sorted, no API call).
+
+    Issue #105: the composer needs the WHOLE list — not one modulo-picked
+    file — so it can hand different cached variants to different scenes and
+    knows when the cache genuinely has nothing new to offer (video 142: one
+    cached file meant `preferred_index % 1 == 0` pinned all six scenes to the
+    same image while the Pexels tier below it never ran).
+    """
+    if not prompt or not prompt.strip():
+        return []
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
+    try:
+        names = sorted(
+            f for f in os.listdir(CACHE_DIR)
+            if f.startswith(f"{digest}_") and f.endswith(".png")
+        )
+    except OSError:
+        return []
+    return [os.path.join(CACHE_DIR, n) for n in names]
+
+
 def cached_illustration(prompt: str, preferred_index: int = 0) -> str | None:
     """Return an ALREADY-CACHED illustration for `prompt` without any API call.
 
@@ -67,17 +89,10 @@ def cached_illustration(prompt: str, preferred_index: int = 0) -> str | None:
     if os.path.exists(exact):
         return exact
 
-    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:16]
-    try:
-        variants = sorted(
-            f for f in os.listdir(CACHE_DIR)
-            if f.startswith(f"{digest}_") and f.endswith(".png")
-        )
-    except OSError:
-        return None
+    variants = cached_illustration_variants(prompt)
     if not variants:
         return None
-    return os.path.join(CACHE_DIR, variants[preferred_index % len(variants)])
+    return variants[preferred_index % len(variants)]
 
 
 def generate_illustration(prompt: str, index: int = 0) -> str | None:


### PR DESCRIPTION
Closes #105.

## Root cause

Video 142 ra 6 scene chung 1 ảnh vì **hai tầng lỗi cộng hưởng**:

1. **Trực tiếp:** `cached_illustration()` khi cache chỉ có 1 file trả `variants[preferred_index % 1]` = luôn file 0 cho mọi index. Mà cache gần như **luôn** chỉ có variant 0 tại thời điểm render scene: `{digest}_0.png` được sinh trước đó cho thumbnail (`main_drama` dùng `index=0`); variant 1 gọi API live thì fail → memo `generation_failed` chặn luôn variant 2.
2. **Thiết kế:** thứ tự resolve của #103 coi "bất kỳ ảnh cache nào" > Pexels và **không nhớ ảnh nào đã dùng trong run**. Vì variant 0 luôn tồn tại, tầng Pexels (xây riêng để mọi scene là ảnh *đa dạng* khi Replicate sập) thành dead code trong đúng kịch bản nó được sinh ra để cứu.

(Phỏng đoán trong issue "`DRAMA_ILLUSTRATION_VARIANTS` mặc định là 1?" không đúng — mặc định là 3; cache chỉ có 1 file vì lý do trên.)

## Fix

Trong 3 gợi ý của issue, PR này chọn hướng (3) tinh chỉnh — (1) không giải quyết gốc (API fail thì variants bao nhiêu cũng fail, lại tăng chi phí), (2) bất khả thi khi cache chỉ có 1 file:

- **`gen_state["used_images"]` — dedupe per-run** trong `_resolve_scene_background()`: nhánh fallback ưu tiên variant cache **chưa dùng** → ảnh Pexels **chưa dùng** → hết ảnh mới **reuse xoay vòng trên toàn pool** (repeat rải đều trên nhiều ảnh thay vì ghim 1 file) → màu fallback chỉ khi không có ảnh nào.
- **`image_generator.cached_illustration_variants(prompt)`** trả toàn bộ pool cache (memo 1 listdir/run) để composer biết khi nào cache thật sự cạn thay vì lấy 1 file theo modulo. `cached_illustration()` giữ nguyên API, refactor dùng chung.
- **Happy path giữ nguyên** rotation `i % DRAMA_ILLUSTRATION_VARIANTS` của #103 (cặp scene 0&3/1&4/2&5 chung ảnh là chủ đích, không nhân chi phí Replicate); ảnh happy-path cũng được track để fallback không phát lại.
- **Pexels tắt + chỉ 1 ảnh cache → vẫn reuse ảnh** (ảnh > màu, đúng yêu cầu chủ kênh 07/2026 "mọi scene drama phải là ẢNH").

Với đúng kịch bản video 142 (1 ảnh cache + Replicate fail từ scene 1 + Pexels sống): scene được gán `cached_0, p0, p1, p2, p0, p1` — 4 ảnh khác nhau thay vì 1.

## Performance / cost

- Zero API call thêm ở happy path; memo `generation_failed` giữ nguyên (không đốt poll-timeout 90s×5).
- Pexels vẫn memo 1 lookup/video; cache listing memo 1 listdir/run.

## Tests

- Regression test #105: mô phỏng đúng flow video 142, assert 4 ảnh distinct trước khi có repeat và repeat xoay vòng (không ghim 1 file).
- Test mới: `cached_illustration_variants` (sorted/empty/missing-dir), Pexels-off vẫn reuse ảnh thay vì rơi về màu.
- Cập nhật các test #103 sang API mới; toàn bộ suite 965 test pass (5 module lỗi `import anthropic` trước đó chỉ là thiếu dependency môi trường, pass sau khi cài).

Docs: cập nhật đoạn resolve-order trong `CLAUDE.md` (Phase 4, issue #103) cho khớp hành vi mới.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWVvSmeMF3JHpcEq5D2ssQ