### PR TITLE
Cảnh báo token TRƯỚC khi hết hạn + không mất video khi token chết (issue #109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,7 +601,9 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   retry). `storage.scheduled_posts.requeue` từ chối post đã có
   `platform_video_id` như chốt chặn cuối, độc lập với phán đoán của caller;
   thiếu migration 009 → suy giảm êm về `mark_failed` (không sập cả tick). Phục
-  hồi tay: `python -m scheduler.post_scheduler requeue <post_id>`.
+  hồi tay: `python -m scheduler.post_scheduler requeue <post_id>` — CHỈ nhận post
+  `failed`; post kẹt `'uploading'` bị từ chối (có thể đã lên sóng mà chưa kịp ghi
+  `platform_video_id`), kiểm tra kênh xong mới `--force` (review Codex PR #110).
 - **TikTok = gửi Telegram (kênh "Bé MC") + upload tay:** thay cho auto-upload
   API. `telegram_bot.send_tiktok_manual(video_id)` gửi **NARRATIVE
   (`script_text` — chính narration đọc trong video) TRƯỚC, rồi FILE GỐC** (giữ
@@ -699,7 +701,10 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   `YOUTUBE_TOKEN_WARN_BEFORE_HOURS` (24) giờ là tới hạn `YOUTUBE_TOKEN_TTL_DAYS`
   (7; **đặt 0 sau khi publish app "In production"** → tắt hẳn) thì alert kèm
   lệnh cấp lại, tối đa 1 tin/ngày/token (3 lần chạy/ngày không thành 3 tin; cấp
-  token mới thì được cảnh báo lại ngay, không đợi sang ngày). `TokenCheckResult`
+  token mới thì được cảnh báo lại ngay, không đợi sang ngày). Mốc dedupe chỉ ghi
+  **sau khi gửi THÀNH CÔNG** (`send_alert` trả False khi Telegram lỗi/chưa cấu
+  hình): cảnh báo này chỉ có 1-2 cơ hội trước khi token chết, nên một lần 08:00
+  hỏng không được nuốt luôn lần 11:30 (review Codex PR #110). `TokenCheckResult`
   mang `warning` TÁCH khỏi `code` có chủ đích — "sắp hết hạn" là lời khuyên, token
   vẫn dùng được, nên `healthy` giữ nguyên nghĩa cho mọi caller cũ. Lần chạy
   **11:30** đặt ngay trước slot đăng 12:00 để token chết trong ngày vẫn còn ~30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,6 +587,21 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   không bao giờ tự retry** — video có thể ĐÃ lên platform trước khi crash, chỉ
   alert Telegram để xử lý tay (chống upload trùng, rủi ro §5 của doc). Nhánh
   `_dispatch` cho TikTok (nếu còn post cũ) gửi Bé MC thay vì auto-upload.
+  **Ngoại lệ DUY NHẤT của "không tự retry" — lỗi token (issue #109):**
+  `RefreshError`/`invalid_grant` xảy ra trong `_get_authenticated_service`, tức
+  TRƯỚC khi `videos.insert` gửi byte đầu tiên, nên không thể tạo video trùng →
+  `_retry_after_auth_error` **requeue** post (cột `attempts`, migration 009) sau
+  `POST_AUTH_RETRY_DELAY_MINUTES` (60) phút, tối đa `POST_AUTH_RETRY_MAX` (6)
+  lần: cấp lại token xong là video tự lên sóng, không thao tác gì. Alert chỉ
+  gửi lần ĐẦU (các tick sau cùng một sự cố) + lần CUỐI khi hết lượt, và nội
+  dung là "token chết + lệnh `--force-reauth`" (dùng chung
+  `token_health.reauth_command` — một nguồn hướng dẫn duy nhất) chứ không phải
+  "❌ Upload thất bại" chung chung như trước. Phân loại lỗi uỷ hết cho
+  `token_health.is_auth_error` (lỗi mạng/ffmpeg vẫn `mark_failed` như cũ, không
+  retry). `storage.scheduled_posts.requeue` từ chối post đã có
+  `platform_video_id` như chốt chặn cuối, độc lập với phán đoán của caller;
+  thiếu migration 009 → suy giảm êm về `mark_failed` (không sập cả tick). Phục
+  hồi tay: `python -m scheduler.post_scheduler requeue <post_id>`.
 - **TikTok = gửi Telegram (kênh "Bé MC") + upload tay:** thay cho auto-upload
   API. `telegram_bot.send_tiktok_manual(video_id)` gửi **NARRATIVE
   (`script_text` — chính narration đọc trong video) TRƯỚC, rồi FILE GỐC** (giữ
@@ -643,8 +658,9 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   scheduler, quota hôm nay, last_success collectors. Mỗi section bọc lỗi
   riêng — DB thiếu bảng không làm sập cả payload.
 - Migration 006 (`scheduled_posts`, `quota_usage`, cột
-  `videos.story_id/thumbnail_path/review_note`) — chạy
-  `python -m storage.migrate up` sau khi pull.
+  `videos.story_id/thumbnail_path/review_note`) và 009
+  (`scheduled_posts.attempts` — đếm lượt retry khi token chết, issue #109) —
+  chạy `python -m storage.migrate up` sau khi pull.
 - TikTok Content Posting API uploader (`publisher/tiktok_uploader.py`) có từ
   trước, giữ nguyên — phần "3-step upload" của doc đã được cover; approval
   app TikTok là task external (2-4 tuần), pipeline không block nhờ queue tay.
@@ -668,8 +684,27 @@ cũ/`needs_review` — không còn chặn video mới, xem `review_bot.py` bên 
   chính "monitor không tới được Google" cũng lộ ra — đếm bền vững qua
   `pipeline_state`, DB chưa migrate 008 → degrade êm). Best-effort, không raise
   (như `collector_health`). Chạy độc lập `python -m publisher.token_health`
-  (08:00, `launchd/com.ai5phut.token-health.plist`) VÀ ké best-effort trong
-  `main.run_pipeline` (defense-in-depth như `launchd_status`). **Khi token bị
+  (**08:00 + 11:30**, `launchd/com.ai5phut.token-health.plist`) VÀ ké best-effort
+  trong `main.run_pipeline` (defense-in-depth như `launchd_status`).
+  **Cảnh báo TRƯỚC khi hết hạn (issue #109) — khe mù check-rồi-mới-dùng:** ngày
+  28/07 monitor báo `Token OK` cho ai_youtube lúc 07:00, upload 12:05 chết
+  `invalid_grant` (video 159). Monitor KHÔNG sai (mô tả issue hiểu nhầm rằng nó
+  chỉ đọc access token — thực tế `_probe_refresh` luôn gọi refresh thật từ #94);
+  root cause là OAuth app còn ở chế độ **Testing** nên refresh token sống đúng
+  **7 ngày** và chết vào ĐÚNG GIỜ được cấp — rơi vào khe 08:00→12:00 thì probe
+  sớm cỡ nào cũng vô ích (cùng root cause với #94, tái diễn trên kênh khác). Nên
+  thay vì probe dày hơn, monitor theo dõi **TUỔI** refresh_token: mốc "lần đầu
+  thấy token này" lưu ở `pipeline_state` dưới dạng **hash** (`_fingerprint`,
+  không bao giờ lưu token), seed bằng mtime file token; còn dưới
+  `YOUTUBE_TOKEN_WARN_BEFORE_HOURS` (24) giờ là tới hạn `YOUTUBE_TOKEN_TTL_DAYS`
+  (7; **đặt 0 sau khi publish app "In production"** → tắt hẳn) thì alert kèm
+  lệnh cấp lại, tối đa 1 tin/ngày/token (3 lần chạy/ngày không thành 3 tin; cấp
+  token mới thì được cảnh báo lại ngay, không đợi sang ngày). `TokenCheckResult`
+  mang `warning` TÁCH khỏi `code` có chủ đích — "sắp hết hạn" là lời khuyên, token
+  vẫn dùng được, nên `healthy` giữ nguyên nghĩa cho mọi caller cũ. Lần chạy
+  **11:30** đặt ngay trước slot đăng 12:00 để token chết trong ngày vẫn còn ~30
+  phút cấp lại. Module này cũng là nguồn duy nhất của `is_auth_error` /
+  `reauth_command` mà scheduler dùng (xem Phase 5). **Khi token bị
   thu hồi phải cấp lại thủ công:** `cd content-pipeline && python
   publisher/youtube_uploader.py --token-file <file> --force-reauth` (xem
   `docs/current/oauth-setup.md` §1.5) — `--force-reauth` bỏ token cũ đã thu hồi

--- a/content-pipeline/config.py
+++ b/content-pipeline/config.py
@@ -212,6 +212,28 @@ TOKEN_HEALTH_TIMEOUT = int(os.getenv("TOKEN_HEALTH_TIMEOUT", "15"))
 TOKEN_HEALTH_TRANSIENT_ALERT_AFTER = int(
     os.getenv("TOKEN_HEALTH_TRANSIENT_ALERT_AFTER", "3")
 )
+# --- Cảnh báo TRƯỚC khi refresh token hết hạn theo lịch (issue #109) ---
+# Probe refresh chỉ trả lời "token còn sống LÚC NÀY". Với OAuth consent screen ở
+# chế độ "Testing", Google cho refresh token sống ĐÚNG 7 ngày kể từ lúc mint
+# (docs/current/oauth-setup.md §1.5) — token chết vào đúng giờ nó được cấp, nên
+# probe 08:00 báo OK rồi 12:00 upload chết là chuyện BÌNH THƯỜNG, không thể sửa
+# bằng cách probe sớm hơn. Cách duy nhất đóng khe mù là cảnh báo theo TUỔI token.
+# TTL (ngày) của refresh token. 7 = chế độ Testing. Đưa app sang "In production"
+# rồi thì đặt 0 để TẮT cảnh báo theo tuổi (token khi đó không hết hạn theo lịch).
+YOUTUBE_TOKEN_TTL_DAYS = float(os.getenv("YOUTUBE_TOKEN_TTL_DAYS", "7"))
+# Cảnh báo trước thời điểm chết bao nhiêu GIỜ (cần đủ để người kịp cấp lại
+# trước slot đăng 12:00 — 24h = luôn có ít nhất 1 lần cron 08:00 nhắc trước).
+YOUTUBE_TOKEN_WARN_BEFORE_HOURS = float(
+    os.getenv("YOUTUBE_TOKEN_WARN_BEFORE_HOURS", "24")
+)
+
+# --- Retry upload khi token chết giữa chừng (issue #109) ---
+# RefreshError xảy ra TRƯỚC khi gửi byte nào lên YouTube, nên retry post đó là
+# an toàn tuyệt đối (khác crash giữa upload — có thể đã lên sóng, không bao giờ
+# tự retry). Requeue có giới hạn để video vẫn lên sóng trong ngày nếu người kịp
+# cấp lại token, mà không nã alert mỗi tick 5 phút.
+POST_AUTH_RETRY_MAX = int(os.getenv("POST_AUTH_RETRY_MAX", "6"))
+POST_AUTH_RETRY_DELAY_MINUTES = int(os.getenv("POST_AUTH_RETRY_DELAY_MINUTES", "60"))
 
 # --- Media asset API key health check (follow-up #94) ---
 # Giám sát API key TĨNH của nhà cung cấp asset video: Pexels (nền b-roll, dùng

--- a/content-pipeline/launchd/com.ai5phut.token-health.plist
+++ b/content-pipeline/launchd/com.ai5phut.token-health.plist
@@ -19,14 +19,28 @@
     <!-- Issue #94: kiểm tra OAuth token của MỌI kênh YouTube (channels.py) mỗi
          sáng 08:00 và alert Telegram nếu token thu hồi/hết hạn. Thay cron cũ chỉ
          soi 1 file token cứng (bỏ sót drama_youtube) và hay timeout 30s bị kill —
-         module tự bound thời gian bằng socket timeout nên không cần timeout cứng. -->
+         module tự bound thời gian bằng socket timeout nên không cần timeout cứng.
+
+         Issue #109: thêm lần chạy 11:30 — ngay TRƯỚC slot đăng "mon-sat 12:00"
+         của post_scheduler. Token chết trong khe 08:00→12:00 (rất thường gặp khi
+         OAuth app còn ở chế độ Testing: refresh token sống đúng 7 ngày và chết
+         vào đúng giờ được cấp) nay được phát hiện khi vẫn còn ~30 phút để cấp
+         lại, thay vì phát hiện bằng chính cú upload thất bại. -->
     <key>StartCalendarInterval</key>
-    <dict>
-        <key>Hour</key>
-        <integer>8</integer>
-        <key>Minute</key>
-        <integer>0</integer>
-    </dict>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>8</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>11</integer>
+            <key>Minute</key>
+            <integer>30</integer>
+        </dict>
+    </array>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/content-pipeline/publisher/token_health.py
+++ b/content-pipeline/publisher/token_health.py
@@ -31,17 +31,32 @@ Thiết kế:
 - KHÔNG log giá trị token/secret/refresh_token — chỉ log tên kênh + trạng thái +
   thông báo lỗi text của Google (an toàn).
 
+Issue #109 — cảnh báo TRƯỚC khi token chết theo lịch:
+Probe chỉ trả lời "token còn sống LÚC NÀY". Với OAuth consent screen ở chế độ
+"Testing", Google cho refresh token sống đúng 7 ngày kể từ lúc mint, và nó chết
+vào ĐÚNG GIỜ được cấp — nên probe 08:00 báo OK rồi upload 12:00 chết vì
+invalid_grant là hành vi bình thường, KHÔNG phải probe sai (đây là hiểu lầm
+trong mô tả issue #109: monitor vẫn luôn refresh thật, xem `_probe_refresh`).
+Khe mù check-rồi-mới-dùng không thể đóng bằng cách probe sớm hơn, nên ta theo
+dõi TUỔI của refresh_token và cảnh báo trước hạn `YOUTUBE_TOKEN_WARN_BEFORE_HOURS`.
+Tuổi đo từ lần ĐẦU monitor nhìn thấy chính refresh_token đó (seed bằng mtime của
+file token), lưu ở pipeline_state dưới dạng **hash** — không bao giờ lưu token.
+Đổi app sang "In production" → đặt YOUTUBE_TOKEN_TTL_DAYS=0 để tắt cảnh báo này.
+
 Chạy độc lập:  python -m publisher.token_health
-launchd:       launchd/com.ai5phut.token-health.plist (08:00 hằng ngày)
+launchd:       launchd/com.ai5phut.token-health.plist (08:00 + 11:30 hằng ngày —
+               lần 11:30 đặt ngay trước slot đăng 12:00, xem issue #109)
 Defense-in-depth: main.run_pipeline gọi best-effort như launchd_status.
 """
 
+import hashlib
 import json
 import logging
 import os
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta
 
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -70,16 +85,24 @@ TRANSIENT = "transient"             # timeout/mạng/5xx/429 — thử lại l�
 
 
 class TokenCheckResult:
-    """Kết quả kiểm tra 1 kênh."""
+    """Kết quả kiểm tra 1 kênh.
 
-    __slots__ = ("channel_key", "channel_name", "token_file", "code", "detail")
+    `warning` tách khỏi `code` có chủ đích (issue #109): "token SẮP hết hạn" là
+    lời khuyên chứ không phải trạng thái hỏng — token vẫn dùng được lúc này, nên
+    `healthy` vẫn True và mọi caller cũ (webui/health, __main__) không đổi nghĩa.
+    """
 
-    def __init__(self, channel_key, channel_name, token_file, code, detail=""):
+    __slots__ = ("channel_key", "channel_name", "token_file", "code", "detail",
+                 "warning")
+
+    def __init__(self, channel_key, channel_name, token_file, code, detail="",
+                 warning=None):
         self.channel_key = channel_key
         self.channel_name = channel_name
         self.token_file = token_file
         self.code = code
         self.detail = detail
+        self.warning = warning
 
     @property
     def healthy(self) -> bool:
@@ -87,7 +110,8 @@ class TokenCheckResult:
 
     def __repr__(self) -> str:
         return (f"TokenCheckResult({self.channel_key}, {self.code}"
-                + (f", {self.detail!r}" if self.detail else "") + ")")
+                + (f", {self.detail!r}" if self.detail else "")
+                + (f", warning={self.warning!r}" if self.warning else "") + ")")
 
 
 def _read_token_file(path: str):
@@ -176,17 +200,126 @@ def _classify_http_error(e: "urllib.error.HTTPError"):
     return MISCONFIG, detail
 
 
-def _check_token_file(token_file: str, timeout: int) -> tuple[str, str]:
-    """Kiểm tra 1 file token (đọc + probe refresh + scope) → (code, detail). Thuần."""
+# --- Tuổi refresh_token → cảnh báo trước khi hết hạn theo lịch (issue #109) ---
+
+_MINTED_PREFIX = "token_health_minted:"          # key → "<fingerprint>|<iso>"
+_EXPIRY_WARNED_PREFIX = "token_health_warned:"   # key → "<fingerprint>|<YYYY-MM-DD>"
+
+
+def _fingerprint(refresh_token: str) -> str:
+    """Định danh KHÔNG thể đảo ngược của 1 refresh_token (không bao giờ lưu token).
+
+    Đủ để nhận ra "vẫn token cũ" hay "đã cấp lại token mới" — chỉ cần vậy để đo
+    tuổi; 16 hex đầu của sha256 là quá đủ cho ~vài token, mà không giữ bí mật.
+    """
+    return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()[:16]
+
+
+def _first_seen(channel_key: str, fingerprint: str, token_file: str,
+                now: datetime) -> datetime | None:
+    """Lần đầu monitor thấy refresh_token này (mốc ước lượng thời điểm cấp).
+
+    Token mới (fingerprint đổi = vừa cấp lại) thì mốc được ghi lại từ đầu. Lần
+    quan sát ĐẦU TIÊN sau khi deploy chưa có state → seed bằng mtime file token
+    (mtime ≥ lúc mint vì uploader ghi đè file mỗi lần refresh access token, nên
+    tuổi ước lượng chỉ có thể THẤP hơn thật → cảnh báo có thể muộn một vòng
+    token, không bao giờ báo động giả). Không đọc/ghi được state → None (tắt êm).
+    """
+    key = _MINTED_PREFIX + channel_key
+    try:
+        from storage.pipeline_state import get_state, set_state
+    except Exception as e:
+        logger.warning("Không đọc được pipeline_state cho tuổi token: %s", e)
+        return None
+
+    try:
+        raw = get_state(key)
+        if raw:
+            saved_fp, _, saved_ts = raw.partition("|")
+            if saved_fp == fingerprint:
+                try:
+                    return datetime.fromisoformat(saved_ts)
+                except ValueError:
+                    pass  # state hỏng → ghi lại (self-heal, như get_int)
+
+        seed = now
+        try:
+            mtime = datetime.fromtimestamp(os.path.getmtime(token_file))
+            seed = min(seed, mtime)
+        except OSError:
+            pass
+        set_state(key, f"{fingerprint}|{seed.isoformat(timespec='seconds')}")
+        return seed
+    except Exception as e:
+        logger.warning("Không theo dõi được tuổi token %s: %s", channel_key, e)
+        return None
+
+
+def _expiry_warning(channel_key: str, token: dict, token_file: str,
+                    now: datetime | None = None) -> str | None:
+    """Cảnh báo "token sắp hết hạn theo lịch", hoặc None nếu chưa tới ngưỡng."""
+    ttl_days = config.YOUTUBE_TOKEN_TTL_DAYS
+    if ttl_days <= 0:  # app đã "In production" → token không hết hạn theo lịch
+        return None
+    refresh_token = token.get("refresh_token")
+    if not refresh_token:
+        return None  # đã có mã NO_REFRESH_TOKEN lo việc này
+
+    now = now or datetime.now()
+    seen = _first_seen(channel_key, _fingerprint(refresh_token), token_file, now)
+    if seen is None:
+        return None
+
+    expires_at = seen + timedelta(days=ttl_days)
+    remaining_h = (expires_at - now).total_seconds() / 3600
+    if remaining_h > config.YOUTUBE_TOKEN_WARN_BEFORE_HOURS:
+        return None
+    if remaining_h <= 0:
+        return (f"token đã quá hạn ước lượng {ttl_days:g} ngày "
+                f"(cấp khoảng {seen:%d/%m %H:%M}) — có thể chết bất cứ lúc nào")
+    return (f"còn ~{remaining_h:.0f} giờ là hết hạn theo lịch "
+            f"({expires_at:%d/%m %H:%M}, TTL {ttl_days:g} ngày kể từ "
+            f"{seen:%d/%m %H:%M})")
+
+
+def _should_send_expiry_warning(channel_key: str,
+                                now: datetime | None = None) -> bool:
+    """True tối đa 1 lần/ngày cho mỗi refresh_token.
+
+    Cảnh báo vẫn lặp lại HẰNG NGÀY tới khi cấp lại token, nhưng 3 lần chạy/ngày
+    (07:00 ké pipeline, 08:00 + 11:30 cron) không thành 3 tin nhắn. Mốc dedupe
+    lấy từ chính state tuổi token đã ghi (`<fingerprint>|<mint>`) nên cấp token
+    MỚI là được cảnh báo lại ngay, không phải đợi sang ngày; đồng thời không
+    phải đọc lại file token và không có bí mật nào đi vào state.
+    """
+    now = now or datetime.now()
+    try:
+        from storage.pipeline_state import get_state, set_state
+        stamp = f"{get_state(_MINTED_PREFIX + channel_key) or '?'}|{now:%Y-%m-%d}"
+        if get_state(_EXPIRY_WARNED_PREFIX + channel_key) == stamp:
+            return False
+        set_state(_EXPIRY_WARNED_PREFIX + channel_key, stamp)
+    except Exception as e:
+        logger.warning("Không ghi được mốc cảnh báo hết hạn (%s): %s", channel_key, e)
+    return True
+
+
+def _check_token_file(token_file: str, timeout: int) -> tuple[str, str, dict | None]:
+    """Kiểm tra 1 file token (đọc + probe refresh + scope) → (code, detail, data).
+
+    Thuần (không alert). Trả kèm nội dung file token đã đọc để tầng trên tính
+    cảnh báo tuổi token (issue #109) mà không phải đọc file lần hai — một nguồn
+    dữ liệu duy nhất cho cả probe lẫn cảnh báo.
+    """
     data, read_code = _read_token_file(token_file)
     if read_code is not None:
         detail = (f"không tìm thấy {token_file}" if read_code == MISSING
                   else f"file token hỏng: {token_file}")
-        return read_code, detail
+        return read_code, detail, None
 
     code, detail = _probe_refresh(data, timeout)
     if code != OK:
-        return code, detail
+        return code, detail, data
 
     # Refresh được nhưng thiếu scope uploader cần (#95 review, line 143): token
     # cũ predate youtube.force-ssl vẫn refresh OK, nhưng youtube_uploader loại bỏ
@@ -195,17 +328,21 @@ def _check_token_file(token_file: str, timeout: int) -> tuple[str, str]:
     if not _has_required_scopes(data.get("scopes")):
         have = data.get("scopes") or []
         missing = [s for s in SCOPES if s not in set(have)]
-        return MISSING_SCOPES, f"thiếu scope: {', '.join(missing) or SCOPES}"
-    return OK, ""
+        return MISSING_SCOPES, f"thiếu scope: {', '.join(missing) or SCOPES}", data
+    return OK, "", data
 
 
 def check_channel(channel_key: str, timeout: int | None = None) -> TokenCheckResult:
-    """Kiểm tra token của 1 kênh YouTube. Không alert, không ghi state (thuần)."""
+    """Kiểm tra token của 1 kênh YouTube. Không alert (nhưng có ghi mốc tuổi
+    token vào pipeline_state để cảnh báo trước hạn — issue #109)."""
     timeout = config.TOKEN_HEALTH_TIMEOUT if timeout is None else timeout
     channel = channels.get_channel(channel_key)
     token_file = resolve_token_file(channel_key)
-    code, detail = _check_token_file(token_file, timeout)
-    return TokenCheckResult(channel_key, channel["name"], token_file, code, detail)
+    code, detail, data = _check_token_file(token_file, timeout)
+    warning = (_expiry_warning(channel_key, data, token_file)
+               if code == OK and data else None)
+    return TokenCheckResult(channel_key, channel["name"], token_file, code, detail,
+                            warning)
 
 
 def _youtube_channel_keys() -> list[str]:
@@ -225,6 +362,9 @@ def check_all(channel_keys: list[str] | None = None,
     thay vì im lặng để token AI hợp lệ khiến cả drama "xanh" (chính blind spot
     monitor này sinh ra để đóng). Kênh có path RIÊNG được probe bình thường
     (cache theo path — path riêng nên không gọi mạng trùng).
+
+    Không alert, nhưng CÓ ghi mốc tuổi token vào pipeline_state (issue #109) để
+    lần chạy sau biết token đã sống bao lâu.
     """
     timeout = config.TOKEN_HEALTH_TIMEOUT if timeout is None else timeout
     keys = channel_keys if channel_keys is not None else _youtube_channel_keys()
@@ -236,11 +376,13 @@ def check_all(channel_keys: list[str] | None = None,
         path_owners.setdefault(path, []).append(key)
 
     results: list[TokenCheckResult] = []
-    probe_cache: dict[str, tuple[str, str]] = {}  # token_file -> (code, detail)
+    # token_file -> (code, detail, token data) — probe 1 lần cho mỗi path.
+    probe_cache: dict[str, tuple[str, str, dict | None]] = {}
 
     for key, token_file in resolved:
         channel = channels.get_channel(key)
         sharing = [k for k in path_owners[token_file] if k != key]
+        warning = None
         if sharing:
             code, detail = (UNCONFIGURED,
                             f"dùng chung file token {token_file} với "
@@ -248,9 +390,14 @@ def check_all(channel_keys: list[str] | None = None,
         else:
             if token_file not in probe_cache:
                 probe_cache[token_file] = _check_token_file(token_file, timeout)
-            code, detail = probe_cache[token_file]
+            code, detail, data = probe_cache[token_file]
+            # Cảnh báo tuổi tính THEO KÊNH (mốc lưu theo channel_key) dù dữ liệu
+            # token dùng chung cache theo path — issue #109.
+            if code == OK and data:
+                warning = _expiry_warning(key, data, token_file)
 
-        results.append(TokenCheckResult(key, channel["name"], token_file, code, detail))
+        results.append(TokenCheckResult(key, channel["name"], token_file, code,
+                                        detail, warning))
     return results
 
 
@@ -275,14 +422,61 @@ def _set_transient_count(channel_key: str, value: int) -> None:
         logger.warning("Không ghi được transient counter (%s): %s", channel_key, e)
 
 
+def reauth_command(token_file: str) -> str:
+    """Câu lệnh cấp lại token cho 1 file token — MỘT nguồn duy nhất.
+
+    --force-reauth: bỏ token cũ (thu hồi/thiếu scope) rồi chạy flow OAuth mới —
+    cần thiết vì rerun thường sẽ refresh() token cũ và raise invalid_grant TRƯỚC
+    khi mở browser (#95 review, line 251). File chưa tồn tại thì flag này vô hại.
+
+    Dùng chung với scheduler (issue #109) để alert lúc upload chết và alert của
+    monitor hướng dẫn y hệt nhau — người vận hành không phải nhớ 2 câu lệnh.
+    """
+    return (f"Cấp lại: cd content-pipeline && "
+            f"python publisher/youtube_uploader.py --token-file {token_file} "
+            f"--force-reauth")
+
+
+def is_auth_error(exc: BaseException) -> bool:
+    """True nếu exception là lỗi TOKEN OAuth (không phải lỗi mạng/upload).
+
+    Dùng ở scheduler để phân biệt "chưa gửi byte nào lên YouTube, retry an toàn"
+    với mọi lỗi khác. google-auth raise RefreshError khi token endpoint từ chối
+    refresh_token (invalid_grant = thu hồi/hết hạn — đúng ca issue #109); lỗi
+    mạng thuần là TransportError nên KHÔNG lọt vào đây.
+
+    Không import google-auth ở top-level: module này chạy được cả khi thiếu
+    dependency (cùng lý do youtube_uploader import lười).
+    """
+    try:
+        from google.auth.exceptions import RefreshError
+        if isinstance(exc, RefreshError):
+            return True
+    except ImportError:
+        pass
+    # Fallback theo nội dung: lỗi có thể đã bị bọc lại thành RuntimeError/chuỗi
+    # (vd đi qua ranh giới process hay thư viện khác).
+    text = f"{type(exc).__name__}: {exc}".lower()
+    return "invalid_grant" in text or "refresherror" in text
+
+
+def auth_failure_alert(channel_key: str, detail: str, extra: str = "") -> str:
+    """Tin nhắn Telegram khi upload chết vì token (scheduler gọi) — issue #109."""
+    try:
+        name = channels.get_channel(channel_key)["name"]
+    except ValueError:
+        name = channel_key
+    token_file = resolve_token_file(channel_key)
+    msg = (f"🔴 Token YouTube kênh '{name}' ({channel_key}) chết giữa chừng — "
+           f"upload thất bại (invalid_grant).\n{detail}\n"
+           f"{reauth_command(token_file)}")
+    return f"{msg}\n{extra}" if extra else msg
+
+
 def _alert_message(res: TokenCheckResult) -> str | None:
     """Tin nhắn Telegram cho 1 kết quả (None = không alert)."""
     name, key, path = res.channel_name, res.channel_key, res.token_file
-    # --force-reauth: bỏ token cũ (thu hồi/thiếu scope) rồi chạy flow OAuth mới —
-    # cần thiết vì rerun thường sẽ refresh() token cũ và raise invalid_grant TRƯỚC
-    # khi mở browser (#95 review, line 251). File chưa tồn tại thì flag này vô hại.
-    reauth = (f"Cấp lại: cd content-pipeline && "
-              f"python publisher/youtube_uploader.py --token-file {path} --force-reauth")
+    reauth = reauth_command(path)
 
     if res.code == REVOKED:
         return (f"🔴 Token YouTube kênh '{name}' ({key}) đã bị THU HỒI/HẾT HẠN "
@@ -334,8 +528,21 @@ def check_and_alert(channel_keys: list[str] | None = None,
 
     for res in results:
         if res.code == OK:
-            logger.info("Token OK: %s (%s)", res.channel_name, res.channel_key)
+            logger.info("Token OK: %s (%s)%s", res.channel_name, res.channel_key,
+                        f" — ⚠️ {res.warning}" if res.warning else "")
             _set_transient_count(res.channel_key, 0)
+            if res.warning:
+                # Token còn sống nhưng sắp hết hạn THEO LỊCH: đây là lớp duy
+                # nhất đóng được khe mù "probe 08:00 OK → upload 12:00 chết"
+                # (issue #109). Cấp lại trước slot đăng là xong, không mất video.
+                if _should_send_expiry_warning(res.channel_key):
+                    _send(f"⚠️ Token YouTube '{res.channel_name}' "
+                          f"({res.channel_key}) {res.warning}. Cấp lại TRƯỚC giờ "
+                          f"đăng để video không kẹt.\n"
+                          f"{reauth_command(res.token_file)}\n"
+                          f"(Hết cảnh báo này vĩnh viễn: đưa OAuth app sang 'In "
+                          f"production' rồi đặt YOUTUBE_TOKEN_TTL_DAYS=0 — xem "
+                          f"docs/current/oauth-setup.md §1.5.)")
             continue
 
         if res.code == TRANSIENT:
@@ -368,8 +575,10 @@ if __name__ == "__main__":
     print(f"Checked {len(results)} YouTube token(s); "
           f"{len(results) - len(bad)} OK, {len(bad)} có vấn đề.")
     for r in results:
-        mark = "✅" if r.healthy else "❌"
+        mark = "⚠️" if (r.healthy and r.warning) else ("✅" if r.healthy else "❌")
         line = f"  {mark} {r.channel_key} ({r.channel_name}): {r.code}"
         if r.detail:
             line += f" — {r.detail}"
+        if r.warning:
+            line += f" — SẮP HẾT HẠN: {r.warning}"
         print(line)

--- a/content-pipeline/publisher/token_health.py
+++ b/content-pipeline/publisher/token_health.py
@@ -282,26 +282,50 @@ def _expiry_warning(channel_key: str, token: dict, token_file: str,
             f"{seen:%d/%m %H:%M})")
 
 
-def _should_send_expiry_warning(channel_key: str,
-                                now: datetime | None = None) -> bool:
-    """True tối đa 1 lần/ngày cho mỗi refresh_token.
+def _expiry_stamp(channel_key: str, now: datetime) -> str:
+    """Mốc dedupe cảnh báo: `<fingerprint>|<mint>|<ngày>`.
 
-    Cảnh báo vẫn lặp lại HẰNG NGÀY tới khi cấp lại token, nhưng 3 lần chạy/ngày
-    (07:00 ké pipeline, 08:00 + 11:30 cron) không thành 3 tin nhắn. Mốc dedupe
-    lấy từ chính state tuổi token đã ghi (`<fingerprint>|<mint>`) nên cấp token
-    MỚI là được cảnh báo lại ngay, không phải đợi sang ngày; đồng thời không
-    phải đọc lại file token và không có bí mật nào đi vào state.
+    Lấy từ chính state tuổi token đã ghi nên cấp token MỚI là được cảnh báo lại
+    ngay, không phải đợi sang ngày; đồng thời không phải đọc lại file token và
+    không có bí mật nào đi vào state.
+    """
+    from storage.pipeline_state import get_state
+    return f"{get_state(_MINTED_PREFIX + channel_key) or '?'}|{now:%Y-%m-%d}"
+
+
+def _expiry_warning_pending(channel_key: str,
+                            now: datetime | None = None) -> bool:
+    """True nếu HÔM NAY chưa gửi được cảnh báo hết hạn cho token này.
+
+    Cảnh báo lặp lại HẰNG NGÀY tới khi cấp lại token, nhưng 3 lần chạy/ngày
+    (07:00 ké pipeline, 08:00 + 11:30 cron) không thành 3 tin nhắn.
+
+    Tách khỏi `_record_expiry_warning` để chỉ ghi mốc SAU KHI gửi thành công
+    (review Codex PR #110): `send_alert` trả False khi Telegram lỗi/chưa cấu
+    hình, mà cảnh báo này thường chỉ có 1-2 cơ hội trước khi token chết — ghi
+    mốc trước khi gửi sẽ khiến một lần 08:00 hỏng nuốt luôn lần 11:30, đúng cái
+    tin nhắn cuối cùng còn kịp cứu video.
     """
     now = now or datetime.now()
     try:
-        from storage.pipeline_state import get_state, set_state
-        stamp = f"{get_state(_MINTED_PREFIX + channel_key) or '?'}|{now:%Y-%m-%d}"
-        if get_state(_EXPIRY_WARNED_PREFIX + channel_key) == stamp:
-            return False
-        set_state(_EXPIRY_WARNED_PREFIX + channel_key, stamp)
+        from storage.pipeline_state import get_state
+        return get_state(_EXPIRY_WARNED_PREFIX + channel_key) != _expiry_stamp(
+            channel_key, now)
+    except Exception as e:
+        # Không đọc được state → cứ gửi (thà nhắc thừa còn hơn im lặng để token
+        # chết), cùng tinh thần degrade êm của phần còn lại module này.
+        logger.warning("Không đọc được mốc cảnh báo hết hạn (%s): %s", channel_key, e)
+        return True
+
+
+def _record_expiry_warning(channel_key: str, now: datetime | None = None) -> None:
+    """Ghi mốc "đã gửi cảnh báo hôm nay" — chỉ gọi sau khi gửi THÀNH CÔNG."""
+    now = now or datetime.now()
+    try:
+        from storage.pipeline_state import set_state
+        set_state(_EXPIRY_WARNED_PREFIX + channel_key, _expiry_stamp(channel_key, now))
     except Exception as e:
         logger.warning("Không ghi được mốc cảnh báo hết hạn (%s): %s", channel_key, e)
-    return True
 
 
 def _check_token_file(token_file: str, timeout: int) -> tuple[str, str, dict | None]:
@@ -519,30 +543,43 @@ def check_and_alert(channel_keys: list[str] | None = None,
     results = check_all(channel_keys, timeout=timeout)
     threshold = config.TOKEN_HEALTH_TRANSIENT_ALERT_AFTER
 
-    def _send(text: str) -> None:
+    def _send(text: str) -> bool:
+        """Gửi Telegram; True nếu tin nhắn thực sự tới nơi.
+
+        `send_alert` trả False (không raise) khi thiếu credential hoặc API lỗi —
+        caller cần biết để không ghi mốc dedupe cho một tin chưa hề gửi được
+        (review Codex PR #110).
+        """
         try:
             from notifier.telegram_bot import send_alert
-            send_alert(text)
+            return bool(send_alert(text))
         except Exception as e:
             logger.warning("Token-health alert send failed (non-fatal): %s", e)
+            return False
 
     for res in results:
         if res.code == OK:
             logger.info("Token OK: %s (%s)%s", res.channel_name, res.channel_key,
                         f" — ⚠️ {res.warning}" if res.warning else "")
             _set_transient_count(res.channel_key, 0)
-            if res.warning:
+            if res.warning and _expiry_warning_pending(res.channel_key):
                 # Token còn sống nhưng sắp hết hạn THEO LỊCH: đây là lớp duy
                 # nhất đóng được khe mù "probe 08:00 OK → upload 12:00 chết"
                 # (issue #109). Cấp lại trước slot đăng là xong, không mất video.
-                if _should_send_expiry_warning(res.channel_key):
-                    _send(f"⚠️ Token YouTube '{res.channel_name}' "
-                          f"({res.channel_key}) {res.warning}. Cấp lại TRƯỚC giờ "
-                          f"đăng để video không kẹt.\n"
-                          f"{reauth_command(res.token_file)}\n"
-                          f"(Hết cảnh báo này vĩnh viễn: đưa OAuth app sang 'In "
-                          f"production' rồi đặt YOUTUBE_TOKEN_TTL_DAYS=0 — xem "
-                          f"docs/current/oauth-setup.md §1.5.)")
+                sent = _send(f"⚠️ Token YouTube '{res.channel_name}' "
+                             f"({res.channel_key}) {res.warning}. Cấp lại TRƯỚC "
+                             f"giờ đăng để video không kẹt.\n"
+                             f"{reauth_command(res.token_file)}\n"
+                             f"(Hết cảnh báo này vĩnh viễn: đưa OAuth app sang 'In "
+                             f"production' rồi đặt YOUTUBE_TOKEN_TTL_DAYS=0 — xem "
+                             f"docs/current/oauth-setup.md §1.5.)")
+                if sent:
+                    _record_expiry_warning(res.channel_key)
+                else:
+                    # Gửi hỏng → KHÔNG ghi mốc, để lần chạy kế tiếp trong ngày
+                    # (11:30) thử lại — đó có thể là tin nhắn cuối còn kịp.
+                    logger.warning("Chưa gửi được cảnh báo hết hạn cho %s — sẽ "
+                                   "thử lại lần chạy sau", res.channel_key)
             continue
 
         if res.code == TRANSIENT:

--- a/content-pipeline/scheduler/post_scheduler.py
+++ b/content-pipeline/scheduler/post_scheduler.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import config
 from channels import get_channel
 from storage import scheduled_posts
 from storage.database import get_video, update_video_status, update_video_publish_url
@@ -177,10 +178,15 @@ def schedule_video(video_id: int, channel_key: str,
 
 
 def run_tick(now: datetime | None = None) -> dict:
-    """Upload mọi post tới giờ. Returns {'uploaded': n, 'failed': n, 'stale': n}."""
+    """Upload mọi post tới giờ.
+
+    Returns {'uploaded': n, 'failed': n, 'stale': n, 'retried': n} — `retried` là
+    số post chết vì token OAuth và đã được xếp lại lịch (issue #109), KHÔNG tính
+    vào `failed` vì video vẫn còn cơ hội lên sóng.
+    """
     now = now or datetime.now()
     now_str = now.isoformat(sep=" ", timespec="seconds")
-    summary = {"uploaded": 0, "failed": 0, "stale": 0}
+    summary = {"uploaded": 0, "failed": 0, "stale": 0, "retried": 0}
 
     stale = scheduled_posts.get_stale_uploading(now=now_str.replace(" ", "T"))
     if stale:
@@ -204,13 +210,20 @@ def run_tick(now: datetime | None = None) -> dict:
     for post in scheduled_posts.get_due(now=now_str):
         if not scheduled_posts.claim(post["id"]):
             continue  # tick khác vừa nhận post này
+        auth_error = False
         try:
             result = _dispatch(post)
         except Exception as e:  # không để 1 post hỏng chặn các post còn lại
             logger.exception("Dispatch error for post %d", post["id"])
             result = (False, f"{type(e).__name__}: {e}", None)
+            auth_error = _is_auth_error(e)
 
         ok, url_or_error, platform_video_id = result
+        # `now` của tick (không phải wall clock) để giờ retry luôn nhất quán với
+        # khung thời gian mà run_tick đang chạy.
+        if not ok and auth_error and _retry_after_auth_error(post, url_or_error, now):
+            summary["retried"] += 1
+            continue
         if ok:
             scheduled_posts.mark_done(post["id"], platform_video_id=platform_video_id,
                                       url=url_or_error)
@@ -221,13 +234,157 @@ def run_tick(now: datetime | None = None) -> dict:
             summary["uploaded"] += 1
         else:
             scheduled_posts.mark_failed(post["id"], url_or_error or "unknown error")
-            _alert_safe(f"❌ Upload thất bại: video {post['video_id']} → "
-                        f"{post['channel_key']} (post {post['id']}):\n{url_or_error}")
+            msg = (f"❌ Upload thất bại: video {post['video_id']} → "
+                   f"{post['channel_key']} (post {post['id']}):\n{url_or_error}")
+            if auth_error:
+                # Hết lượt retry mà token vẫn chết → nhắc lại đúng cách cấp lại
+                # và cách đẩy video đi sau khi cấp (issue #109).
+                msg += (f"\n\nĐã thử lại {config.POST_AUTH_RETRY_MAX} lần, token "
+                        f"vẫn chưa được cấp lại.\n"
+                        f"{_reauth_hint(post['channel_key'])}\n"
+                        f"Cấp lại xong, đẩy video đi bằng: python -m "
+                        f"scheduler.post_scheduler requeue {post['id']}")
+            _alert_safe(msg)
             summary["failed"] += 1
 
     if any(summary.values()):
         logger.info("Scheduler tick: %s", summary)
     return summary
+
+
+def requeue_post(post_id: int, in_minutes: int = 1,
+                 now: datetime | None = None) -> str:
+    """Đẩy lại 1 post đã failed — phục hồi TAY sau khi cấp lại token (#109).
+
+    An toàn kép: `scheduled_posts.requeue` từ chối post đã có `platform_video_id`
+    (đã lên sóng) và post không ở trạng thái uploading/failed, nên lệnh này
+    không thể tạo video trùng. `attempts` được reset về 0 vì đây là hành động có
+    chủ đích của người vận hành, không phải retry tự động.
+    """
+    post = scheduled_posts.get_post(post_id)
+    if not post:
+        return f"Không có post {post_id}."
+    if post.get("platform_video_id"):
+        return (f"Post {post_id} ĐÃ lên platform "
+                f"({post.get('url') or post['platform_video_id']}) — không đẩy "
+                f"lại (tránh video trùng). Nếu cần, mark done tay.")
+
+    now = now or datetime.now()
+    base = now + timedelta(minutes=max(in_minutes, 0))
+    for minute in range(10):
+        slot = (base + timedelta(minutes=minute)).isoformat(sep=" ", timespec="seconds")
+        try:
+            if scheduled_posts.requeue(post_id, slot, error=None, reset_attempts=True):
+                return (f"Post {post_id} (video {post['video_id']} → "
+                        f"{post['channel_key']}) đã xếp lại lúc {slot}. "
+                        f"Tick kế tiếp sẽ upload.")
+            return (f"Post {post_id} đang ở trạng thái {post['status']!r} — chỉ "
+                    f"đẩy lại được post 'failed'/'uploading'.")
+        except sqlite3.IntegrityError:
+            continue
+        except sqlite3.OperationalError as e:
+            return (f"Thiếu schema mới ({e}) — chạy `python -m storage.migrate up` "
+                    f"rồi thử lại.")
+    return f"Không tìm được slot trống quanh {base:%H:%M} cho post {post_id}."
+
+
+def _is_auth_error(exc: BaseException) -> bool:
+    """Lỗi TOKEN OAuth (invalid_grant) chứ không phải lỗi mạng/upload — #109.
+
+    Uỷ cho publisher.token_health (module sở hữu mọi hiểu biết về token) để chỉ
+    có MỘT định nghĩa "lỗi token" trong codebase. Thiếu module/dependency thì
+    coi như không phải lỗi auth → hành vi cũ (mark_failed), không bao giờ retry
+    nhầm.
+    """
+    try:
+        from publisher.token_health import is_auth_error
+        return is_auth_error(exc)
+    except Exception as e:
+        logger.warning("Không phân loại được lỗi dispatch (%s) — coi như không "
+                       "phải lỗi token", e)
+        return False
+
+
+def _retry_after_auth_error(post: dict, error: str | None,
+                            now: datetime | None = None) -> bool:
+    """Requeue post chết vì token, có giới hạn. True nếu đã xếp lại lịch.
+
+    Vì sao retry ở đây là AN TOÀN dù nguyên tắc chung của module là "không bao
+    giờ tự retry": RefreshError xảy ra trong `_get_authenticated_service`, tức
+    TRƯỚC khi `videos.insert` gửi byte đầu tiên — không thể có video trùng trên
+    kênh. Post đã kịp có `platform_video_id` bị `scheduled_posts.requeue` từ
+    chối như chốt chặn cuối, độc lập với phán đoán ở đây.
+
+    Vì sao đáng làm: cấp lại token là thao tác TAY mất hàng giờ (issue #109 —
+    token chết 12:00, người dùng thấy alert lúc nào hay lúc đó). Không requeue
+    thì video mồ côi vĩnh viễn dù đã cấp lại token; requeue mỗi tick 5 phút thì
+    nã alert. Nên: lùi POST_AUTH_RETRY_DELAY_MINUTES phút, tối đa
+    POST_AUTH_RETRY_MAX lần, alert lần ĐẦU và lần CUỐI.
+    """
+    now = now or datetime.now()
+    attempts = post.get("attempts") or 0
+    channel_key = post["channel_key"]
+
+    if attempts >= config.POST_AUTH_RETRY_MAX:
+        return False  # caller mark_failed + alert như cũ
+
+    # Dò phút trống kế tiếp: unique index (channel_key, scheduled_at) chặn 2 post
+    # cùng slot, mà giờ retry có thể trùng slot cadence của post khác.
+    base = now + timedelta(minutes=config.POST_AUTH_RETRY_DELAY_MINUTES)
+    try:
+        for minute in range(10):
+            slot = (base + timedelta(minutes=minute)).isoformat(sep=" ",
+                                                                timespec="seconds")
+            try:
+                if scheduled_posts.requeue(post["id"], slot, error=error):
+                    break
+                return False  # post không còn ở trạng thái requeue được (đã done?)
+            except sqlite3.IntegrityError:
+                continue
+        else:
+            logger.warning("Không tìm được slot retry cho post %d", post["id"])
+            return False
+    except sqlite3.OperationalError as e:
+        # Điển hình: quên `python -m storage.migrate up` sau khi pull (cột
+        # `attempts` của migration 009 chưa có). Suy giảm êm về hành vi cũ
+        # (mark_failed + alert) thay vì làm sập cả tick và chặn các post khác.
+        logger.error("Không requeue được post %d (%s) — chạy `python -m "
+                     "storage.migrate up`?", post["id"], e)
+        return False
+
+    attempt_no = attempts + 1
+    logger.warning("Post %d (%s) chết vì token — retry lần %d/%d lúc %s",
+                   post["id"], channel_key, attempt_no,
+                   config.POST_AUTH_RETRY_MAX, slot)
+    if attempt_no == 1:
+        # Chỉ alert lần đầu: các lần sau là cùng một sự cố, im lặng cho tới khi
+        # hết lượt (alert cuối do nhánh mark_failed của run_tick gửi).
+        _alert_safe(_auth_alert(channel_key, post, error, slot, attempt_no))
+    return True
+
+
+def _reauth_hint(channel_key: str) -> str:
+    """Câu lệnh cấp lại token của kênh (token_health là nguồn duy nhất)."""
+    try:
+        from publisher.token_health import reauth_command
+        from publisher.youtube_uploader import resolve_token_file
+        return reauth_command(resolve_token_file(channel_key))
+    except Exception:
+        return "Cấp lại token: xem docs/current/oauth-setup.md §1.5"
+
+
+def _auth_alert(channel_key: str, post: dict, error: str | None, slot: str,
+                attempt_no: int) -> str:
+    """Alert token chết lúc upload — dùng chung câu lệnh cấp lại với token_health."""
+    extra = (f"Video {post['video_id']} (post {post['id']}) KHÔNG mất: đã xếp lại "
+             f"lúc {slot}, tự thử lại tối đa {config.POST_AUTH_RETRY_MAX} lần "
+             f"(lần {attempt_no}). Cấp lại token xong là video tự lên sóng.")
+    try:
+        from publisher.token_health import auth_failure_alert
+        return auth_failure_alert(channel_key, error or "invalid_grant", extra)
+    except Exception:  # token_health không import được → alert tối giản
+        return (f"🔴 Token YouTube kênh {channel_key} chết — upload thất bại.\n"
+                f"{error}\n{extra}")
 
 
 def _dispatch(post: dict) -> tuple[bool, str | None, str | None]:
@@ -292,6 +449,12 @@ def main():
     p_sched = sub.add_parser("schedule", help="Xếp lịch 1 video vào slot kế tiếp")
     p_sched.add_argument("video_id", type=int)
     p_sched.add_argument("channel_key")
+    p_requeue = sub.add_parser(
+        "requeue",
+        help="Đẩy lại 1 post đã failed (vd sau khi cấp lại token — issue #109)")
+    p_requeue.add_argument("post_id", type=int)
+    p_requeue.add_argument("--in-minutes", type=int, default=1,
+                           help="Bao nhiêu phút nữa thì đăng (mặc định 1)")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO,
@@ -308,6 +471,8 @@ def main():
     elif args.command == "schedule":
         post = schedule_video(args.video_id, args.channel_key)
         print(post if post else "Không xếp được lịch — xem log.")
+    elif args.command == "requeue":
+        print(requeue_post(args.post_id, in_minutes=args.in_minutes))
 
 
 if __name__ == "__main__":

--- a/content-pipeline/scheduler/post_scheduler.py
+++ b/content-pipeline/scheduler/post_scheduler.py
@@ -253,13 +253,22 @@ def run_tick(now: datetime | None = None) -> dict:
 
 
 def requeue_post(post_id: int, in_minutes: int = 1,
-                 now: datetime | None = None) -> str:
+                 now: datetime | None = None, force: bool = False) -> str:
     """Đẩy lại 1 post đã failed — phục hồi TAY sau khi cấp lại token (#109).
 
-    An toàn kép: `scheduled_posts.requeue` từ chối post đã có `platform_video_id`
-    (đã lên sóng) và post không ở trạng thái uploading/failed, nên lệnh này
-    không thể tạo video trùng. `attempts` được reset về 0 vì đây là hành động có
-    chủ đích của người vận hành, không phải retry tự động.
+    CHỈ nhận post `failed` (review Codex PR #110). Post kẹt `'uploading'` bị từ
+    chối vì có thể ĐÃ lên YouTube mà chưa kịp ghi `platform_video_id` (crash
+    giữa lúc `videos.insert` trả về và callback `record_platform_id` chạy) —
+    đúng trạng thái mà alert stale của `run_tick` gọi là "chưa rõ đã lên chưa,
+    kiểm tra kênh trước". Đẩy lại mù = video trùng. Người vận hành đã kiểm tra
+    kênh và chắc chắn video CHƯA lên thì dùng `force=True` (`--force`).
+
+    Khác nhánh tự động: `_retry_after_auth_error` requeue được post `'uploading'`
+    vì ở đó lỗi là RefreshError — biết chắc chưa gửi byte nào lên YouTube.
+
+    `attempts` reset về 0 vì đây là hành động có chủ đích của người vận hành,
+    không phải retry tự động. `scheduled_posts.requeue` vẫn từ chối post đã có
+    `platform_video_id` như chốt chặn cuối.
     """
     post = scheduled_posts.get_post(post_id)
     if not post:
@@ -268,18 +277,25 @@ def requeue_post(post_id: int, in_minutes: int = 1,
         return (f"Post {post_id} ĐÃ lên platform "
                 f"({post.get('url') or post['platform_video_id']}) — không đẩy "
                 f"lại (tránh video trùng). Nếu cần, mark done tay.")
+    if post["status"] == "uploading" and not force:
+        return (f"Post {post_id} đang ở trạng thái 'uploading' — video có thể ĐÃ "
+                f"lên kênh {post['channel_key']} mà chưa kịp ghi lại id. Kiểm tra "
+                f"kênh trước; chắc chắn CHƯA lên thì chạy lại với --force.")
 
+    from_statuses = ("failed", "uploading") if force else ("failed",)
     now = now or datetime.now()
     base = now + timedelta(minutes=max(in_minutes, 0))
     for minute in range(10):
         slot = (base + timedelta(minutes=minute)).isoformat(sep=" ", timespec="seconds")
         try:
-            if scheduled_posts.requeue(post_id, slot, error=None, reset_attempts=True):
+            if scheduled_posts.requeue(post_id, slot, error=None,
+                                       from_statuses=from_statuses,
+                                       reset_attempts=True):
                 return (f"Post {post_id} (video {post['video_id']} → "
                         f"{post['channel_key']}) đã xếp lại lúc {slot}. "
                         f"Tick kế tiếp sẽ upload.")
             return (f"Post {post_id} đang ở trạng thái {post['status']!r} — chỉ "
-                    f"đẩy lại được post 'failed'/'uploading'.")
+                    f"đẩy lại được post 'failed'.")
         except sqlite3.IntegrityError:
             continue
         except sqlite3.OperationalError as e:
@@ -455,6 +471,10 @@ def main():
     p_requeue.add_argument("post_id", type=int)
     p_requeue.add_argument("--in-minutes", type=int, default=1,
                            help="Bao nhiêu phút nữa thì đăng (mặc định 1)")
+    p_requeue.add_argument("--force", action="store_true",
+                           help="Cho phép đẩy lại cả post kẹt 'uploading'. CHỈ "
+                                "dùng khi đã kiểm tra kênh và chắc chắn video "
+                                "CHƯA lên — nếu đã lên thì đây là video trùng.")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO,
@@ -472,7 +492,8 @@ def main():
         post = schedule_video(args.video_id, args.channel_key)
         print(post if post else "Không xếp được lịch — xem log.")
     elif args.command == "requeue":
-        print(requeue_post(args.post_id, in_minutes=args.in_minutes))
+        print(requeue_post(args.post_id, in_minutes=args.in_minutes,
+                           force=args.force))
 
 
 if __name__ == "__main__":

--- a/content-pipeline/storage/migrations/009_post_attempts.sql
+++ b/content-pipeline/storage/migrations/009_post_attempts.sql
@@ -1,0 +1,15 @@
+-- Migration 009: đếm số lần thử upload của 1 post (issue #109).
+--
+-- Bối cảnh: token OAuth của ai_youtube hết hạn giữa hai lần kiểm tra (probe
+-- 08:00 báo OK, upload 12:00 chết vì invalid_grant). Post bị mark_failed và
+-- KHÔNG có đường quay lại — cấp lại token xong video vẫn nằm im.
+--
+-- RefreshError xảy ra TRƯỚC khi gửi byte nào lên YouTube nên requeue post đó
+-- an toàn tuyệt đối (khác post kẹt 'uploading' giữa chừng — có thể đã lên sóng,
+-- vẫn KHÔNG bao giờ tự retry). `attempts` chặn vòng lặp vô hạn: quá
+-- config.POST_AUTH_RETRY_MAX lần thì mark_failed như cũ.
+--
+-- No BEGIN/COMMIT here — storage/migrate.py wraps this file's contents
+-- together with the _migrations bookkeeping INSERT in one transaction.
+
+ALTER TABLE scheduled_posts ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;

--- a/content-pipeline/storage/migrations/009_post_attempts_down.sql
+++ b/content-pipeline/storage/migrations/009_post_attempts_down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 009_post_attempts.
+-- SQLite 3.35+ hỗ trợ DROP COLUMN; cột không nằm trong index nào nên drop sạch.
+
+ALTER TABLE scheduled_posts DROP COLUMN attempts;

--- a/content-pipeline/storage/scheduled_posts.py
+++ b/content-pipeline/storage/scheduled_posts.py
@@ -10,6 +10,10 @@ qua `claim()` (UPDATE có điều kiện, atomic) — 2 tick scheduler chạy ch
 nhau không thể cùng upload 1 post. `platform_video_id` được lưu NGAY khi
 platform trả về id (mark_done) để một lần restart giữa chừng không bao giờ
 tạo video trùng trên YouTube (rủi ro "Upload trùng", phase-5-detailed.md §5).
+
+Ngoại lệ DUY NHẤT của "không bao giờ tự retry": `requeue()` (issue #109) — chỉ
+cho lỗi token OAuth, xảy ra trước khi gửi byte nào lên platform. Xem docstring
+của hàm đó.
 """
 
 import logging
@@ -144,6 +148,46 @@ def mark_failed(post_id: int, error: str) -> None:
             (error[:1000], _now_str(), post_id),
         )
         conn.commit()
+    finally:
+        conn.close()
+
+
+def requeue(post_id: int, scheduled_at: str, error: Optional[str] = None,
+            from_statuses: tuple[str, ...] = ("uploading", "failed"),
+            reset_attempts: bool = False) -> bool:
+    """Đưa post về 'queued' ở giờ mới, tăng `attempts`. True nếu đổi được.
+
+    CHỈ dùng cho lỗi xảy ra TRƯỚC khi byte nào lên platform — thực tế là token
+    OAuth chết (RefreshError/invalid_grant, issue #109): uploader chưa gọi
+    videos.insert nên retry không thể tạo video trùng. Post đã có
+    `platform_video_id` (đã lên sóng) bị TỪ CHỐI ở đây như một chốt chặn cuối,
+    độc lập với phán đoán của caller.
+
+    `attempts` tăng mỗi lần requeue để scheduler dừng lại sau
+    config.POST_AUTH_RETRY_MAX lần thay vì retry vô hạn; `reset_attempts=True`
+    cho lệnh phục hồi TAY (người vận hành đã cấp lại token → cho lại đủ lượt).
+
+    Raises:
+        sqlite3.IntegrityError: slot (channel_key, scheduled_at) mới đã có post
+            khác đang hoạt động — caller dò giờ kế tiếp (như schedule_video).
+    """
+    conn = get_connection()
+    try:
+        placeholders = ",".join("?" * len(from_statuses))
+        attempts_expr = "0" if reset_attempts else "attempts + 1"
+        cur = conn.execute(
+            "UPDATE scheduled_posts SET status = 'queued', scheduled_at = ?, "
+            f"error = ?, attempts = {attempts_expr}, updated_at = ? "
+            f"WHERE id = ? AND status IN ({placeholders}) "
+            "AND (platform_video_id IS NULL OR platform_video_id = '')",
+            (scheduled_at, (error or "")[:1000] or None, _now_str(), post_id,
+             *from_statuses),
+        )
+        conn.commit()
+        if cur.rowcount == 1:
+            logger.info("Requeued post %d at %s", post_id, scheduled_at)
+            return True
+        return False
     finally:
         conn.close()
 

--- a/content-pipeline/tests/test_post_scheduler.py
+++ b/content-pipeline/tests/test_post_scheduler.py
@@ -188,6 +188,124 @@ class TestRunTick(SchedulerBase):
         self.assertEqual(sp.get_post(post_id)["status"], "uploading")
 
 
+class TestAuthErrorRetry(SchedulerBase):
+    """Token OAuth chết giữa chừng → requeue có giới hạn (issue #109).
+
+    An toàn vì RefreshError xảy ra TRƯỚC videos.insert — không thể video trùng.
+    """
+
+    def _queue_due_post(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        return vid, post_id
+
+    @staticmethod
+    def _refresh_error():
+        return RuntimeError("RefreshError: ('invalid_grant: Token has been "
+                            "expired or revoked.',)")
+
+    def test_auth_error_requeues_instead_of_failing(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch", side_effect=self._refresh_error()), \
+             patch.object(ps, "_alert_safe") as alert:
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["retried"], 1)
+        self.assertEqual(summary["failed"], 0)
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "queued")
+        self.assertEqual(post["attempts"], 1)
+        # Lùi POST_AUTH_RETRY_DELAY_MINUTES phút → không retry ngay tick sau.
+        self.assertGreater(post["scheduled_at"], "2026-07-07 12:02:00")
+        # Alert nêu rõ token + cách cấp lại, không phải "upload thất bại" chung chung.
+        alert.assert_called_once()
+        msg = alert.call_args[0][0]
+        self.assertIn("--force-reauth", msg)
+        self.assertIn("KHÔNG mất", msg)
+
+    def test_retry_alerts_only_once_not_every_tick(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch", side_effect=self._refresh_error()), \
+             patch.object(ps, "_alert_safe") as alert:
+            ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+            ps.run_tick(now=datetime(2026, 7, 7, 13, 30))
+        self.assertEqual(sp.get_post(post_id)["attempts"], 2)
+        self.assertEqual(alert.call_count, 1)
+
+    def test_gives_up_after_max_attempts_with_recovery_hint(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps.config, "POST_AUTH_RETRY_MAX", 1), \
+             patch.object(ps, "_dispatch", side_effect=self._refresh_error()), \
+             patch.object(ps, "_alert_safe") as alert:
+            ps.run_tick(now=datetime(2026, 7, 7, 12, 2))          # attempt 1
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 13, 30))  # hết lượt
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(sp.get_post(post_id)["status"], "failed")
+        final = alert.call_args[0][0]
+        self.assertIn("--force-reauth", final)
+        self.assertIn(f"requeue {post_id}", final)
+
+    def test_non_auth_error_still_fails_without_retry(self):
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch", side_effect=RuntimeError("ffmpeg boom")), \
+             patch.object(ps, "_alert_safe"):
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["retried"], 0)
+        self.assertEqual(sp.get_post(post_id)["status"], "failed")
+
+    def test_missing_migration_degrades_to_old_behaviour(self):
+        """Quên `storage.migrate up` → mark_failed như trước, KHÔNG sập cả tick."""
+        import sqlite3 as _sqlite3
+        vid, post_id = self._queue_due_post()
+        with patch.object(ps, "_dispatch", side_effect=self._refresh_error()), \
+             patch.object(ps.scheduled_posts, "requeue",
+                          side_effect=_sqlite3.OperationalError(
+                              "no such column: attempts")), \
+             patch.object(ps, "_alert_safe"):
+            summary = ps.run_tick(now=datetime(2026, 7, 7, 12, 2))
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(sp.get_post(post_id)["status"], "failed")
+
+    def test_never_requeues_a_post_already_live(self):
+        """Chốt chặn cuối: post đã có platform_video_id không bao giờ đăng lại."""
+        vid, post_id = self._queue_due_post()
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "abc123", "https://youtu.be/abc123")
+        post = sp.get_post(post_id)
+        self.assertFalse(ps._retry_after_auth_error(post, "invalid_grant"))
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
+
+class TestRequeuePostCommand(SchedulerBase):
+    """Phục hồi TAY sau khi cấp lại token (issue #109)."""
+
+    def test_requeues_failed_post_and_resets_attempts(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)
+        sp.mark_failed(post_id, "invalid_grant")
+        msg = ps.requeue_post(post_id, in_minutes=1,
+                              now=datetime(2026, 7, 7, 15, 0))
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "queued")
+        self.assertEqual(post["attempts"], 0)
+        self.assertEqual(post["scheduled_at"], "2026-07-07 15:01:00")
+        self.assertIn("xếp lại", msg)
+
+    def test_refuses_post_already_on_platform(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "abc", "https://youtu.be/abc")
+        sp.mark_failed(post_id, "late failure")
+        msg = ps.requeue_post(post_id, now=datetime(2026, 7, 7, 15, 0))
+        self.assertIn("ĐÃ lên platform", msg)
+        self.assertEqual(sp.get_post(post_id)["status"], "failed")
+
+    def test_unknown_post(self):
+        self.assertIn("Không có post", ps.requeue_post(999))
+
+
 class TestDispatchYouTube(SchedulerBase):
     def test_on_uploaded_persists_platform_id_before_return(self):
         vid = _make_video()

--- a/content-pipeline/tests/test_post_scheduler.py
+++ b/content-pipeline/tests/test_post_scheduler.py
@@ -292,6 +292,32 @@ class TestRequeuePostCommand(SchedulerBase):
         self.assertEqual(post["scheduled_at"], "2026-07-07 15:01:00")
         self.assertIn("xếp lại", msg)
 
+    def test_refuses_stuck_uploading_post_without_force(self):
+        """Post kẹt 'uploading' có thể ĐÃ lên kênh mà chưa ghi được id (Codex #110)."""
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)  # 'uploading', chưa có platform_video_id
+        msg = ps.requeue_post(post_id, now=datetime(2026, 7, 7, 15, 0))
+        self.assertIn("--force", msg)
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
+    def test_force_allows_uploading_after_operator_checked(self):
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)
+        ps.requeue_post(post_id, now=datetime(2026, 7, 7, 15, 0), force=True)
+        self.assertEqual(sp.get_post(post_id)["status"], "queued")
+
+    def test_force_still_refuses_post_already_on_platform(self):
+        """--force chỉ nới trạng thái, KHÔNG bỏ qua bằng chứng đã lên sóng."""
+        vid = _make_video()
+        post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "abc", "https://youtu.be/abc")
+        msg = ps.requeue_post(post_id, now=datetime(2026, 7, 7, 15, 0), force=True)
+        self.assertIn("ĐÃ lên platform", msg)
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
     def test_refuses_post_already_on_platform(self):
         vid = _make_video()
         post_id = sp.insert_post(vid, "drama_youtube", "2026-07-07 12:00:00")

--- a/content-pipeline/tests/test_scheduled_posts.py
+++ b/content-pipeline/tests/test_scheduled_posts.py
@@ -139,6 +139,48 @@ class TestQueries(ScheduledPostsBase):
         stale = sp.get_stale_uploading(older_than_minutes=90)
         self.assertEqual([p["id"] for p in stale], [post_id])
 
+    def test_requeue_from_uploading_increments_attempts(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        self.assertTrue(sp.requeue(post_id, "2026-07-08 13:00:00", error="invalid_grant"))
+        post = sp.get_post(post_id)
+        self.assertEqual(post["status"], "queued")
+        self.assertEqual(post["scheduled_at"], "2026-07-08 13:00:00")
+        self.assertEqual(post["attempts"], 1)
+        self.assertEqual(post["error"], "invalid_grant")
+
+    def test_requeue_refuses_post_already_on_platform(self):
+        """Chốt chặn cuối chống upload trùng — độc lập với phán đoán của caller."""
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.record_platform_id(post_id, "yt1", "https://youtu.be/yt1")
+        self.assertFalse(sp.requeue(post_id, "2026-07-08 13:00:00"))
+        self.assertEqual(sp.get_post(post_id)["status"], "uploading")
+
+    def test_requeue_refuses_done_post(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.mark_done(post_id, "yt1", "https://youtu.be/yt1")
+        self.assertFalse(sp.requeue(post_id, "2026-07-08 13:00:00"))
+        self.assertEqual(sp.get_post(post_id)["status"], "done")
+
+    def test_requeue_reset_attempts_for_manual_recovery(self):
+        post_id = sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(post_id)
+        sp.requeue(post_id, "2026-07-08 13:00:00")
+        sp.claim(post_id)
+        sp.mark_failed(post_id, "invalid_grant")
+        self.assertTrue(sp.requeue(post_id, "2026-07-08 14:00:00", reset_attempts=True))
+        self.assertEqual(sp.get_post(post_id)["attempts"], 0)
+
+    def test_requeue_blocked_by_occupied_slot(self):
+        first = sp.insert_post(1, "drama_youtube", "2026-07-08 13:00:00")
+        second = sp.insert_post(2, "drama_youtube", "2026-07-08 12:00:00")
+        sp.claim(second)
+        with self.assertRaises(sqlite3.IntegrityError):
+            sp.requeue(second, "2026-07-08 13:00:00")  # slot của post `first`
+        self.assertEqual(sp.get_post(first)["video_id"], 1)
+
     def test_count_by_status(self):
         sp.insert_post(1, "drama_youtube", "2026-07-08 12:00:00")
         p2 = sp.insert_post(2, "drama_youtube", "2026-07-08 21:00:00")

--- a/content-pipeline/tests/test_token_health.py
+++ b/content-pipeline/tests/test_token_health.py
@@ -367,6 +367,38 @@ class TestExpiryWarning(_AlertTestBase):
         self.assertIn("--force-reauth", msg)
         self.assertIn("YOUTUBE_TOKEN_TTL_DAYS", msg)  # cách tắt khi đã publish app
 
+    def test_failed_send_does_not_burn_the_daily_slot(self):
+        """Telegram lỗi lúc 08:00 KHÔNG được nuốt mất cảnh báo 11:30 (Codex #110).
+
+        Cảnh báo này thường chỉ có 1-2 cơ hội trước khi token chết, nên mốc
+        dedupe chỉ được ghi sau khi gửi THÀNH CÔNG.
+        """
+        res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ")
+        with patch.object(th, "check_all", return_value=[res]), \
+             patch("notifier.telegram_bot.send_alert", return_value=False) as alert:
+            th.check_and_alert()   # 08:00 — Telegram từ chối
+            th.check_and_alert()   # 11:30 — phải thử lại
+        self.assertEqual(alert.call_count, 2)
+
+    def test_send_exception_also_leaves_the_slot_open(self):
+        res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ")
+        with patch.object(th, "check_all", return_value=[res]), \
+             patch("notifier.telegram_bot.send_alert",
+                   side_effect=RuntimeError("net")) as alert:
+            th.check_and_alert()
+            th.check_and_alert()
+        self.assertEqual(alert.call_count, 2)
+
+    def test_stops_repeating_once_delivered(self):
+        res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ")
+        with patch.object(th, "check_all", return_value=[res]), \
+             patch("notifier.telegram_bot.send_alert",
+                   side_effect=[False, True, True]) as alert:
+            th.check_and_alert()   # hỏng → thử lại
+            th.check_and_alert()   # tới nơi → ghi mốc
+            th.check_and_alert()   # im lặng
+        self.assertEqual(alert.call_count, 2)
+
     def test_warning_does_not_make_channel_unhealthy(self):
         """Token sắp hết hạn vẫn dùng được — không được coi là hỏng."""
         res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ")

--- a/content-pipeline/tests/test_token_health.py
+++ b/content-pipeline/tests/test_token_health.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import unittest
 import urllib.error
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -165,7 +166,7 @@ class TestScopeCheck(unittest.TestCase):
     def test_full_scopes_is_ok(self):
         with patch.object(th, "_read_token_file", return_value=(_VALID_TOKEN, None)), \
              patch.object(th, "_probe_refresh", return_value=(th.OK, "")):
-            code, _ = th._check_token_file("/t.json", 5)
+            code, _, _ = th._check_token_file("/t.json", 5)
         self.assertEqual(code, th.OK)
 
     def test_missing_force_ssl_scope_flagged(self):
@@ -173,7 +174,7 @@ class TestScopeCheck(unittest.TestCase):
         token["scopes"] = ["https://www.googleapis.com/auth/youtube.upload"]  # no force-ssl
         with patch.object(th, "_read_token_file", return_value=(token, None)), \
              patch.object(th, "_probe_refresh", return_value=(th.OK, "")):
-            code, detail = th._check_token_file("/t.json", 5)
+            code, detail, _ = th._check_token_file("/t.json", 5)
         self.assertEqual(code, th.MISSING_SCOPES)
         self.assertIn("force-ssl", detail)
 
@@ -181,14 +182,14 @@ class TestScopeCheck(unittest.TestCase):
         token = {"refresh_token": "rt", "client_id": "c", "client_secret": "s"}
         with patch.object(th, "_read_token_file", return_value=(token, None)), \
              patch.object(th, "_probe_refresh", return_value=(th.REVOKED, "invalid_grant")):
-            code, _ = th._check_token_file("/t.json", 5)
+            code, _, _ = th._check_token_file("/t.json", 5)
         self.assertEqual(code, th.REVOKED)
 
 
 class TestCheckAll(unittest.TestCase):
     def test_defaults_to_all_youtube_channels(self):
         with patch.object(th, "resolve_token_file", side_effect=lambda k: f"/{k}.json"), \
-             patch.object(th, "_check_token_file", return_value=(th.OK, "")):
+             patch.object(th, "_check_token_file", return_value=(th.OK, "", None)):
             results = th.check_all()
         keys = {r.channel_key for r in results}
         self.assertIn("ai_youtube", keys)
@@ -199,7 +200,7 @@ class TestCheckAll(unittest.TestCase):
         # Both channels fall back to the same token file → each is flagged
         # unconfigured (no distinct token), and the shared file is NOT probed
         # (the misconfiguration matters even if that token happens to be valid).
-        probe = MagicMock(return_value=(th.OK, ""))
+        probe = MagicMock(return_value=(th.OK, "", None))
         with patch.object(th, "resolve_token_file", return_value="/shared.json"), \
              patch.object(th, "_check_token_file", probe):
             results = th.check_all(["ai_youtube", "drama_youtube"])
@@ -211,7 +212,7 @@ class TestCheckAll(unittest.TestCase):
         probe.assert_not_called()
 
     def test_distinct_paths_are_probed(self):
-        probe = MagicMock(return_value=(th.OK, ""))
+        probe = MagicMock(return_value=(th.OK, "", None))
         with patch.object(th, "resolve_token_file", side_effect=lambda k: f"/{k}.json"), \
              patch.object(th, "_check_token_file", probe):
             results = th.check_all(["ai_youtube", "drama_youtube"])
@@ -231,8 +232,9 @@ class _AlertTestBase(unittest.TestCase):
     def tearDown(self):
         self._patch.stop()
 
-    def _result(self, code, key="drama_youtube"):
-        return th.TokenCheckResult(key, "[2P] Chuyện Đời", "/t.json", code, "detail")
+    def _result(self, code, key="drama_youtube", warning=None):
+        return th.TokenCheckResult(key, "[2P] Chuyện Đời", "/t.json", code, "detail",
+                                   warning)
 
 
 class TestCheckAndAlert(_AlertTestBase):
@@ -297,6 +299,96 @@ class TestCheckAndAlert(_AlertTestBase):
             # must not raise
             results = th.check_and_alert()
         self.assertEqual(results[0].code, th.REVOKED)
+
+
+class TestExpiryWarning(_AlertTestBase):
+    """Cảnh báo TRƯỚC khi refresh token hết hạn theo lịch (issue #109).
+
+    Đây là lớp duy nhất đóng được khe mù "probe 08:00 báo OK → upload 12:00
+    chết": probe không thể biết trước, chỉ tuổi token mới nói được điều đó.
+    """
+
+    def _token_file(self, refresh_token="1//rt", age_days=0.0):
+        path = os.path.join(self.tmp, f"tok_{abs(hash(refresh_token))}.json")
+        token = dict(_VALID_TOKEN, refresh_token=refresh_token)
+        with open(path, "w") as f:
+            json.dump(token, f)
+        if age_days:
+            old = datetime.now() - timedelta(days=age_days)
+            os.utime(path, (old.timestamp(), old.timestamp()))
+        return path, token
+
+    def test_no_warning_when_token_is_fresh(self):
+        path, token = self._token_file()
+        self.assertIsNone(th._expiry_warning("ai_youtube", token, path))
+
+    def test_warns_within_window_before_scheduled_expiry(self):
+        # Token cấp 6.5 ngày trước, TTL 7 ngày → còn ~12h < ngưỡng 24h.
+        path, token = self._token_file(age_days=6.5)
+        warning = th._expiry_warning("ai_youtube", token, path)
+        self.assertIsNotNone(warning)
+        self.assertIn("hết hạn", warning)
+
+    def test_past_ttl_says_can_die_any_moment(self):
+        path, token = self._token_file(age_days=8)
+        warning = th._expiry_warning("ai_youtube", token, path)
+        self.assertIn("quá hạn", warning)
+
+    def test_disabled_when_ttl_zero(self):
+        """App đã 'In production' → token không hết hạn theo lịch, tắt cảnh báo."""
+        path, token = self._token_file(age_days=30)
+        with patch.object(th.config, "YOUTUBE_TOKEN_TTL_DAYS", 0):
+            self.assertIsNone(th._expiry_warning("ai_youtube", token, path))
+
+    def test_new_token_resets_the_clock(self):
+        """Cấp lại token (refresh_token đổi) → tuổi tính lại từ đầu, hết cảnh báo."""
+        old_path, old_token = self._token_file("1//old", age_days=8)
+        self.assertIsNotNone(th._expiry_warning("ai_youtube", old_token, old_path))
+        new_path, new_token = self._token_file("1//new")
+        self.assertIsNone(th._expiry_warning("ai_youtube", new_token, new_path))
+
+    def test_state_never_stores_the_refresh_token(self):
+        from storage.pipeline_state import get_state
+        path, token = self._token_file("1//supersecret", age_days=6.9)
+        th._expiry_warning("ai_youtube", token, path)
+        stored = get_state("token_health_minted:ai_youtube") or ""
+        self.assertNotIn("supersecret", stored)
+        self.assertIn(th._fingerprint("1//supersecret"), stored)
+
+    def test_alert_sent_once_per_day_across_runs(self):
+        res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ là hết hạn")
+        with patch.object(th, "check_all", return_value=[res]), \
+             patch("notifier.telegram_bot.send_alert") as alert:
+            th.check_and_alert()   # 07:00 ké pipeline
+            th.check_and_alert()   # 08:00 cron
+            th.check_and_alert()   # 11:30 cron
+        alert.assert_called_once()
+        msg = alert.call_args[0][0]
+        self.assertIn("--force-reauth", msg)
+        self.assertIn("YOUTUBE_TOKEN_TTL_DAYS", msg)  # cách tắt khi đã publish app
+
+    def test_warning_does_not_make_channel_unhealthy(self):
+        """Token sắp hết hạn vẫn dùng được — không được coi là hỏng."""
+        res = self._result(th.OK, key="ai_youtube", warning="còn ~5 giờ")
+        self.assertTrue(res.healthy)
+
+
+class TestIsAuthError(unittest.TestCase):
+    """Phân loại lỗi token cho scheduler (issue #109) — một định nghĩa duy nhất."""
+
+    def test_invalid_grant_text_is_auth_error(self):
+        exc = RuntimeError("RefreshError: ('invalid_grant: Token has been expired "
+                           "or revoked.',)")
+        self.assertTrue(th.is_auth_error(exc))
+
+    def test_network_error_is_not_auth_error(self):
+        self.assertFalse(th.is_auth_error(TimeoutError("connection timed out")))
+        self.assertFalse(th.is_auth_error(OSError("ffmpeg died")))
+
+    def test_reauth_command_targets_the_channel_token_file(self):
+        cmd = th.reauth_command("/x/.youtube_token_drama.json")
+        self.assertIn("--force-reauth", cmd)
+        self.assertIn("/x/.youtube_token_drama.json", cmd)
 
 
 if __name__ == "__main__":

--- a/docs/current/oauth-setup.md
+++ b/docs/current/oauth-setup.md
@@ -156,8 +156,10 @@ probe sớm hơn. Ba lớp bù:
    python -m scheduler.post_scheduler requeue <post_id>   # vd: requeue 43
    ```
 
-   Lệnh này từ chối post đã có `platform_video_id` (đã lên sóng) nên không thể
-   tạo video trùng.
+   Lệnh này chỉ nhận post `failed` và từ chối post đã có `platform_video_id`
+   (đã lên sóng) nên không thể tạo video trùng. Post kẹt `uploading` cũng bị từ
+   chối — trạng thái đó nghĩa là "chưa rõ đã lên chưa": kiểm tra kênh trước, nếu
+   chắc chắn video CHƯA lên thì thêm `--force`.
 
 ---
 

--- a/docs/current/oauth-setup.md
+++ b/docs/current/oauth-setup.md
@@ -119,9 +119,45 @@ python publisher/youtube_uploader.py --token-file <đường dẫn file token c�
 > nặng để publish ở mức dùng riêng.
 
 **Giám sát tự động:** `publisher/token_health.py` (cron
-`com.ai5phut.token-health`, 08:00 hằng ngày) probe refresh_token của **mọi**
-kênh YouTube trong `channels.py` và alert Telegram ngay khi token thu hồi/hết
-hạn — thay cron cũ chỉ soi 1 file token (bỏ sót drama_youtube).
+`com.ai5phut.token-health`, **08:00 và 11:30** hằng ngày) probe refresh_token của
+**mọi** kênh YouTube trong `channels.py` và alert Telegram ngay khi token thu
+hồi/hết hạn — thay cron cũ chỉ soi 1 file token (bỏ sót drama_youtube).
+
+### 1.6 Token chết GIỮA hai lần kiểm tra (issue #109)
+
+Ngày 28/07/2026 monitor báo `Token OK` cho `ai_youtube` lúc 07:00, rồi upload
+12:05 chết `invalid_grant` (video 159 / post 43). **Monitor không sai** — nó vẫn
+gọi refresh thật (`_probe_refresh`); token chỉ đơn giản là chết trong khe
+07:00→12:00. Với TTL 7 ngày của chế độ Testing, token chết vào **đúng giờ nó
+được cấp** 7 ngày trước, nên khe mù này là tất yếu và không sửa được bằng cách
+probe sớm hơn. Ba lớp bù:
+
+1. **Cảnh báo TRƯỚC khi hết hạn.** Monitor theo dõi tuổi refresh_token (mốc
+   lưu trong `pipeline_state` dưới dạng **hash**, không bao giờ lưu token) và
+   nhắn Telegram khi còn `YOUTUBE_TOKEN_WARN_BEFORE_HOURS` giờ (mặc định 24) là
+   tới hạn `YOUTUBE_TOKEN_TTL_DAYS` (mặc định 7 = chế độ Testing), tối đa 1
+   tin/ngày. **Đưa app sang "In production" rồi thì đặt `YOUTUBE_TOKEN_TTL_DAYS=0`**
+   trong `.env` để tắt hẳn cảnh báo này — token khi đó không hết hạn theo lịch.
+   *Lưu ý:* tuổi tính từ lần đầu monitor THẤY token đó (seed bằng mtime file
+   token), nên ngay sau khi deploy có thể trễ một vòng token; từ lần cấp lại kế
+   tiếp là chính xác.
+2. **Kiểm tra 11:30**, ngay trước slot đăng 12:00 — token chết trong ngày vẫn
+   còn ~30 phút để cấp lại trước giờ đăng.
+3. **Video không mất.** Upload chết vì token → post được **xếp lại** mỗi
+   `POST_AUTH_RETRY_DELAY_MINUTES` phút (mặc định 60), tối đa
+   `POST_AUTH_RETRY_MAX` lần (mặc định 6): cấp lại token xong là video tự lên
+   sóng, không phải thao tác gì. Retry này an toàn tuyệt đối vì `RefreshError`
+   xảy ra **trước** khi gửi byte nào lên YouTube (khác post kẹt `uploading`
+   giữa chừng — loại đó vẫn KHÔNG bao giờ tự retry). Hết lượt mà token vẫn
+   chưa cấp lại thì post `failed`; cấp lại token rồi đẩy đi bằng:
+
+   ```bash
+   cd content-pipeline
+   python -m scheduler.post_scheduler requeue <post_id>   # vd: requeue 43
+   ```
+
+   Lệnh này từ chối post đã có `platform_video_id` (đã lên sóng) nên không thể
+   tạo video trùng.
 
 ---
 


### PR DESCRIPTION
Closes #109

## Mô tả issue không khớp với code

Issue nói `token_health` "không refresh token, chỉ check access token còn sống". **Điều này không đúng** — `_probe_refresh` (publisher/token_health.py:112) luôn `POST grant_type=refresh_token` tới Google từ issue #94, và không hề đọc `expiry` của access token. Thêm "refresh probe" như issue đề xuất sẽ là no-op, và lỗi vẫn tái diễn.

## Root cause thật

**1. Ngoài code — OAuth app còn ở chế độ "Testing".** Google cho refresh token sống **đúng 7 ngày** kể từ lúc mint, và nó chết vào **đúng giờ được cấp**. Đây là **cùng root cause với #94** (drama_youtube chết 10/07), nay tái diễn trên ai_youtube — `docs/current/oauth-setup.md` §1.5 đã ghi nhận cơ chế này từ lần trước.

**2. Khe mù check-rồi-mới-dùng.** Monitor chạy 07:00 (ké `main.run_pipeline`) + 08:00 (cron); slot đăng là `mon-sat 12:00`. Token chết trong khe 08:00→12:00 thì **probe sớm cỡ nào cũng vô ích** — probe chỉ trả lời "còn sống LÚC NÀY".

**3. Không có đường phục hồi.** `run_tick` bắt `RefreshError` → `mark_failed` + alert `❌ Upload thất bại` chung chung, không kèm cách cấp lại token. Cấp lại token xong cũng **không ai requeue** → video 159 mồ côi vĩnh viễn.

## Ba lớp sửa

**1. Cảnh báo theo TUỔI token** (`publisher/token_health.py`) — lớp duy nhất thực sự đóng được khe mù.
Mốc "lần đầu monitor thấy refresh_token này" lưu ở `pipeline_state` dưới dạng **hash** (`_fingerprint`, không bao giờ lưu token), seed bằng mtime file token nên tuổi ước lượng chỉ có thể **thấp hơn** thật → cảnh báo có thể muộn một vòng token, **không bao giờ báo động giả**. Alert khi còn `YOUTUBE_TOKEN_WARN_BEFORE_HOURS` (24) giờ là tới hạn `YOUTUBE_TOKEN_TTL_DAYS` (7), tối đa **1 tin gửi thành công/ngày/token**; cấp token mới thì được cảnh báo lại ngay, không đợi sang ngày.
`TokenCheckResult.warning` tách khỏi `code` có chủ đích: "sắp hết hạn" là lời khuyên, token vẫn dùng được → `healthy` giữ nguyên nghĩa cho mọi caller cũ.

**2. Thu hẹp khe mù** — token-health chạy thêm lúc **11:30**, ngay trước slot 12:00 (còn ~30 phút để cấp lại). *Cân nhắc và bỏ:* pre-flight probe trong scheduler — chính cú upload đã refresh rồi, probe thêm chỉ tốn một request mà không biết thêm gì; thay vào đó phân loại lỗi tại chỗ.

**3. Video không mất** (`scheduler/post_scheduler.py`) — lỗi token → **requeue** post mỗi `POST_AUTH_RETRY_DELAY_MINUTES` (60) phút, tối đa `POST_AUTH_RETRY_MAX` (6) lần. Cấp lại token xong là video **tự lên sóng**, không thao tác gì.

## Vì sao retry ở đây an toàn (nguyên tắc §5 vẫn nguyên vẹn)

`RefreshError` xảy ra trong `_get_authenticated_service`, tức **trước khi `videos.insert` gửi byte đầu tiên** → không thể tạo video trùng. Post kẹt `'uploading'` giữa chừng (có thể đã lên sóng) **vẫn không bao giờ tự retry** như cũ. Ba chốt chặn:
- `scheduled_posts.requeue` từ chối post đã có `platform_video_id` — chốt ở tầng storage, độc lập với phán đoán của caller.
- Lỗi không phân loại được (mạng/ffmpeg/upload) → `mark_failed` như cũ, không retry.
- Thiếu migration 009 → suy giảm êm về `mark_failed`, **không làm sập cả tick** (chặn các post khác).

## UX alert

Trước: `❌ Upload thất bại: video 159 → ai_youtube (post 43): RefreshError...`
Sau: nói rõ **token chết**, kèm lệnh `--force-reauth` đúng file token của kênh (dùng chung `token_health.reauth_command` — một nguồn hướng dẫn duy nhất), và trấn an *"video KHÔNG mất, đã xếp lại lúc 13:05"*. Alert chỉ gửi **lần đầu** (các tick sau cùng một sự cố) + **lần cuối** khi hết lượt.

Phục hồi tay: `python -m scheduler.post_scheduler requeue POST_ID` — chỉ nhận post `failed`, và từ chối post đã có `platform_video_id`, nên không thể tạo video trùng. Post kẹt `uploading` ("chưa rõ đã lên chưa") bị từ chối; kiểm tra kênh xong, chắc chắn video chưa lên thì thêm `--force`.

## Kiểm chứng — mô phỏng đúng timeline #109

```
── 08:00  token-health (probe OK, token 6.6 ngày tuổi)
   alert: ⚠️ Token '[2P] AI Hôm Nay' (ai_youtube) còn ~10 giờ là hết hạn theo lịch...
── 12:05  upload → invalid_grant (token chết trong khe mù)
   summary: {'uploaded': 0, 'failed': 0, 'retried': 1} | post: queued → 2026-07-28 13:05:00
   alert: 🔴 Token YouTube kênh '[2P] AI Hôm Nay' chết giữa chừng... Cấp lại: ... --force-reauth
── 12:40  cấp lại token; 13:06 tick kế tiếp
   summary: {'uploaded': 1, 'failed': 0} | post: done | video: published
```

## Bảo mật

Không có bí mật nào đi vào state hay log: chỉ 16 hex đầu của sha256(refresh_token). Có test khẳng định điều này (`test_state_never_stores_the_refresh_token`).

## Đã xử lý review Codex (commit 42e9580)

Hai P2, cả hai đều đúng:
1. **Mốc dedupe cảnh báo ghi trước khi gửi** — `send_alert` báo lỗi bằng giá trị trả về chứ không raise, nên Telegram hỏng lúc 08:00 sẽ khoá luôn lần 11:30, đúng tin nhắn cuối cùng còn kịp cứu video. Nay tách đọc/ghi, chỉ ghi mốc sau khi gửi thành công.
2. **`requeue` tay nhận cả post kẹt `uploading`** — trạng thái đó nghĩa là "chưa rõ đã lên chưa", đẩy lại mù có thể tạo video trùng. Nay mặc định chỉ nhận `failed`, có `--force` cho ca đã kiểm tra kênh (nhưng `--force` vẫn không bỏ qua `platform_video_id`).

## Việc cần làm ngoài code

1. **Fix tận gốc:** đưa OAuth app sang **"In production"** (Google Cloud Console → OAuth consent screen → Publish app) — hết hẳn chuyện token chết 7 ngày/lần. Xong thì đặt `YOUTUBE_TOKEN_TTL_DAYS=0` trong `.env` để tắt cảnh báo theo tuổi.
2. `python -m storage.migrate up` sau khi pull (migration 009 — `scheduled_posts.attempts`).
3. `launchd/install.sh reload com.ai5phut.token-health` để nhận lịch 11:30.
4. Video 159 / post 43: cấp lại token ai_youtube rồi `python -m scheduler.post_scheduler requeue 43` (nếu post đang kẹt `uploading` thì kiểm tra kênh trước, xem mục UX alert ở trên).

## Test

`992 passed, 21 skipped` (5 module cần `anthropic` không cài được trong sandbox — không liên quan thay đổi này). Thêm 28 test: cảnh báo hết hạn (TTL=0, cấp token mới reset đồng hồ, dedupe theo ngày, gửi hỏng không đốt lượt, không lưu token), phân loại lỗi auth, retry có giới hạn, requeue ở tầng storage, `--force`, và ca **quên chạy migrate**.