### PR TITLE
Chống treo bot sau sleep/wake + rotate log + TikTok nhiều người nhận (issue #107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,6 +789,31 @@ Xem `launchd/README.md`. Mọi service chạy nền là launchd LaunchAgent
   `run_pipeline.sh` uỷ cho `run_module.sh` (1 chỗ resolve venv + cwd + log). Thêm
   plist mới → trỏ `run_module.sh` + đặt `LOG_BASENAME`, giữ quy ước **tên file
   plist == Label**.
+- **Bot treo sau sleep/wake + log 3.4GB (issue #107).** Root cause (stack
+  sample): bot kẹt VĨNH VIỄN ở `sock_connect → internal_select → poll` khi mở
+  TCP tới api.telegram.org dù `urlopen` có timeout 35s — CPython đặt deadline
+  theo đồng hồ MONOTONIC (`mach_absolute_time` NGỪNG chạy khi Mac ngủ) nên qua
+  chu kỳ ngủ/dậy deadline không bao giờ tới; CPU 0% nhưng PID sống → KeepAlive
+  không cứu (chỉ restart process đã chết). Fix 3 lớp: (1) **watchdog thread**
+  trong `run_bot` đo pha vòng lặp (`poll`/`handle`) bằng **WALL CLOCK**
+  (time.time vẫn chạy khi máy ngủ) — pha vượt trần
+  (`BOT_WATCHDOG_POLL_TIMEOUT`=180s / `BOT_WATCHDOG_HANDLE_TIMEOUT`=1800s, 0 =
+  tắt) → `os._exit(70)` cho launchd restart; trần handle rộng riêng vì approve
+  → upload hợp lệ có thể vài phút; Mac ngủ dài giữa poll → watchdog restart
+  ngay khi dậy (chủ đích — restart sạch sau sleep). Exit 70 (EX_SOFTWARE),
+  KHÔNG 78 — launchd khoá job exit 78 tới khi reload. (2) **SIGTERM handler**
+  raise SystemExit → thoát gọn + nhả PID lock (trước đây `exit -15` không nhả
+  lock; signal cũng làm syscall kẹt trả EINTR nên unstick được connect đang
+  treo); timeout transient của getUpdates hạ ERROR→WARNING (1.343 dòng rác).
+  (3) **`run_module.sh` rotate log lúc spawn**: file vượt `LOG_MAX_BYTES`
+  (50MB, env qua plist) → `tail -c` giữ đuôi mới nhất sang `<file>.1` + làm
+  rỗng file chính — file 3.4GB cũ tự co về trần ở lần restart tới, không cần
+  dọn tay; `LOG_DIR` env-overridable (test). Đồng thời
+  **`TELEGRAM_TIKTOK_CHAT_ID` nhận NHIỀU chat id** cách nhau dấu phẩy
+  (`_tiktok_chat_ids()`): mỗi người nhận trọn bộ narrative + video, export
+  queue tay chỉ chạy 1 lần/lượt, một người lỗi không chặn người khác (trả True
+  nếu ≥1 người nhận được); người nhận DM phải Start bot trước (giới hạn
+  Telegram), hoặc dùng id GROUP chung.
 - **`storage/launchd_status.py` — watchdog + self-heal (defense-in-depth).** Chạy
   ké trong `main.py` (07:00) và `storage.collector_health` (06:30/18:30),
   best-effort không bao giờ raise. Ngoài việc alert service **chưa load** (#72),

--- a/content-pipeline/.env.example
+++ b/content-pipeline/.env.example
@@ -3,8 +3,20 @@ TELEGRAM_BOT_TOKEN=...
 TELEGRAM_CHAT_ID=...
 # Kênh "Bé MC" nhận NARRATIVE (text) + video để upload TikTok THỦ CÔNG cho cả
 # 2 track AI/Drama (TikTok không auto-upload). Để trống → dùng chung
-# TELEGRAM_CHAT_ID.
+# TELEGRAM_CHAT_ID. Nhận NHIỀU chat id cách nhau dấu phẩy (vd "123456,789012")
+# để gửi cho nhiều người cùng lúc — LƯU Ý: mỗi người phải bấm Start với bot
+# TRƯỚC (Telegram cấm bot chủ động nhắn người lạ); lấy chat id của họ bằng cách
+# họ nhắn @userinfobot. Cách khác không cần nhiều id: tạo GROUP chung (thêm bot
+# + mọi người nhận) rồi điền id group (số âm) vào đây.
 TELEGRAM_TIKTOK_CHAT_ID=
+
+# --- Bot watchdog (issue #107) ---
+# Bot long-poll từng treo VĨNH VIỄN ở sock_connect sau khi Mac ngủ/dậy (timeout
+# socket đặt theo đồng hồ monotonic — đứng im khi máy ngủ) → CPU 0%, launchd
+# thấy PID sống nên không cứu. Watchdog đo bằng wall clock: pha vượt trần → bot
+# tự thoát (exit 70) để launchd KeepAlive kéo dậy sạch. 0 = tắt trần pha đó.
+# BOT_WATCHDOG_POLL_TIMEOUT=180      # trần pha poll getUpdates (bình thường ≤40s)
+# BOT_WATCHDOG_HANDLE_TIMEOUT=1800   # trần pha xử lý update (approve → upload)
 # Bản "TÓM TẮT AI HÔM NAY (5 bài)" buổi sáng qua Telegram — TẮT mặc định
 # (Bé MC đã nhận narrative theo từng video nên bản tóm tắt thành nhiễu).
 # AI_NARRATIVE_REPORT_ENABLED=0

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -10,7 +10,24 @@ TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
 # Kênh Telegram "Bé MC" nhận video đã render để upload TikTok THỦ CÔNG. TikTok
 # không auto-upload nữa: pipeline gửi video vào đây, user tự tải lên TikTok.
 # Rỗng → dùng chung TELEGRAM_CHAT_ID (không để video rơi vào hư không).
+# Nhận NHIỀU chat id cách nhau bằng dấu phẩy ("123,456") để gửi cùng lúc cho
+# nhiều người (issue #107 follow-up) — mỗi người nhận phải bấm Start với bot
+# trước thì bot mới nhắn riêng được (giới hạn của Telegram).
 TELEGRAM_TIKTOK_CHAT_ID = os.getenv("TELEGRAM_TIKTOK_CHAT_ID", "")
+
+# --- Bot watchdog (issue #107) ---
+# Bot long-poll từng bị kẹt VĨNH VIỄN ở sock_connect sau chu kỳ ngủ/dậy của
+# macOS: timeout của urlopen đặt deadline theo đồng hồ MONOTONIC
+# (mach_absolute_time — NGỪNG chạy khi máy ngủ) nên deadline không bao giờ
+# tới; CPU 0%, PID còn sống nên launchd KeepAlive không cứu. Watchdog thread
+# trong run_bot đo bằng WALL CLOCK (time.time — vẫn chạy khi máy ngủ): pha nào
+# vượt trần → os._exit để launchd kéo bot dậy sạch sẽ (offset getUpdates đã
+# persist nên không mất update). Đặt 0 để tắt trần của pha tương ứng.
+# Pha poll (getUpdates) bình thường ≤ ~40s → trần 180s là rất rộng.
+BOT_WATCHDOG_POLL_TIMEOUT = int(os.getenv("BOT_WATCHDOG_POLL_TIMEOUT", "180"))
+# Pha xử lý update hợp lệ có thể dài nhiều phút (approve = ghi DB + xếp lịch +
+# upload/gửi file) — trần riêng, rộng hơn hẳn pha poll.
+BOT_WATCHDOG_HANDLE_TIMEOUT = int(os.getenv("BOT_WATCHDOG_HANDLE_TIMEOUT", "1800"))
 TWITTER_BEARER_TOKEN = os.getenv("TWITTER_BEARER_TOKEN", "")
 PRODUCTHUNT_API_TOKEN = os.getenv("PRODUCTHUNT_API_TOKEN", "")
 

--- a/content-pipeline/launchd/README.md
+++ b/content-pipeline/launchd/README.md
@@ -56,6 +56,29 @@ endpoint `GET /health` cũng có section `launchd`.
 Quy ước: **tên file plist == Label bên trong** — cả `install.sh` lẫn
 `storage/launchd_status.py` dựa vào điều này; giữ quy ước khi thêm plist mới.
 
+## Bot treo sau sleep/wake + log 3.4GB (issue #107)
+
+**Root cause (đã kiểm chứng bằng stack sample):** bot kẹt VĨNH VIỄN ở
+`sock_connect → internal_select → poll` khi mở TCP tới api.telegram.org, dù
+`urlopen` có timeout 35s — CPython đặt deadline theo đồng hồ **monotonic**
+(`mach_absolute_time`, **ngừng chạy khi Mac ngủ**) nên qua chu kỳ ngủ/dậy
+deadline không bao giờ tới. CPU 0% nhưng PID còn sống → `KeepAlive` của launchd
+KHÔNG cứu (nó chỉ restart process đã chết).
+
+**Fix 3 lớp:**
+- **Watchdog thread** trong `run_bot` (notifier/telegram_bot.py) đo pha vòng
+  lặp (`poll`/`handle`) bằng **wall clock** (vẫn chạy khi máy ngủ); pha vượt
+  trần (`BOT_WATCHDOG_POLL_TIMEOUT`=180s / `BOT_WATCHDOG_HANDLE_TIMEOUT`=1800s)
+  → `os._exit(70)` để launchd restart. (Exit 70, KHÔNG phải 78 — launchd khoá
+  job exit 78 tới khi reload.) Mac ngủ dài giữa lúc poll → watchdog restart bot
+  ngay khi dậy: đó là hành vi chủ đích, restart sạch sau sleep.
+- **SIGTERM handler**: `exit -15` khi Mac ngủ giờ thoát gọn — nhả PID lock
+  (`notifier/.bot.pid`), unwind cả khi đang kẹt trong syscall (EINTR).
+- **Log rotation trong `run_module.sh`**: lúc spawn, file log vượt
+  `LOG_MAX_BYTES` (mặc định 50MB, đặt qua EnvironmentVariables của plist nếu
+  muốn đổi) → giữ ĐUÔI mới nhất sang `<file>.1` + làm rỗng file chính. File
+  3.4GB cũ tự co về trần ở lần restart kế tiếp — không cần dọn tay.
+
 ## Danh sách service
 
 | Service | Lịch chạy |

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -516,13 +516,18 @@ def run_bot(publish_callback):
         # phụ (test/tool) vẫn chạy, chỉ mất graceful shutdown.
         logger.warning("Không đặt được SIGTERM handler (không phải main thread)")
 
+    # Watchdog phải sống TRƯỚC call mạng đầu tiên: _delete_webhook/_send_text
+    # khởi động cũng đi đúng đường sock_connect có thể treo vĩnh viễn sau
+    # sleep/wake (review Codex PR #108). Đánh pha "poll" vì các call khởi động
+    # đều là network op ngắn (timeout ≤10s) — trần poll 180s bao chúng thoải
+    # mái; vòng lặp bên dưới sẽ tự đánh lại pha mỗi iteration.
+    _watchdog_mark("poll")
+    _start_watchdog()
+
     # Webhook tồn đọng khiến MỌI getUpdates trả 409 Conflict — xoá 1 lần lúc
     # khởi động để long-polling dùng được (root cause #88). Giữ pending updates
     # để callback approve vừa bấm vẫn tới.
     _delete_webhook()
-
-    _watchdog_mark("handle")   # khởi động tính là pha xử lý
-    _start_watchdog()
 
     logger.info("🤖 Telegram bot started — listening for approvals...")
     _send_text("🤖 Bot đã khởi động. Sẵn sàng nhận lệnh approve/reject.")

--- a/content-pipeline/notifier/telegram_bot.py
+++ b/content-pipeline/notifier/telegram_bot.py
@@ -11,6 +11,9 @@ Chạy: python main.py --bot (chạy liên tục như daemon)
 import json
 import logging
 import os
+import signal
+import socket
+import threading
 import time
 from datetime import date
 from urllib.error import HTTPError
@@ -171,14 +174,18 @@ def send_tiktok_manual(video_id: int) -> bool:
     Gửi FILE GỐC (giữ nguyên chất lượng để upload). Nếu >50MB (trần Telegram
     bot) hoặc gửi lỗi → export ra queue tay local (publisher/tiktok_manual) rồi
     gửi 1 tin nhắn báo đường dẫn file gốc, để Bé MC vẫn upload được bản nét.
-    Trả True nếu video HOẶC thông báo fallback đã tới Bé MC.
+
+    TELEGRAM_TIKTOK_CHAT_ID nhận NHIỀU chat id cách nhau dấu phẩy — mỗi người
+    nhận trọn bộ narrative + video (issue #107 follow-up). Trả True nếu video
+    HOẶC thông báo fallback đã tới ÍT NHẤT một người nhận (người lỗi chỉ log
+    warning, không kéo sập cả lượt gửi).
     """
     video = get_video(video_id)
     if not video:
         logger.error("send_tiktok_manual: video %d not found", video_id)
         return False
-    chat_id = config.TELEGRAM_TIKTOK_CHAT_ID or config.TELEGRAM_CHAT_ID
-    if not config.TELEGRAM_BOT_TOKEN or not chat_id:
+    chat_ids = _tiktok_chat_ids()
+    if not config.TELEGRAM_BOT_TOKEN or not chat_ids:
         logger.warning("Bé MC chat chưa cấu hình — bỏ qua gửi TikTok video %d", video_id)
         return False
     video_path = video.get("video_path")
@@ -190,60 +197,91 @@ def send_tiktok_manual(video_id: int) -> bool:
     title = video.get("youtube_title", "") or video.get("tiktok_caption", "")
     tiktok_caption = video.get("tiktok_caption", "")
     hashtags = video.get("tiktok_hashtags", "")
-
-    # Narrative (script_text) đi TRƯỚC video — yêu cầu chủ kênh: Bé MC nhận
-    # cả text lẫn video cho MỌI video TikTok (cả track AI lẫn Drama đều route
-    # qua hàm này). script_text là chính narration đọc trong video (một nguồn
-    # text cho TTS/phụ đề/review), nên Bé MC dùng nó làm caption/mô tả hoặc
-    # đối chiếu nội dung mà không phải chờ hỏi lại. Best-effort: text lỗi
-    # không chặn gửi video (video mới là thứ bắt buộc để upload).
-    narrative_sent = False
     narration = video.get("script_text", "") or ""
-    if narration.strip():
-        narrative_sent = _send_text_chunks(
-            f"📋 NARRATIVE VIDEO TIKTOK #{video_id} ({len(narration.split())} từ)\n"
-            f"{'─' * 30}\n\n{narration}",
-            chat_id=chat_id,
-        )
-        if not narrative_sent:
-            logger.warning("Không gửi được narrative video %d tới Bé MC "
-                           "(vẫn gửi video)", video_id)
-
-    caption = (
-        f"🎵 VIDEO TIKTOK #{video_id} — UPLOAD TAY\n"
-        f"📝 {title}\n"
-        + (f"💬 Caption: {tiktok_caption}\n" if tiktok_caption else "")
-        + (f"🏷 {hashtags}\n" if hashtags else "")
-        + ("📋 Narrative (script) ở tin nhắn phía trên.\n" if narrative_sent else "")
-        + "➡️ Tải video này lên TikTok giúp nhé (Bé MC tự đăng)."
-    )
 
     # File gốc trong ngưỡng → gửi thẳng (chất lượng nguyên vẹn cho upload).
     try:
         size_ok = os.path.getsize(video_path) <= TELEGRAM_MAX_FILE_BYTES
     except OSError:
         size_ok = False
-    if size_ok:
-        msg_id = _send_video_file(video_path, caption, chat_id=chat_id)
-        if msg_id:
-            logger.info("Video %d gửi tới Bé MC để upload TikTok tay", video_id)
-            return True
-        logger.warning("Gửi video %d tới Bé MC lỗi — chuyển sang fallback queue tay",
-                       video_id)
 
-    # >50MB hoặc gửi lỗi → giữ bản gốc trong queue tay + báo đường dẫn.
-    exported_note = ""
-    try:
-        from publisher.tiktok_manual import export_for_manual_upload
-        exported = export_for_manual_upload(video_id)
-        if exported:
-            exported_note = f"\n📁 File gốc (nét) đã lưu: {exported}"
-    except Exception as e:
-        logger.warning("Export queue tay cho video %d lỗi (non-fatal): %s", video_id, e)
-    return _send_single_text(
-        caption + "\n\n⚠️ File quá lớn để gửi qua Telegram." + exported_note,
-        chat_id=chat_id,
-    )
+    # Export queue tay chỉ chạy 1 LẦN cho cả lượt (file chung, không phụ thuộc
+    # người nhận) và chỉ khi thật sự cần fallback — None = chưa export.
+    exported_note: str | None = None
+    # file_id Telegram của lần upload đầu tiên thành công trong lượt này —
+    # người nhận sau gửi lại theo file_id, không upload lại file.
+    cached_file_id: str | None = None
+
+    def _fallback_note() -> str:
+        nonlocal exported_note
+        if exported_note is None:
+            exported_note = ""
+            try:
+                from publisher.tiktok_manual import export_for_manual_upload
+                exported = export_for_manual_upload(video_id)
+                if exported:
+                    exported_note = f"\n📁 File gốc (nét) đã lưu: {exported}"
+            except Exception as e:
+                logger.warning("Export queue tay cho video %d lỗi (non-fatal): %s",
+                               video_id, e)
+        return exported_note
+
+    delivered_any = False
+    for chat_id in chat_ids:
+        # Narrative (script_text) đi TRƯỚC video — yêu cầu chủ kênh: Bé MC nhận
+        # cả text lẫn video cho MỌI video TikTok (cả track AI lẫn Drama đều
+        # route qua hàm này). script_text là chính narration đọc trong video
+        # (một nguồn text cho TTS/phụ đề/review), nên Bé MC dùng nó làm
+        # caption/mô tả hoặc đối chiếu nội dung mà không phải chờ hỏi lại.
+        # Best-effort: text lỗi không chặn gửi video.
+        narrative_sent = False
+        if narration.strip():
+            narrative_sent = _send_text_chunks(
+                f"📋 NARRATIVE VIDEO TIKTOK #{video_id} ({len(narration.split())} từ)\n"
+                f"{'─' * 30}\n\n{narration}",
+                chat_id=chat_id,
+            )
+            if not narrative_sent:
+                logger.warning("Không gửi được narrative video %d tới chat %s "
+                               "(vẫn gửi video)", video_id, chat_id)
+
+        caption = (
+            f"🎵 VIDEO TIKTOK #{video_id} — UPLOAD TAY\n"
+            f"📝 {title}\n"
+            + (f"💬 Caption: {tiktok_caption}\n" if tiktok_caption else "")
+            + (f"🏷 {hashtags}\n" if hashtags else "")
+            + ("📋 Narrative (script) ở tin nhắn phía trên.\n" if narrative_sent else "")
+            + "➡️ Tải video này lên TikTok giúp nhé (Bé MC tự đăng)."
+        )
+
+        sent = False
+        if size_ok:
+            # Người nhận thứ 2+ tái dùng file_id của lần upload đầu (gửi tức
+            # thì, không re-upload ~50MB); file_id lỗi → rơi về upload thường.
+            msg_id = None
+            if cached_file_id:
+                msg_id = _send_video_by_file_id(cached_file_id, caption, chat_id)
+            if not msg_id:
+                msg_id = _send_video_file(video_path, caption, chat_id=chat_id)
+                if msg_id:
+                    cached_file_id = _last_video_file_id
+            if msg_id:
+                logger.info("Video %d gửi tới chat %s để upload TikTok tay",
+                            video_id, chat_id)
+                sent = True
+            else:
+                logger.warning("Gửi video %d tới chat %s lỗi — chuyển sang "
+                               "fallback queue tay", video_id, chat_id)
+
+        if not sent:
+            # >50MB hoặc gửi lỗi → giữ bản gốc trong queue tay + báo đường dẫn.
+            sent = _send_single_text(
+                caption + "\n\n⚠️ File quá lớn để gửi qua Telegram." + _fallback_note(),
+                chat_id=chat_id,
+            )
+        delivered_any = delivered_any or sent
+
+    return delivered_any
 
 
 def send_publish_notification(video_id: int, platform: str, url: str):
@@ -381,6 +419,80 @@ def _release_bot_lock():
         pass
 
 
+# --- Watchdog chống treo (issue #107) ---
+# Root cause #107: getUpdates kẹt VĨNH VIỄN ở sock_connect sau chu kỳ ngủ/dậy
+# của Mac dù urlopen có timeout=35s — CPython đặt deadline theo đồng hồ
+# MONOTONIC (mach_absolute_time trên macOS NGỪNG chạy khi máy ngủ) nên deadline
+# không bao giờ tới. PID còn sống (CPU 0%) → launchd KeepAlive không cứu. Lớp
+# bảo vệ ngoài: thread watchdog đo pha hiện tại của vòng lặp bằng WALL CLOCK
+# (time.time vẫn chạy khi máy ngủ); pha vượt trần → os._exit để launchd restart
+# bot sạch (offset getUpdates + PID lock đều được xử lý qua restart). Hệ quả
+# phụ CÓ CHỦ ĐÍCH: Mac ngủ dài giữa lúc poll → watchdog restart bot ngay khi
+# dậy — chính là trạng thái sạch ta muốn sau sleep.
+_WATCHDOG_CHECK_INTERVAL = 15  # giây giữa 2 lần kiểm tra
+_watchdog_state = {"phase": "idle", "since": 0.0}
+
+
+def _watchdog_mark(phase: str) -> None:
+    """Ghi pha hiện tại của vòng lặp bot ('poll' | 'handle') + mốc wall-clock."""
+    _watchdog_state["phase"] = phase
+    _watchdog_state["since"] = time.time()
+
+
+def _watchdog_verdict(state: dict, now: float) -> str | None:
+    """Trả lý do cần kill nếu pha hiện tại vượt trần, None nếu khoẻ.
+
+    Tách thuần để test được không cần thread/không cần chờ thật. Trần theo pha:
+    poll (mạng, bình thường ≤40s) chặt hơn hẳn handle (approve → upload có thể
+    vài phút). Trần ≤0 = tắt kiểm tra pha đó.
+    """
+    limits = {
+        "poll": getattr(config, "BOT_WATCHDOG_POLL_TIMEOUT", 180),
+        "handle": getattr(config, "BOT_WATCHDOG_HANDLE_TIMEOUT", 1800),
+    }
+    limit = limits.get(state.get("phase", ""))
+    if not limit or limit <= 0:
+        return None
+    elapsed = now - state.get("since", now)
+    if elapsed > limit:
+        return (f"pha '{state['phase']}' kẹt {elapsed:.0f}s "
+                f"(trần {limit}s)")
+    return None
+
+
+def _watchdog_loop() -> None:
+    while True:
+        time.sleep(_WATCHDOG_CHECK_INTERVAL)
+        reason = _watchdog_verdict(_watchdog_state, time.time())
+        if reason:
+            logger.critical(
+                "Watchdog: %s — os._exit để launchd KeepAlive restart bot "
+                "(socket timeout không tin được qua sleep/wake, issue #107)",
+                reason,
+            )
+            _release_bot_lock()
+            # os._exit (không phải sys.exit): main thread đang kẹt trong
+            # syscall, chỉ hạ cả process mới chắc chắn thoát. 70 = EX_SOFTWARE
+            # (KHÔNG dùng 78/EX_CONFIG — launchd khoá job exit 78 tới khi reload).
+            os._exit(70)
+
+
+def _start_watchdog() -> threading.Thread:
+    t = threading.Thread(target=_watchdog_loop, name="bot-watchdog", daemon=True)
+    t.start()
+    return t
+
+
+def _sigterm_handler(signum, frame):
+    """launchd gửi SIGTERM khi Mac ngủ/reload/shutdown (issue #107: 'exit -15').
+
+    Raise SystemExit để unwind stack — signal làm syscall đang chờ (kể cả
+    sock_connect kẹt) trả EINTR nên bot thoát được ngay; finally trong run_bot
+    nhả PID lock → instance mới không phải chờ stale-lock check.
+    """
+    raise SystemExit(0)
+
+
 def run_bot(publish_callback):
     """Run persistent Telegram bot with long-polling.
 
@@ -397,35 +509,57 @@ def run_bot(publish_callback):
     if not _acquire_bot_lock():
         return  # Another instance running — exit cleanly (no 409)
 
+    try:
+        signal.signal(signal.SIGTERM, _sigterm_handler)
+    except ValueError:
+        # signal.signal chỉ gọi được từ main thread — bot nhúng trong thread
+        # phụ (test/tool) vẫn chạy, chỉ mất graceful shutdown.
+        logger.warning("Không đặt được SIGTERM handler (không phải main thread)")
+
     # Webhook tồn đọng khiến MỌI getUpdates trả 409 Conflict — xoá 1 lần lúc
     # khởi động để long-polling dùng được (root cause #88). Giữ pending updates
     # để callback approve vừa bấm vẫn tới.
     _delete_webhook()
+
+    _watchdog_mark("handle")   # khởi động tính là pha xử lý
+    _start_watchdog()
 
     logger.info("🤖 Telegram bot started — listening for approvals...")
     _send_text("🤖 Bot đã khởi động. Sẵn sàng nhận lệnh approve/reject.")
 
     consecutive_errors = 0
 
-    while True:
-        try:
-            updates = _get_updates(timeout=30)
-            consecutive_errors = 0  # Reset on success
+    try:
+        while True:
+            try:
+                _watchdog_mark("poll")
+                updates = _get_updates(timeout=30)
+                _watchdog_mark("handle")
+                consecutive_errors = 0  # Reset on success
 
-            for update in updates:
-                _handle_update(update, publish_callback)
+                for update in updates:
+                    _handle_update(update, publish_callback)
 
-        except KeyboardInterrupt:
-            logger.info("Bot stopped by user")
-            _send_text("🛑 Bot đã dừng.")
-            _release_bot_lock()
-            break
-        except Exception as e:
-            consecutive_errors += 1
-            wait = min(2 ** consecutive_errors, 60)
-            logger.error("Bot error (attempt %d): %s — retrying in %ds",
-                         consecutive_errors, e, wait)
-            time.sleep(wait)
+            except KeyboardInterrupt:
+                logger.info("Bot stopped by user")
+                _send_text("🛑 Bot đã dừng.")
+                break
+            except Exception as e:
+                # Backoff không phải poll — chuyển pha để trần poll (chặt)
+                # không chém nhầm giấc ngủ backoff hợp lệ (tối đa 60s).
+                _watchdog_mark("handle")
+                consecutive_errors += 1
+                wait = min(2 ** consecutive_errors, 60)
+                logger.error("Bot error (attempt %d): %s — retrying in %ds",
+                             consecutive_errors, e, wait)
+                time.sleep(wait)
+    except SystemExit:
+        # SIGTERM từ launchd (ngủ/reload/shutdown): thoát nhanh, KHÔNG gửi
+        # Telegram — mạng có thể đã down và launchd chỉ chờ vài giây trước
+        # khi SIGKILL; finally bên dưới vẫn nhả lock.
+        logger.info("Bot nhận SIGTERM — thoát gọn")
+    finally:
+        _release_bot_lock()
 
 
 def _handle_update(update: dict, publish_callback):
@@ -634,6 +768,17 @@ def _handle_callback_query(callback_query: dict):
 
 # --- Internal helpers ---
 
+def _tiktok_chat_ids() -> list[str]:
+    """Danh sách chat nhận video TikTok (kênh Bé MC).
+
+    TELEGRAM_TIKTOK_CHAT_ID nhận nhiều id cách nhau dấu phẩy để gửi cùng lúc
+    cho nhiều người (issue #107 follow-up); rỗng → fallback TELEGRAM_CHAT_ID
+    (không để video rơi vào hư không).
+    """
+    raw = config.TELEGRAM_TIKTOK_CHAT_ID or config.TELEGRAM_CHAT_ID or ""
+    return [c.strip() for c in raw.split(",") if c.strip()]
+
+
 def _send_video_file(video_path: str, caption: str,
                      reply_markup: dict | None = None,
                      chat_id: str | None = None) -> str | None:
@@ -722,6 +867,14 @@ def _send_video_file(video_path: str, caption: str,
             result = json.loads(resp.read().decode())
             if result.get("ok"):
                 msg_id = str(result["result"]["message_id"])
+                # Lưu file_id Telegram cấp cho lần upload này (side channel —
+                # KHÔNG đổi return type vì nhiều caller/test dựa vào msg_id).
+                # send_tiktok_manual dùng nó để gửi lại cho người nhận tiếp
+                # theo mà không phải upload lại cả file (issue #107 follow-up).
+                global _last_video_file_id
+                _last_video_file_id = (
+                    (result["result"].get("video") or {}).get("file_id") or None
+                )
                 # Send remainder of caption as follow-up text if it was truncated
                 if caption_remainder:
                     _send_text_chunks(f"📝 (tiếp theo)\n\n{caption_remainder}")
@@ -730,6 +883,40 @@ def _send_video_file(video_path: str, caption: str,
             return None
     except Exception as e:
         logger.error("Failed to send video to Telegram: %s", e)
+        return None
+
+
+# file_id của lần sendVideo thành công gần nhất (do _send_video_file set).
+_last_video_file_id: str | None = None
+
+
+def _send_video_by_file_id(file_id: str, caption: str, chat_id: str) -> str | None:
+    """Gửi lại một video ĐÃ upload bằng file_id Telegram (không re-upload).
+
+    Telegram cho phép truyền file_id thay cho bytes trong sendVideo — gửi cho
+    người nhận thứ 2+ gần như tức thì thay vì upload lại file (có thể ~50MB)
+    cho từng người. Caption ở đường này luôn ngắn (caption TikTok) nên chỉ cắt
+    an toàn ở 1024, không cần logic remainder của _send_video_file.
+    """
+    if not file_id or not config.TELEGRAM_BOT_TOKEN:
+        return None
+    url = f"https://api.telegram.org/bot{config.TELEGRAM_BOT_TOKEN}/sendVideo"
+    payload = json.dumps({
+        "chat_id": chat_id,
+        "video": file_id,
+        "caption": caption[:1024],
+    }).encode("utf-8")
+    try:
+        req = Request(url, data=payload,
+                      headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+        if result.get("ok"):
+            return str(result["result"]["message_id"])
+        logger.warning("sendVideo theo file_id lỗi (fallback re-upload): %s", result)
+        return None
+    except Exception as e:
+        logger.warning("sendVideo theo file_id lỗi (fallback re-upload): %s", e)
         return None
 
 
@@ -979,7 +1166,14 @@ def _get_updates(timeout: int = 30) -> list[dict]:
             logger.error("Telegram getUpdates failed (code=%s): %s", e.code, body)
         return []
     except Exception as e:
-        logger.error("Telegram getUpdates failed: %s", e)
+        # Timeout đọc/kết nối là nhiễu transient bình thường của long-poll
+        # (mạng chập chờn, Mac vừa wake) — hạ xuống WARNING để không tích rác
+        # ERROR trong log (1.343 dòng "read operation timed out", issue #107).
+        # Lỗi khác giữ ERROR.
+        if isinstance(e, (TimeoutError, socket.timeout)) or "timed out" in str(e).lower():
+            logger.warning("Telegram getUpdates timeout (transient): %s", e)
+        else:
+            logger.error("Telegram getUpdates failed: %s", e)
         return []
 
 

--- a/content-pipeline/run_module.sh
+++ b/content-pipeline/run_module.sh
@@ -18,8 +18,10 @@
 #   phá được scheduled run.
 #
 # Dùng: run_module.sh -m package.module [args...]   (hoặc run_module.sh script.py)
-# Env:  LOG_BASENAME — tên file log (mặc định "run_module"); log ghi vào
+# Env:  LOG_BASENAME  — tên file log (mặc định "run_module"); log ghi vào
 #       <script_dir>/logs/${LOG_BASENAME}_stdout.log + _stderr.log.
+#       LOG_DIR       — thư mục log (mặc định <script_dir>/logs).
+#       LOG_MAX_BYTES — trần size mỗi file log (mặc định 50MB, issue #107).
 
 set -e
 
@@ -29,9 +31,29 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Wrapper tự mở file log với inode tươi mỗi lần chạy → không còn stale-handle như
 # khi để launchd/xpcproxy mở. Đặt SỚM để cả lỗi cấp wrapper (vd thiếu venv) cũng
 # được ghi lại thay vì rơi vào hư không.
-LOG_DIR="$SCRIPT_DIR/logs"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/logs}"
 mkdir -p "$LOG_DIR"
 LOG_BASENAME="${LOG_BASENAME:-run_module}"
+
+# --- Log rotation (issue #107: bot_stdout.log phình 3.4GB vì chỉ append) ---
+# Rotate lúc SPAWN (trước redirect): file vượt trần → giữ ĐUÔI mới nhất
+# (LOG_MAX_BYTES) sang <file>.1 rồi làm rỗng file chính. tail -c thay vì mv
+# nguyên file để một file đã phình khổng lồ (3.4GB) co ngay về trần trong một
+# lần rotate — không cần dọn tay. Tối đa ~2×LOG_MAX_BYTES/stream trên đĩa.
+LOG_MAX_BYTES="${LOG_MAX_BYTES:-52428800}"
+rotate_log() {
+    local f="$1" size
+    [ -f "$f" ] || return 0
+    size=$(wc -c < "$f" 2>/dev/null | tr -d '[:space:]') || size=0
+    [ -n "$size" ] || size=0
+    if [ "$size" -gt "$LOG_MAX_BYTES" ]; then
+        tail -c "$LOG_MAX_BYTES" "$f" > "$f.1" 2>/dev/null || cp "$f" "$f.1"
+        : > "$f"
+    fi
+}
+rotate_log "$LOG_DIR/${LOG_BASENAME}_stdout.log"
+rotate_log "$LOG_DIR/${LOG_BASENAME}_stderr.log"
+
 exec >>"$LOG_DIR/${LOG_BASENAME}_stdout.log" 2>>"$LOG_DIR/${LOG_BASENAME}_stderr.log"
 
 # --- cwd = package root ở runtime (thay cho WorkingDirectory) ---

--- a/content-pipeline/tests/test_bot_watchdog.py
+++ b/content-pipeline/tests/test_bot_watchdog.py
@@ -1,0 +1,108 @@
+"""Tests cho watchdog chống treo + SIGTERM graceful shutdown (issue #107).
+
+Root cause #107: getUpdates kẹt vĩnh viễn ở sock_connect sau chu kỳ ngủ/dậy
+của Mac dù urlopen có timeout (deadline theo monotonic clock — đứng im khi máy
+ngủ). Watchdog đo bằng wall clock và hạ process khi một pha vượt trần.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import notifier.telegram_bot as tb
+
+
+class TestWatchdogVerdict(unittest.TestCase):
+    def setUp(self):
+        p = patch.object(tb, "config")
+        self.cfg = p.start()
+        self.addCleanup(p.stop)
+        self.cfg.BOT_WATCHDOG_POLL_TIMEOUT = 180
+        self.cfg.BOT_WATCHDOG_HANDLE_TIMEOUT = 1800
+
+    def test_poll_within_limit_ok(self):
+        state = {"phase": "poll", "since": 1000.0}
+        self.assertIsNone(tb._watchdog_verdict(state, 1000.0 + 60))
+
+    def test_poll_over_limit_kills(self):
+        state = {"phase": "poll", "since": 1000.0}
+        self.assertIsNotNone(tb._watchdog_verdict(state, 1000.0 + 181))
+
+    def test_handle_uses_wider_limit(self):
+        # Pha handle (approve → upload) hợp lệ có thể dài nhiều phút — trần
+        # poll chặt không được chém nhầm pha handle.
+        state = {"phase": "handle", "since": 1000.0}
+        self.assertIsNone(tb._watchdog_verdict(state, 1000.0 + 600))
+        self.assertIsNotNone(tb._watchdog_verdict(state, 1000.0 + 1801))
+
+    def test_idle_never_kills(self):
+        self.assertIsNone(tb._watchdog_verdict({"phase": "idle", "since": 0.0}, 1e12))
+
+    def test_zero_limit_disables_phase(self):
+        self.cfg.BOT_WATCHDOG_POLL_TIMEOUT = 0
+        self.assertIsNone(tb._watchdog_verdict({"phase": "poll", "since": 0.0}, 1e12))
+
+    def test_mark_updates_state(self):
+        old = dict(tb._watchdog_state)
+        self.addCleanup(lambda: tb._watchdog_state.update(old))
+        tb._watchdog_mark("poll")
+        self.assertEqual(tb._watchdog_state["phase"], "poll")
+        self.assertAlmostEqual(tb._watchdog_state["since"], time.time(), delta=5)
+
+
+class TestWatchdogLoop(unittest.TestCase):
+    def test_loop_exits_process_when_stuck(self):
+        old = dict(tb._watchdog_state)
+        self.addCleanup(lambda: tb._watchdog_state.update(old))
+        with patch.object(tb, "config") as cfg, \
+             patch.object(tb.time, "sleep"), \
+             patch.object(tb, "_release_bot_lock") as rel, \
+             patch.object(tb.os, "_exit", side_effect=SystemExit) as ex:
+            cfg.BOT_WATCHDOG_POLL_TIMEOUT = 180
+            cfg.BOT_WATCHDOG_HANDLE_TIMEOUT = 1800
+            tb._watchdog_state.update({"phase": "poll",
+                                       "since": time.time() - 999})
+            with self.assertRaises(SystemExit):
+                tb._watchdog_loop()
+        rel.assert_called_once()
+        # 70 = EX_SOFTWARE. KHÔNG được là 78 (EX_CONFIG): launchd khoá job
+        # exit 78 vào "spawn scheduled" tới khi reload — KeepAlive không cứu.
+        ex.assert_called_once_with(70)
+
+
+class TestSigterm(unittest.TestCase):
+    def test_handler_raises_systemexit(self):
+        with self.assertRaises(SystemExit):
+            tb._sigterm_handler(signal.SIGTERM, None)
+
+    def test_run_bot_releases_lock_on_sigterm(self):
+        # run_bot đang poll thì SystemExit (SIGTERM từ launchd khi Mac ngủ/
+        # reload) → thoát gọn KHÔNG raise ra ngoài, PID lock được nhả để
+        # instance mới không đụng stale lock.
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        os.remove(tmp.name)
+        old_handler = signal.getsignal(signal.SIGTERM)
+        try:
+            with patch.object(tb, "config") as cfg, \
+                 patch.object(tb, "_BOT_LOCK_FILE", tmp.name), \
+                 patch.object(tb, "_delete_webhook"), \
+                 patch.object(tb, "_send_text"), \
+                 patch.object(tb, "_start_watchdog"), \
+                 patch.object(tb, "_get_updates", side_effect=SystemExit(0)):
+                cfg.TELEGRAM_BOT_TOKEN = "token"
+                tb.run_bot(publish_callback=lambda vid: None)
+            self.assertFalse(os.path.exists(tmp.name))
+        finally:
+            signal.signal(signal.SIGTERM, old_handler)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_bot_watchdog.py
+++ b/content-pipeline/tests/test_bot_watchdog.py
@@ -77,6 +77,32 @@ class TestWatchdogLoop(unittest.TestCase):
         ex.assert_called_once_with(70)
 
 
+class TestWatchdogStartOrder(unittest.TestCase):
+    def test_watchdog_started_before_first_network_call(self):
+        # _delete_webhook là call mạng đầu tiên và đi cùng đường sock_connect
+        # có thể treo sau sleep/wake — watchdog phải sống TRƯỚC nó, nếu không
+        # bot treo ngay lúc khởi động mà không ai cứu (review Codex PR #108).
+        order = []
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        os.remove(tmp.name)
+        old_handler = signal.getsignal(signal.SIGTERM)
+        try:
+            with patch.object(tb, "config") as cfg, \
+                 patch.object(tb, "_BOT_LOCK_FILE", tmp.name), \
+                 patch.object(tb, "_delete_webhook",
+                              side_effect=lambda *a, **k: order.append("webhook")), \
+                 patch.object(tb, "_start_watchdog",
+                              side_effect=lambda: order.append("watchdog")), \
+                 patch.object(tb, "_send_text"), \
+                 patch.object(tb, "_get_updates", side_effect=SystemExit(0)):
+                cfg.TELEGRAM_BOT_TOKEN = "token"
+                tb.run_bot(publish_callback=lambda vid: None)
+        finally:
+            signal.signal(signal.SIGTERM, old_handler)
+        self.assertEqual(order, ["watchdog", "webhook"])
+
+
 class TestSigterm(unittest.TestCase):
     def test_handler_raises_systemexit(self):
         with self.assertRaises(SystemExit):

--- a/content-pipeline/tests/test_run_module_rotation.py
+++ b/content-pipeline/tests/test_run_module_rotation.py
@@ -1,0 +1,62 @@
+"""Tests cho log rotation của run_module.sh (issue #107 — bot_stdout.log 3.4GB).
+
+Wrapper rotate lúc spawn: file log vượt LOG_MAX_BYTES → giữ ĐUÔI mới nhất sang
+<file>.1 rồi làm rỗng file chính. Dùng tail -c thay vì mv nguyên file để một
+file đã phình khổng lồ co ngay về trần trong một lần rotate.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "run_module.sh"))
+
+
+def _run_wrapper(log_dir: str, max_bytes: int) -> subprocess.CompletedProcess:
+    env = dict(os.environ, LOG_DIR=log_dir, LOG_BASENAME="testlog",
+               LOG_MAX_BYTES=str(max_bytes))
+    # Môi trường test thường không có venv → wrapper exit 78 SAU bước rotate;
+    # ta chỉ kiểm tra hiệu ứng rotation trên file, không cần exec python thật.
+    return subprocess.run(["bash", SCRIPT, "-c", "pass"], env=env,
+                          capture_output=True, timeout=30)
+
+
+class TestLogRotation(unittest.TestCase):
+    def test_oversized_log_rotated_keeping_newest_tail(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = os.path.join(d, "testlog_stdout.log")
+            with open(f, "wb") as fh:
+                fh.write(b"A" * 900 + b"TAIL_MARKER")
+            _run_wrapper(d, 500)
+            # File chính đã co về ~0 (chỉ còn log mới của chính lần chạy này).
+            self.assertLess(os.path.getsize(f), 900)
+            with open(f + ".1", "rb") as fh:
+                kept = fh.read()
+            # .1 giữ đúng ĐUÔI mới nhất, bị cap ở LOG_MAX_BYTES.
+            self.assertEqual(len(kept), 500)
+            self.assertTrue(kept.endswith(b"TAIL_MARKER"))
+
+    def test_small_log_untouched(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = os.path.join(d, "testlog_stdout.log")
+            with open(f, "wb") as fh:
+                fh.write(b"small-but-precious")
+            _run_wrapper(d, 500)
+            self.assertFalse(os.path.exists(f + ".1"))
+            with open(f, "rb") as fh:
+                self.assertTrue(fh.read().startswith(b"small-but-precious"))
+
+    def test_missing_log_files_ok(self):
+        # Lần chạy đầu tiên (chưa có file log nào) không được vỡ vì rotation.
+        with tempfile.TemporaryDirectory() as d:
+            proc = _run_wrapper(d, 500)
+            # Wrapper đi tiếp qua bước rotate (venv thiếu → 78, venv có → mã
+            # của lệnh python) — miễn không phải lỗi bash cấp cú pháp/rotate.
+            self.assertIn(proc.returncode, (0, 78))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content-pipeline/tests/test_tiktok_telegram.py
+++ b/content-pipeline/tests/test_tiktok_telegram.py
@@ -135,5 +135,121 @@ class TestSendTiktokManual(unittest.TestCase):
             self.assertFalse(tb.send_tiktok_manual(42))
 
 
+class TestSendTiktokMultiRecipient(unittest.TestCase):
+    """TELEGRAM_TIKTOK_CHAT_ID nhận nhiều chat id (dấu phẩy) — issue #107
+    follow-up: gửi video TikTok cho chủ kênh VÀ một người khác cùng lúc."""
+
+    def setUp(self):
+        self.p_cfg = patch.object(tb, "config")
+        self.cfg = self.p_cfg.start()
+        self.addCleanup(self.p_cfg.stop)
+        self.cfg.TELEGRAM_BOT_TOKEN = "token"
+        self.cfg.TELEGRAM_CHAT_ID = "main_chat"
+        self.cfg.TELEGRAM_TIKTOK_CHAT_ID = "be_mc_chat, friend_chat"
+
+        self.p_get = patch.object(tb, "get_video", return_value=_video())
+        self.p_get.start()
+        self.addCleanup(self.p_get.stop)
+        self.p_exists = patch("os.path.exists", return_value=True)
+        self.p_exists.start()
+        self.addCleanup(self.p_exists.stop)
+
+    def test_chat_ids_parsed_with_whitespace_and_empties(self):
+        self.cfg.TELEGRAM_TIKTOK_CHAT_ID = " a , ,b,"
+        self.assertEqual(tb._tiktok_chat_ids(), ["a", "b"])
+
+    def test_single_id_stays_single(self):
+        self.cfg.TELEGRAM_TIKTOK_CHAT_ID = "be_mc_chat"
+        self.assertEqual(tb._tiktok_chat_ids(), ["be_mc_chat"])
+
+    def test_video_sent_to_every_recipient(self):
+        with patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_video_file", return_value="9") as sendv:
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+        chats = [c.kwargs["chat_id"] for c in sendv.call_args_list]
+        self.assertEqual(chats, ["be_mc_chat", "friend_chat"])
+
+    def test_narrative_reaches_each_recipient(self):
+        video = _video(script_text="Chuyện tối qua ở nhà chồng.")
+        with patch.object(tb, "get_video", return_value=video), \
+             patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_text_chunks", return_value=True) as sendn, \
+             patch.object(tb, "_send_video_file", return_value="9"):
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+        chats = [c.kwargs["chat_id"] for c in sendn.call_args_list]
+        self.assertEqual(chats, ["be_mc_chat", "friend_chat"])
+
+    def test_one_recipient_failing_does_not_block_other(self):
+        # Người đầu lỗi cả video lẫn text fallback; người sau nhận được video
+        # → tổng thể vẫn True (best-effort per-recipient).
+        with patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_video_file", side_effect=[None, "9"]), \
+             patch("publisher.tiktok_manual.export_for_manual_upload",
+                   return_value=None), \
+             patch.object(tb, "_send_single_text", return_value=False):
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+
+    def test_oversized_exports_once_but_notifies_everyone(self):
+        big = tb.TELEGRAM_MAX_FILE_BYTES + 1
+        with patch("os.path.getsize", return_value=big), \
+             patch("publisher.tiktok_manual.export_for_manual_upload",
+                   return_value="/queue/video_42.mp4") as exp, \
+             patch.object(tb, "_send_single_text", return_value=True) as sendt:
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+        exp.assert_called_once_with(42)   # export file chung, chạy đúng 1 lần
+        chats = [c.kwargs["chat_id"] for c in sendt.call_args_list]
+        self.assertEqual(chats, ["be_mc_chat", "friend_chat"])
+        for call in sendt.call_args_list:
+            self.assertIn("/queue/video_42.mp4", call.args[0])
+
+    def test_second_recipient_reuses_file_id_no_reupload(self):
+        # Upload thật chỉ 1 lần; người nhận sau đi đường file_id (tức thì,
+        # không đẩy lại ~50MB qua mạng).
+        old_fid = tb._last_video_file_id
+        self.addCleanup(lambda: setattr(tb, "_last_video_file_id", old_fid))
+
+        def _upload(path, caption, chat_id=None):
+            tb._last_video_file_id = "FID123"
+            return "9"
+
+        with patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_video_file", side_effect=_upload) as sendv, \
+             patch.object(tb, "_send_video_by_file_id", return_value="10") as sendf:
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+        sendv.assert_called_once()   # chỉ upload 1 lần
+        sendf.assert_called_once_with(
+            "FID123", sendf.call_args.args[1], "friend_chat")
+
+    def test_file_id_send_failure_falls_back_to_reupload(self):
+        # Đường file_id lỗi (vd file_id hết hạn) → người nhận sau vẫn nhận
+        # được video qua upload thường.
+        old_fid = tb._last_video_file_id
+        self.addCleanup(lambda: setattr(tb, "_last_video_file_id", old_fid))
+
+        def _upload(path, caption, chat_id=None):
+            tb._last_video_file_id = "FID123"
+            return "9"
+
+        with patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_video_file", side_effect=_upload) as sendv, \
+             patch.object(tb, "_send_video_by_file_id", return_value=None):
+            ok = tb.send_tiktok_manual(42)
+        self.assertTrue(ok)
+        self.assertEqual(sendv.call_count, 2)
+
+    def test_all_recipients_failing_returns_false(self):
+        with patch("os.path.getsize", return_value=1024), \
+             patch.object(tb, "_send_video_file", return_value=None), \
+             patch("publisher.tiktok_manual.export_for_manual_upload",
+                   return_value=None), \
+             patch.object(tb, "_send_single_text", return_value=False):
+            self.assertFalse(tb.send_tiktok_manual(42))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #107.

## Root cause (đã xác minh trên code + stack sample trong issue)

1. **Bot treo vĩnh viễn ở `sock_connect`**: `_get_updates` có `urlopen(timeout=35)`, nhưng CPython đặt deadline theo đồng hồ **monotonic** (`mach_absolute_time` trên macOS **ngừng chạy khi máy ngủ**). Mac ngủ giữa lúc đang connect → deadline không bao giờ tới → kẹt trong `poll` mãi mãi. PID còn sống (CPU 0%) nên `KeepAlive` của launchd không cứu — nó chỉ restart process đã chết.
2. **Log 3.4GB**: `run_module.sh` chỉ `exec >>` append, không có rotation.
3. **`exit -15` + 409**: bot không có SIGTERM handler — chết không nhả PID lock, không thoát gọn.

## Fix 3 lớp

- **Watchdog thread** trong `run_bot` (`notifier/telegram_bot.py`): đo pha vòng lặp (`poll`/`handle`) bằng **wall clock** (`time.time` vẫn chạy khi máy ngủ). Pha vượt trần (`BOT_WATCHDOG_POLL_TIMEOUT`=180s / `BOT_WATCHDOG_HANDLE_TIMEOUT`=1800s, `0`=tắt) → `os._exit(70)` để launchd restart sạch (offset getUpdates đã persist nên không mất update). Dùng exit **70** (EX_SOFTWARE), cố ý tránh 78 (EX_CONFIG) vì launchd khoá job exit 78 tới khi reload. Trần `handle` rộng riêng vì approve → upload hợp lệ có thể mất vài phút. Hệ quả phụ có chủ đích: Mac ngủ dài giữa lúc poll → watchdog restart bot ngay khi dậy — đúng trạng thái sạch ta muốn sau sleep.
- **SIGTERM handler**: raise `SystemExit` → unwind (signal làm syscall kẹt trả EINTR nên unstick được cả connect đang treo), `finally` nhả PID lock. Không gửi Telegram khi SIGTERM (mạng có thể đã down, launchd chỉ chờ vài giây trước SIGKILL). Timeout transient của getUpdates hạ ERROR→WARNING (1.343 dòng rác log).
- **Log rotation trong `run_module.sh`**: lúc spawn, file vượt `LOG_MAX_BYTES` (mặc định 50MB) → `tail -c` giữ **đuôi mới nhất** sang `<file>.1` + làm rỗng file chính. File 3.4GB hiện tại **tự co về trần ở lần restart kế tiếp — không cần dọn tay**. `LOG_DIR` env-overridable để test được.

## Kèm theo (yêu cầu chủ kênh)

`TELEGRAM_TIKTOK_CHAT_ID` giờ nhận **nhiều chat id** cách nhau dấu phẩy (`"123,456"`) để gửi video TikTok cho nhiều người cùng lúc:
- Mỗi người nhận trọn bộ narrative + video; một người lỗi không chặn người khác (trả True nếu ≥1 người nhận được).
- **Performance**: người nhận thứ 2+ tái dùng `file_id` Telegram của lần upload đầu — gửi gần như tức thì thay vì re-upload ~50MB cho từng người; `file_id` lỗi thì tự rơi về upload thường.
- Export queue tay (file >50MB) chạy đúng 1 lần/lượt.
- Docs trong `.env.example`: người nhận DM phải bấm Start với bot trước (giới hạn Telegram), hoặc dùng id group chung.

## Tests

- `tests/test_bot_watchdog.py` (mới): verdict theo pha/trần, watchdog kill với exit 70, SIGTERM nhả lock.
- `tests/test_run_module_rotation.py` (mới): rotate giữ đuôi + cap size, file nhỏ không đụng, lần chạy đầu không vỡ.
- `tests/test_tiktok_telegram.py`: 9 test mới cho multi-recipient + tái dùng file_id.
- Toàn bộ suite: 986 tests, chỉ 5 error do sandbox thiếu package `anthropic` (pre-existing, không liên quan).

## Sau khi merge

```bash
cd ~/ContentCreator && git pull
cd content-pipeline/launchd && ./install.sh reload com.ai5phut.bot
```
(reload là bắt buộc để gỡ PID 44658 đang kẹt + nạp code mới; log 3.4GB sẽ tự co về 50MB ngay lần spawn này.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkaR2Ec7a1RqGNV32g7nrK