### PR TITLE
Loại bỏ màn hình toàn văn narrative khỏi video drama

### DIFF
--- a/content-pipeline/main_drama.py
+++ b/content-pipeline/main_drama.py
@@ -287,7 +287,6 @@ def _render_story(story: dict) -> int | None:
     if not compose_drama_video(
         audio_path, srt_path if burn else None, video_path,
         thumbnail_prompt=rewrite.get("thumbnail_prompt"),
-        vn_commentary=rewrite.get("vn_commentary"),
     ):
         _fail(video_id, f"Composition failed for story {story_id}")
         return None

--- a/content-pipeline/tests/test_drama_composer.py
+++ b/content-pipeline/tests/test_drama_composer.py
@@ -27,9 +27,21 @@ from video.drama_composer import (
     scaled_scene_durations,
     compose_drama_video,
 )
+from video.templates.drama import DRAMA_SHORTS_TEMPLATE
 
 HAS_FFMPEG = shutil.which("ffmpeg") is not None
 HAS_FFPROBE = shutil.which("ffprobe") is not None
+
+
+class TestDramaTemplate(unittest.TestCase):
+    def test_has_no_full_text_commentary_scene(self):
+        scenes = DRAMA_SHORTS_TEMPLATE["scenes"]
+        self.assertNotIn("vn_commentary_overlay", {scene["type"] for scene in scenes})
+        self.assertFalse(any(scene.get("commentary") for scene in scenes))
+        self.assertEqual(
+            DRAMA_SHORTS_TEMPLATE["duration_target"],
+            sum(scene["duration"] for scene in scenes),
+        )
 
 
 class TestLavfiSource(unittest.TestCase):
@@ -495,23 +507,6 @@ class TestBuildDramaSceneReelMocked(unittest.TestCase):
         self.assertIsNotNone(reel)
         # 1 failed motion attempt + 1 static retry + 1 concat
         self.assertEqual(len(calls), 3)
-
-    @patch("video.drama_composer.render_commentary_card")
-    @patch("video.drama_composer._run_ffmpeg")
-    def test_commentary_rendered_when_scene_wants_it_and_text_given(self, mock_run, mock_card):
-        mock_run.side_effect = lambda cmd, out: out
-        mock_card.return_value = "/tmp/card.png"
-        template = {
-            "duration_target": 10,
-            "scenes": [
-                {"type": "vn_commentary_overlay", "duration": 10, "background": "solid_blue",
-                 "lower_third": False, "commentary": True},
-            ],
-        }
-        build_drama_scene_reel(template, 10.0, 1080, 1920, self.tmp,
-                               vn_commentary="Bình luận của mình...")
-        mock_card.assert_called_once()
-
 
 class TestComposeDramaVideo(unittest.TestCase):
     def setUp(self):

--- a/content-pipeline/tests/test_main_drama.py
+++ b/content-pipeline/tests/test_main_drama.py
@@ -251,11 +251,11 @@ class TestRenderHappyPath(RenderBase):
         self.assertIn("Ở Việt Nam mình", video["script_text"])
         # hashtags sinh từ tags (bỏ dấu cách)
         self.assertIn("#mẹchồng", video["tiktok_hashtags"])
-        # story chuyển 'produced', vn_commentary được truyền cho composer
+        # story chuyển 'produced'; narrative chỉ dùng cho audio/subtitle,
+        # không bị đưa vào composer để tạo màn hình toàn văn.
         from storage.stories import get_story
         self.assertEqual(get_story(story["id"])["status"], "produced")
-        self.assertEqual(compose.call_args.kwargs.get("vn_commentary"),
-                         rewrite["vn_commentary"])
+        self.assertNotIn("vn_commentary", compose.call_args.kwargs)
         dispatch.assert_called_once_with(video_id)
 
     def test_tts_failure_marks_video_failed_and_story_retryable(self):

--- a/content-pipeline/tests/test_templates.py
+++ b/content-pipeline/tests/test_templates.py
@@ -59,9 +59,13 @@ class TestTemplateStructure(unittest.TestCase):
         total = sum(s["duration"] for s in AI_SHORTS_TEMPLATE["scenes"])
         self.assertEqual(total, AI_SHORTS_TEMPLATE["duration_target"])
 
-    def test_drama_has_exactly_one_commentary_scene(self):
+    def test_drama_has_no_full_text_commentary_scene(self):
         commentary_scenes = [s for s in DRAMA_SHORTS_TEMPLATE["scenes"] if s.get("commentary")]
-        self.assertEqual(len(commentary_scenes), 1)
+        self.assertEqual(commentary_scenes, [])
+        self.assertNotIn(
+            "vn_commentary_overlay",
+            {scene["type"] for scene in DRAMA_SHORTS_TEMPLATE["scenes"]},
+        )
 
     def test_drama_has_exactly_one_lower_third_scene(self):
         lt_scenes = [s for s in DRAMA_SHORTS_TEMPLATE["scenes"] if s.get("lower_third")]

--- a/content-pipeline/video/drama_composer.py
+++ b/content-pipeline/video/drama_composer.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 Drama Scene Composer (Phase 4 EPIC #4.2 — Video Composer Multi-track).
 
 Builds a Drama Shorts video: pre-renders each template scene as its own short
-segment (background + optional lower-third/commentary overlay baked in),
+segment (background + optional lower-third overlay baked in),
 concatenates them into one "scene reel", then feeds that reel as the
 background into the EXISTING `video_composer.compose_video()` — reusing its
 already-robust audio/subtitle/crop pipeline rather than duplicating it.
 
-Note on `lower_third`/`vn_commentary` inputs: processors/drama_rewriter.py's
+Note on `lower_third` input: processors/drama_rewriter.py's
 output schema (Phase 3) has no structured per-character name/role field —
 only free-text `script`. Rather than guess at parsing character names out of
 the script, this module takes lower-third data as an explicit optional
@@ -29,7 +29,6 @@ import config
 from video.video_composer import _scale_filter, _run_ffmpeg, compose_video
 from video.templates import load_template
 from video.lower_third import render_lower_third
-from video.commentary_card import render_commentary_card
 from video.image_generator import generate_illustration, cached_illustration_variants
 
 logger = logging.getLogger(__name__)
@@ -53,8 +52,7 @@ _SCENE_FPS = 30
 # strong zooms on AI stills read as cheap slideshow.
 _ZOOM_RANGE = 0.10
 # eq filter params for "illustration_dark" scenes: dim + slightly desaturate
-# so the twist scene reads darker and the commentary card stays legible on
-# top of a busy image.
+# so the twist scene reads darker and subtitles stay legible on a busy image.
 _DARKEN_FILTER = "eq=brightness=-0.18:saturation=0.85"
 
 
@@ -84,7 +82,7 @@ def build_scene_segment_command(background: str, is_lavfi: bool, duration: float
     Args:
         background: an lavfi source spec string (is_lavfi=True) or a real
             file path to loop (is_lavfi=False, e.g. an AI illustration PNG).
-        overlay_png: lower-third or commentary-card PNG, composited for the
+        overlay_png: lower-third PNG, composited for the
             full segment duration when given.
         motion: still-image sources only — animate a slow Ken Burns zoom via
             zoompan instead of holding a frozen frame (issue #103: static
@@ -293,7 +291,6 @@ def build_drama_scene_reel(
     tmpdir: str,
     thumbnail_prompt: str | None = None,
     lower_third: dict | None = None,
-    vn_commentary: str | None = None,
     fill: bool = True,
 ) -> str | None:
     """Render every scene as its own segment and concat them into one reel.
@@ -318,11 +315,6 @@ def build_drama_scene_reel(
                 lower_third.get("name", ""), lower_third.get("role", ""),
                 width, height, os.path.join(tmpdir, f"overlay_{i}.png"),
             )
-        elif scene.get("commentary") and vn_commentary:
-            overlay_png = render_commentary_card(
-                vn_commentary, width, height, os.path.join(tmpdir, f"overlay_{i}.png"),
-            )
-
         source, is_lavfi = _resolve_scene_background(scene, width, height, i,
                                                      thumbnail_prompt, gen_state)
         darken = (not is_lavfi) and scene["background"] == "illustration_dark"
@@ -364,7 +356,6 @@ def compose_drama_video(
     output_path: str,
     thumbnail_prompt: str | None = None,
     lower_third: dict | None = None,
-    vn_commentary: str | None = None,
     video_format: str = "shorts",
 ) -> str | None:
     """Compose a full Drama video: multi-scene reel + audio + subtitles.
@@ -398,7 +389,7 @@ def compose_drama_video(
         reel = build_drama_scene_reel(
             template, audio_duration, width, height, tmpdir,
             thumbnail_prompt=thumbnail_prompt, lower_third=lower_third,
-            vn_commentary=vn_commentary, fill=True,
+            fill=True,
         )
         if reel is None:
             logger.warning("Scene reel failed — falling back to plain background compose")

--- a/content-pipeline/video/templates/drama.py
+++ b/content-pipeline/video/templates/drama.py
@@ -26,27 +26,21 @@ scene.
 
 DRAMA_SHORTS_TEMPLATE = {
     "format": "9:16",
-    # phase-4-detailed.md states duration_target=75 but its own per-scene
-    # durations below (copied verbatim: 3+12+30+25+8+12) sum to 90 — another
-    # doc inconsistency (see docs/current/prompts-decisions.md for the
-    # similar word-count/duration mismatch found in Phase 3). Corrected here
-    # to match the actual scene sum rather than silently drifting from it;
-    # kept the specific named-scene durations since those came with an
-    # explicit rationale ("Hook 3s", "Twist 25s", ...).
-    "duration_target": 90,  # seconds
+    # Keep the target equal to the remaining visual scene weights. The old
+    # 8-second full-text commentary scene was removed: narration and subtitles
+    # still carry that content without covering the video with a text page.
+    "duration_target": 82,  # seconds
     "scenes": [
         {"type": "hook", "duration": 3, "background": "illustration",
-         "fallback": "gradient_warm", "lower_third": False, "commentary": False},
+         "fallback": "gradient_warm", "lower_third": False},
         {"type": "setup", "duration": 12, "background": "illustration",
-         "fallback": "gradient_warm", "lower_third": False, "commentary": False},
+         "fallback": "gradient_warm", "lower_third": False},
         {"type": "escalation", "duration": 30, "background": "illustration",
-         "fallback": "gradient_cool", "lower_third": True, "commentary": False},
+         "fallback": "gradient_cool", "lower_third": True},
         {"type": "twist", "duration": 25, "background": "illustration_dark",
-         "fallback": "solid_blue", "lower_third": False, "commentary": False},
-        {"type": "vn_commentary_overlay", "duration": 8, "background": "illustration_dark",
-         "fallback": "solid_blue", "lower_third": False, "commentary": True},
+         "fallback": "solid_blue", "lower_third": False},
         {"type": "reflection_cta", "duration": 12, "background": "illustration",
-         "fallback": "gradient_cool", "lower_third": False, "commentary": False},
+         "fallback": "gradient_cool", "lower_third": False},
     ],
     "transitions": "match_cut",
     "music_track": "tense_minimal_loop.mp3",


### PR DESCRIPTION
### Motivation
- Tránh hiển thị toàn bộ `vn_commentary` lên một màn hình cuối video, vì điều này lộ toàn bộ nội dung narrative trên khung hình và làm UX/MI bị kém.
- Giảm công việc render không cần thiết (ít scene hơn → ít lần gọi ffmpeg / génération ảnh), cải thiện tốc độ và giảm bề mặt lỗi khi API hình ảnh hoặc ffmpeg thất bại.

### Description
- Xoá scene toàn màn hình hiển thị `vn_commentary` khỏi template drama và cập nhật `DRAMA_SHORTS_TEMPLATE` để không còn scene kiểu `vn_commentary_overlay` nữa, đồng thời điều chỉnh `duration_target` cho khớp. (file: `video/templates/drama.py`)
- Composer (`video/drama_composer.py`) không còn support render toàn màn hình commentary và không import/khởi tạo `commentary_card`; chỉ giữ `lower_third` overlay cho các scene cần label nhân vật. (file: `video/drama_composer.py`)
- Pipeline render (`main_drama.py`) ngừng truyền `vn_commentary` vào `compose_drama_video`, đảm bảo narrative vẫn được dùng cho TTS + phụ đề nhưng không bị chuyển thành full-text trên video. (file: `main_drama.py`)
- Cập nhật unit tests để phản ánh invariant mới (không còn full-text commentary scene) và để đảm bảo narrative vẫn xuất hiện trong audio/subtitle nhưng không trong composer args. (files: `tests/test_templates.py`, `tests/test_drama_composer.py`, `tests/test_main_drama.py`)
- Giữ nguyên security/UX: nội dung narrative vẫn được đọc (TTS) và xuất làm phụ đề, tránh leak toàn văn trên màn hình; thay đổi giảm attack surface (ít lần lưu/hiển thị text large).
- PR liên quan: closes issue `#111`.

### Testing
- Đã chạy unit tests chuyên dụng: `python -m unittest tests.test_drama_composer tests.test_main_drama` — tất cả tests trong mục này passed (75 tests, 1 skipped).
- Đã chạy toàn bộ test suite: `python -m unittest discover -s tests` — toàn bộ suite chạy thành công (1121 tests, 1 skipped).
- Đã chạy compile check: `python -m compileall -q main_drama.py video tests/test_drama_composer.py tests/test_main_drama.py tests/test_templates.py` — không lỗi biên dịch.
- Các test cập nhật kiểm tra cấu trúc template và hành vi composer đều xanh, xác nhận không tái tạo màn hình toàn văn và rằng narration vẫn dùng cho audio/subtitle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a778889c97c832f9ca267fded50bb3e)